### PR TITLE
Configure Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+# Licensed under the MIT License. See LICENSE in the repository root for details.
+#
+# Dependabot version updates. Security updates are driven by the advisory database and need
+# no configuration here, but they inherit this file's grouping and scheduling, so keeping the
+# two ecosystems below configured is what stops security bumps arriving one PR at a time.
+# Reference: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Vienna"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    # Order matters: a dependency joins the *first* group it matches, so the narrow Firebase
+    # group has to precede the catch-all ones or it would never match anything.
+    groups:
+      # The Firebase packages move together and share transitive dependencies -- which is
+      # where most advisories against this repo surface. Bumping them in one PR lets a single
+      # emulator run prove the whole set, instead of each PR re-testing the same tree.
+      firebase:
+        patterns:
+          - "firebase"
+          - "firebase-admin"
+          - "firebase-tools"
+          - "@firebase/*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Every PR runs the full CI matrix and `main` refuses anything that is not green, so a
+      # PR costs a CI run rather than a click. Group the low-risk updates to keep that bill
+      # small; majors stay ungrouped, since those are the ones that need actually reading.
+      production-minor-and-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-minor-and-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Vienna"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      # The workflows pin actions by major tag, so these are nearly always retag bumps.
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
The committed `.github/dependabot.yml` was still GitHub's starter template with `package-ecosystem: ""`. That is not a valid ecosystem, so Dependabot rejected the config and **nothing was being watched for version updates**.

### What this declares

- **npm** at the root (the only manifest — no workspaces or nested packages)
- **github-actions** for the two workflows

### Grouping, and why the order matters

`main` now refuses anything that is not green, so a PR costs a full CI run rather than a click. Minor and patch updates travel together, split production vs development; majors stay ungrouped, since those are the ones worth reading.

The Firebase packages get their own group, **listed first**. That ordering is load-bearing: a dependency joins the *first* group it matches, so sitting below the catch-all groups the Firebase group would have matched nothing at all. They share transitive dependencies — which is where every current advisory against this repo originates — so bumping them together lets one emulator run prove the whole set.

### On the open alerts

Four are open, all `moderate`, all reached through **`firebase-tools` (a devDependency)** and `firebase-admin`:

| Package | Advisory | Reachable via |
| --- | --- | --- |
| `re2@1.24.1` | 3 × DoS (GHSA) | `firebase-tools → superstatic` |
| `uuid@9.0.1` | `GHSA-w5hq-g745-h8pq` | `firebase-admin → @google-cloud/storage`, `firebase-tools → gaxios` |

**They are deliberately not "fixed" here.** `npm audit` proposes *downgrades*, not upgrades — `firebase-admin` 14.3.0 → **10.3.0** and `firebase-tools` 15.28.1 → **14.23.0**, both flagged `isSemVerMajor`. Running `npm audit fix --force` would tear the app apart to silence a dev-only advisory.

The `uuid` issue is a missing buffer bounds check in **v3/v5/v6 when `buf` is provided**; the callers here (`gaxios`, `teeny-request`) use v4 for request IDs, so it is not on a reachable path. `re2` is dev-only tooling.

The sustainable fix is upstream bumps, which is exactly what this config will now surface — grouped, on a schedule, gated by CI.