### PR TITLE
Restrict the public Firebase API key, and document why it is public

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -1,9 +1,29 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+# Licensed under the MIT License. See LICENSE in the repository root for details.
+
 # See .agents/skills/firebase-app-hosting-basics/references/configuration.md for the full schema.
 runConfig:
   minInstances: 0
   maxInstances: 3
 
 env:
+  # Not a secret, despite the name. A Firebase Web API key identifies the project, it does not
+  # grant access -- it is compiled into the client bundle and served to every visitor, so it is
+  # readable by anyone who opens the app regardless of this repository's visibility. Access is
+  # decided by Firestore Security Rules and by the sign-in providers, never by this value.
+  #
+  # It is nonetheless restricted in Google Cloud, so it cannot be lifted and reused elsewhere:
+  #   - API restrictions: limited to the Firebase/Google services this app actually calls.
+  #   - HTTP referrer restrictions: only this app's own origins (the custom domain, the App
+  #     Hosting backend, the two default Firebase domains, and localhost for `npm run dev`).
+  #     A request without a matching Referer is rejected as API_KEY_HTTP_REFERRER_BLOCKED.
+  #
+  # A Referer header can be forged, so that is a speed bump rather than a boundary. The actual
+  # control on the abuse path this closes -- creating accounts through the Identity Toolkit
+  # endpoints -- is that Microsoft/Entra ID is the only enabled sign-in provider. E-mail
+  # /password, anonymous and phone sign-in are all disabled, so accounts:signUp answers
+  # ADMIN_ONLY_OPERATION. Keep it that way: enabling another provider would open that path.
   - variable: NEXT_PUBLIC_FIREBASE_API_KEY
     value: AIzaSyBWfiPscbz7JDxxvqOMw9p80DP6TRAdzQM
     availability:


### PR DESCRIPTION
Now that the repository is public, the Firebase Web API key in `apphosting.yaml` is the first thing a reader — or an automated secret scanner — will flag. This documents it in place and records the restrictions now applied in Google Cloud.

### The key was never secret

It identifies the project; it does not grant access. It is compiled into the client bundle and served to every visitor, so publishing the repository changed nothing about its exposure. Verified by pulling it out of the deployed JS chunk at `sportsweek.htldornbirn.org`.

### What changed in Google Cloud (no code impact)

**HTTP referrer restrictions** added to the key, listing only this app's own origins — the custom domain, the App Hosting backend, the two default Firebase domains, and `localhost` so `npm run dev` keeps working. The existing 27 API-target restrictions were preserved, not replaced.

Verified against the live endpoint:

| Request | Result |
| --- | --- |
| `accounts:signUp`, no Referer | `403 API_KEY_HTTP_REFERRER_BLOCKED` |
| `accounts:signUp`, forged Referer | `403 API_KEY_HTTP_REFERRER_BLOCKED` |
| `accounts:signUp`, real app Referer | `400 ADMIN_ONLY_OPERATION` |
| Firestore + securetoken, app Referer | reachable — normal `PERMISSION_DENIED` / `INVALID_REFRESH_TOKEN`, not referrer-blocked |

So legitimate traffic is unaffected, in production and in local dev.

### Where the real control sits

A `Referer` header can be forged, so the restriction is a speed bump rather than a boundary — the comment says so plainly. The actual control on the abuse path it closes (creating accounts through Identity Toolkit) is that **Microsoft/Entra ID is the only enabled sign-in provider**. Email/password, anonymous and phone are all disabled, which is why the forged-Referer case still ends at `ADMIN_ONLY_OPERATION`. I verified this was already the case and changed nothing about it — the comment records it so that someone enabling another provider sees what it would reopen.

Firestore does not enforce referrer checks the same way, but never relied on them: unauthenticated reads are refused by Security Rules.

### Not done

Firebase App Check would bind the key to attested app instances and close the forged-Referer gap properly. It needs client SDK changes, so it is out of scope here.