### PR TITLE
Add teacher-maintained master data with drag-and-drop ordering

### DIFF
--- a/firestore-tests/master-data.rules.test.ts
+++ b/firestore-tests/master-data.rules.test.ts
@@ -125,6 +125,39 @@ describe.each(READABLE_COLLECTIONS)("/%s", (collection, valid) => {
   });
 });
 
+/**
+ * Bookkeeping the app keeps for itself. Neither is part of any view, and both would hand a
+ * client a way to interfere with invariants it is not allowed to touch: freeing a reserved
+ * name would let a duplicate through, and rewriting the seed marker would resurrect defaults
+ * a teacher deleted (US-5 to US-10).
+ */
+describe.each([
+  ["reservedNames", { scope: "classOptions", name: "5AHIF", ownerId: "c1" }],
+  ["seedState", { seededKeys: ["classes|5ahif"] }],
+])("/%s stays invisible to every client", (collection, valid) => {
+  it("denies a teacher reading it", async () => {
+    await seed(collection, "item1", valid);
+
+    await assertFails(teacher().collection(collection).doc("item1").get());
+  });
+
+  it("denies a student reading it", async () => {
+    await seed(collection, "item1", valid);
+
+    await assertFails(student().collection(collection).doc("item1").get());
+  });
+
+  it("denies a teacher writing it", async () => {
+    await assertFails(teacher().collection(collection).doc("new").set(valid));
+  });
+
+  it("denies a teacher deleting it", async () => {
+    await seed(collection, "item1", valid);
+
+    await assertFails(teacher().collection(collection).doc("item1").delete());
+  });
+});
+
 describe("invariants that rules cannot express are not left half-guarded", () => {
   it("stops a teacher marking a second season active from the client", async () => {
     await seed("seasons", "a", { name: "Winter 2026", isActive: true, isArchived: false });

--- a/firestore-tests/master-data.rules.test.ts
+++ b/firestore-tests/master-data.rules.test.ts
@@ -64,13 +64,12 @@ async function seed(collection: string, id: string, data: Record<string, unknown
  * guarantees worthless.
  */
 const READABLE_COLLECTIONS: [string, Record<string, unknown>][] = [
-  ["programs", { name: "Ski" }],
+  ["programs", { name: "Ski", requiredEquipment: ["Helm"] }],
   ["classOptions", { name: "5AHIF" }],
   ["skillLevels", { name: "Fortgeschritten" }],
   ["busPickupPoints", { name: "Dornbirn" }],
   ["foodOptions", { name: "Vegetarisch" }],
   ["seasonPassOptions", { name: "Montafon Card" }],
-  ["requiredEquipmentItems", { programId: "p1", name: "Helm" }],
   ["seasons", { name: "Winter 2026", isActive: false, isArchived: false }],
   ["events", { seasonId: "s1", name: "Montafon" }],
 ];

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,14 +7,6 @@
         { "fieldPath": "seasonId", "order": "ASCENDING" },
         { "fieldPath": "name", "order": "ASCENDING" }
       ]
-    },
-    {
-      "collectionGroup": "requiredEquipmentItems",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "programId", "order": "ASCENDING" },
-        { "fieldPath": "name", "order": "ASCENDING" }
-      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,14 @@
         { "fieldPath": "seasonId", "order": "ASCENDING" },
         { "fieldPath": "name", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "requiredEquipmentItems",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "programId", "order": "ASCENDING" },
+        { "fieldPath": "name", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -68,7 +68,7 @@ service cloud.firestore {
      */
     match /{collection}/{itemId} {
       allow read: if isSignedIn() && collection in [
-        'seasons', 'events', 'programs', 'requiredEquipmentItems',
+        'seasons', 'events', 'programs',
         'classOptions', 'skillLevels', 'busPickupPoints', 'foodOptions', 'seasonPassOptions'
       ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,13 @@
     "": {
       "name": "sportsweek",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.7.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.9.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -825,6 +830,73 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.9.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/spec/database-erd.puml
+++ b/spec/database-erd.puml
@@ -31,6 +31,7 @@ entity "Season" as season {
   hasStudentData : boolean  ' mirrors "a StudentMasterData record exists for this season", so the
                             ' client can enable/disable archive and delete without reading a
                             ' collection it may not read; the server re-checks and decides (US-4)
+  position : number  ' teacher-defined order, not alphabetical (see Ordering)
   --
   ' Displayed state is derived, not stored: active (isActive), archived (isArchived),
   ' or inactive (neither). A season with no student data can be deleted in any state but
@@ -43,6 +44,7 @@ entity "Event" as event {
   FK seasonId : string
   --
   name : string
+  position : number  ' teacher-defined order within the season (see Ordering)
 }
 
 entity "Program" as program {
@@ -54,31 +56,37 @@ entity "Program" as program {
                                 ' identity outside the program and is referenced from nowhere.
                                 ' Unique within the program, compared case- and space-insensitively;
                                 ' two programs may each require a helmet. The whole list is
-                                ' rewritten in one step, so adding/renaming/removing is atomic.
+                                ' rewritten in one step, so adding/renaming/removing is atomic,
+                                ' and the array order is the teacher-defined order (see Ordering).
+  position : number  ' teacher-defined order, not alphabetical (see Ordering)
 }
 
 entity "ClassOption" as classOption {
   PK id : string
   --
   name : string  ' Klasse (US-6); only editable/removable if unused by a non-archived season's master data
+  position : number  ' teacher-defined order (see Ordering)
 }
 
 entity "SkillLevel" as skillLevel {
   PK id : string
   --
-  name : string  ' complete beginner, beginner, advanced, expert (US-7)
+  name : string  ' Absoluter Anfänger, Anfänger, Fortgeschritten, Profi (US-7)
+  position : number  ' teacher-defined order — these are ranked, so alphabetical would be wrong
 }
 
 entity "BusPickupPoint" as busPickupPoint {
   PK id : string
   --
   name : string  ' US-8
+  position : number  ' teacher-defined order, typically along the bus route (see Ordering)
 }
 
 entity "FoodOption" as foodOption {
   PK id : string
   --
-  name : string  ' eats everything, vegetarian, vegan, no pork (US-9)
+  name : string  ' Alles, Vegetarisch, Vegan, Kein Schweinefleisch (US-9)
+  position : number  ' teacher-defined order (see Ordering)
   ' note: the fixed "other" option is not a row here — it is always available
   ' and cannot be edited/removed; see StudentMasterData.foodOtherText
 }
@@ -87,6 +95,7 @@ entity "SeasonPassOption" as seasonPassOption {
   PK id : string
   --
   name : string  ' no, maybe, Golm-Bielerhöhe (Illwerke), Silvretta-Montafon (US-10)
+  position : number  ' teacher-defined order (see Ordering)
 }
 
 entity "StudentMasterData" as studentMasterData {

--- a/spec/database-erd.puml
+++ b/spec/database-erd.puml
@@ -94,7 +94,7 @@ entity "FoodOption" as foodOption {
 entity "SeasonPassOption" as seasonPassOption {
   PK id : string
   --
-  name : string  ' no, maybe, Golm-Bielerhöhe (Illwerke), Silvretta-Montafon (US-10)
+  name : string  ' Keine, Vielleicht, Golm-Bielerhöhe (Illwerke), Silvretta-Montafon (US-10)
   position : number  ' teacher-defined order (see Ordering)
 }
 

--- a/spec/database-erd.puml
+++ b/spec/database-erd.puml
@@ -49,13 +49,12 @@ entity "Program" as program {
   PK id : string
   --
   name : string  ' e.g. Ski, Snowboard, Alternativ (US-5); only editable/removable if unused by a non-archived season's master data
-}
-
-entity "RequiredEquipmentItem" as requiredEquipmentItem {
-  PK id : string
-  FK programId : string
-  --
-  name : string  ' e.g. ski, ski boots, poles, helmet (US-5)
+  requiredEquipment : string[]  ' e.g. ski, ski boots, poles, helmet (US-5); stored on the program
+                                ' itself rather than as records of their own — an item has no
+                                ' identity outside the program and is referenced from nowhere.
+                                ' Unique within the program, compared case- and space-insensitively;
+                                ' two programs may each require a helmet. The whole list is
+                                ' rewritten in one step, so adding/renaming/removing is atomic.
 }
 
 entity "ClassOption" as classOption {
@@ -138,7 +137,7 @@ entity "EquipmentRentalItem" as equipmentRentalItem {
   PK id : string
   FK studentMasterDataId : string
   --
-  itemName : string  ' copied from RequiredEquipmentItem.name at selection time, not a foreign key
+  itemName : string  ' copied from a Program.requiredEquipment entry at selection time, not a foreign key
 }
 
 entity "SavedReportFilter" as savedReportFilter {
@@ -164,7 +163,7 @@ season ||--o{ studentMasterData : "registered in (US-11)"
 event  |o--o{ studentMasterData : "assigned to (US-12); removing an event unassigns its students"
 
 ' Sports Week Master Data teacher-maintained lists (US-5 .. US-10)
-program ||--o{ requiredEquipmentItem : "requires"
+' Program.requiredEquipment is an attribute, not an entity — there is no relationship to draw.
 
 ' The dotted lines below are NOT foreign keys — they indicate that a StudentMasterData
 ' field is a plain-text copy of a list item's name at the time it was selected (US-11).
@@ -174,7 +173,7 @@ skillLevel        .down.> studentMasterData : "value copied to .skillLevel"
 busPickupPoint    .down.> studentMasterData : "value copied to .busPickupPoint"
 seasonPassOption  .down.> studentMasterData : "value copied to .seasonPassOption"
 foodOption        .down.> studentMasterData : "value copied to .foodOption"
-requiredEquipmentItem .down.> equipmentRentalItem : "value copied to .itemName"
+program           .down.> equipmentRentalItem : "a .requiredEquipment entry is copied to .itemName"
 
 ' Student edits own master data (US-11)
 user              ||--o{ studentMasterData : "owns (student)"

--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -102,7 +102,7 @@ As a teacher, I can maintain seasons and, within each season, maintain events so
 
 Unless a story below says otherwise, every list in this section follows the same edit/remove restriction: an item can only be edited or removed if it is not currently selected by any master data record (US-11) belonging to a non-archived season (US-4); when blocked by this rule, a hint is shown: "This item is still in use in a non-archived season. Archive that season to edit or remove it."
 
-Every list in this section also enforces unique names: two items of the same category cannot share a name, compared ignoring surrounding whitespace and letter case. The same name may of course appear in two different categories (e.g. a class and a program). Required equipment items (US-5) are unique within their program, in the same way events are unique within their season. A rejected name is reported on the name field itself, in German, and nothing is saved.
+Every list in this section also enforces unique names: two items of the same category cannot share a name, compared ignoring surrounding whitespace and letter case. The same name may of course appear in two different categories (e.g. a class and a program). Required equipment items (US-5) are unique within their program — two different programs may each require a helmet. A rejected name is reported on the name field itself, in German, and nothing is saved.
 
 All categories in this section (US-5 through US-10) share one unified, intuitive CRUD interface pattern for adding, editing, and deleting list items — consistent across every category, differing only in the fields each item has.
 
@@ -116,9 +116,12 @@ As a teacher, I can maintain the list of programs so that students can register 
 - A teacher can add, edit, and remove programs from the list.
 - The list is pre-populated with the programs Ski, Snowboard, and Alternativ.
 - The program a student selects in their master data (US-11) is chosen from this maintained list.
-- Each program has an associated list of required equipment items; the default Ski program is pre-populated with ski, ski boots, poles, and helmet, and the default Snowboard program is pre-populated with board, boots, and helmet; the default Alternativ program has no pre-populated required equipment items.
+- Each program carries its required equipment as a list of names stored on the program itself, not as records of their own: an equipment item has no identity outside the program that requires it, and is never referenced from anywhere else. The default Ski program is pre-populated with ski, ski boots, poles, and helmet, and the default Snowboard program with board, boots, and helmet; the default Alternativ program has no pre-populated required equipment items.
 - A teacher can add, edit, and remove the required equipment items for each program.
+- Because the list lives on the program, the whole list is saved in one step: adding, renaming, or removing an item rewrites the program's equipment list as a single change, and either all of it is stored or none of it is.
+- Deleting a program deletes its required equipment list along with it, since the list has no existence apart from the program.
 - A program is matched via its `.program` value on master data records; a required equipment item is matched via students' equipment rental selections instead — both follow the shared edit/remove restriction above.
+- A program can only be deleted if none of its required equipment items is in use either, since deleting the program would take those items with it.
 
 ### US-6: Teacher maintains classes
 

--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -164,7 +164,7 @@ As a teacher, I can maintain the list of food/diet options so that students can 
 
 - A view for maintaining the list of food/diet options exists.
 - A teacher can add, edit, and remove food/diet options from the list.
-- The list is pre-populated with the options eats everything, vegetarian, vegan, and no pork.
+- The list is pre-populated with the options "Alles" (eats everything), "Vegetarisch", "Vegan", and "Kein Schweinefleisch" (no pork).
 - In addition to the teacher-maintained list, the option "other" is always available and cannot be removed or edited by the teacher.
 - Selecting the "other" option always requires the student to enter free text explaining the intolerance; the free text must not be empty.
 - The food/diet option a student selects in their master data (US-11) is chosen from this maintained list.

--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -22,6 +22,29 @@ Licensed under the MIT License. See LICENSE in the repository root for details.
 - Warning dialogs (e.g. irreversible delete confirmations) and error messages are exceptions to the palette rule above and may use red in a suitable way to signal danger or a problem.
 - Icons throughout the UI use a single, consistent, minimalistic icon set (Lucide, the default icon set for shadcn/ui) that fits the clean visual design while still looking polished and refined.
 
+## Drag and Drop
+
+One drag-and-drop mechanism is used everywhere in the application: for ordering lists (US-4 through US-10) and for the assignment dialog's transfer lists (US-12). It is specified once here rather than per story, so the gesture a user learns in one place works in every other.
+
+- Dragging is initiated from a dedicated grip handle on the item, not from the item's body, so a drag can never be started by accident and the rest of the row stays free for its own controls.
+- The grip handle is always visible, on every device — it is not revealed on hover. A control that only appears on hover is unreachable on touch (see General), and a handle the user cannot see is a feature they will not find.
+- The handle uses the shared icon set (see Design Guidelines) and is the leftmost element of the item.
+- Dragging works with mouse, touch, and pen alike, because it is driven by pointer input rather than by the browser's native HTML drag-and-drop, which touch devices do not support.
+- Dragging is keyboard-accessible: the handle can be focused, and the item moved with the arrow keys, so ordering is not a mouse-only capability.
+- While an item is dragged, the position it would take is shown, and the item follows the pointer.
+- A drag that is cancelled (Escape, or released outside a valid target) leaves the list exactly as it was.
+
+## Ordering
+
+Every list the teacher maintains is shown in an order the teacher decides, not in alphabetical order. Sorting by name would be a guess at intent: teachers group classes by year, put the most common program first, and order pickup points along the bus route. None of that is alphabetical.
+
+- The teacher can reorder the items of a list by dragging them (see Drag and Drop).
+- The order is persisted and is the order in which the list is shown to everyone, including the order in which students see the options they choose from (US-11).
+- A newly added item goes to the end of the list.
+- Removing an item closes the gap; the remaining items keep their relative order.
+- Reordering is never restricted by the in-use rule that governs editing and removing (see Sports Week Master Data): moving an item changes no stored value, so master data records cannot be affected by it.
+- The lists that are ordered this way are: seasons and, within a season, events (US-4); every teacher-maintained category (US-5 through US-10); and the required equipment of a program (US-5).
+
 ## Authentication & User Management
 
 ### US-1: Login with Microsoft Entra ID
@@ -94,6 +117,7 @@ As a teacher, I can maintain seasons and, within each season, maintain events so
 - An archived season cannot be activated, and the active season cannot be archived: it must be deactivated first, either in a prior call or in the same one. Either way no season is left active.
 - The assignment dialog (US-12) and the student report (US-13) only ever operate on the active season; when no season is active they show an explicit empty state instead of falling back to a previously active season.
 - Season names are unique: two seasons cannot share the same name.
+- The list of seasons, and the list of events within a season, are each shown in an order the teacher sets by dragging (see Ordering).
 - Event names are unique within their season: two events of the same season cannot share the same name, while two different seasons may each have an event of the same name.
 - Name comparison ignores surrounding whitespace and letter case, so "Montafon" and " montafon " count as the same name.
 - A rejected name is reported on the name field itself, in German, and nothing is saved.
@@ -104,7 +128,7 @@ Unless a story below says otherwise, every list in this section follows the same
 
 Every list in this section also enforces unique names: two items of the same category cannot share a name, compared ignoring surrounding whitespace and letter case. The same name may of course appear in two different categories (e.g. a class and a program). Required equipment items (US-5) are unique within their program — two different programs may each require a helmet. A rejected name is reported on the name field itself, in German, and nothing is saved.
 
-All categories in this section (US-5 through US-10) share one unified, intuitive CRUD interface pattern for adding, editing, and deleting list items — consistent across every category, differing only in the fields each item has.
+All categories in this section (US-5 through US-10) share one unified, intuitive CRUD interface pattern for adding, editing, and deleting list items — consistent across every category, differing only in the fields each item has. Every one of them is also shown in an order the teacher sets by dragging (see Ordering).
 
 ### US-5: Teacher maintains programs
 
@@ -118,6 +142,7 @@ As a teacher, I can maintain the list of programs so that students can register 
 - The program a student selects in their master data (US-11) is chosen from this maintained list.
 - Each program carries its required equipment as a list of names stored on the program itself, not as records of their own: an equipment item has no identity outside the program that requires it, and is never referenced from anywhere else. The default Ski program is pre-populated with ski, ski boots, poles, and helmet, and the default Snowboard program with board, boots, and helmet; the default Alternativ program has no pre-populated required equipment items.
 - A teacher can add, edit, and remove the required equipment items for each program.
+- The required equipment of a program is shown in an order the teacher sets by dragging (see Ordering); the list's order is the order the items are stored in.
 - Because the list lives on the program, the whole list is saved in one step: adding, renaming, or removing an item rewrites the program's equipment list as a single change, and either all of it is stored or none of it is.
 - Deleting a program deletes its required equipment list along with it, since the list has no existence apart from the program.
 - A program is matched via its `.program` value on master data records; a required equipment item is matched via students' equipment rental selections instead — both follow the shared edit/remove restriction above.
@@ -226,7 +251,7 @@ As a teacher, I can assign students to the events of the active season using an 
 - A per-class overview table shows, for each class: the total number of registered students (attending and not attending), the number of those students who are attending, and the percentage of registered students in the class who are attending; the remaining columns (number of male students, number of female students, and skill-level statistics per program, see US-7 and US-5) describe attending students only.
 - Below the per-class overview table, a second table shows the same attending-only statistics (male, female, skill levels per program — no total or attendance percentage, since every student in this table is by definition attending), broken down by event instead of by class; it only counts students assigned to that event.
 - Below the two overview tables, a left/right (transfer) list shows students for the event selected by clicking its row in the per-event overview table: the left list shows students not yet assigned to any event; the right list shows the students assigned to the selected event.
-- The teacher can select one or more students in either list (multi-select is supported) and move the selection to the other list either by dragging and dropping, or by pressing a move button between the two lists (e.g. arrow buttons); the button-based option keeps the dialog fully usable on touch devices (tablet, mobile), where drag-and-drop is unreliable or unsupported (see General).
+- The teacher can select one or more students in either list (multi-select is supported) and move the selection to the other list either by dragging and dropping, or by pressing a move button between the two lists (e.g. arrow buttons). Dragging uses the application's one drag-and-drop mechanism (see Drag and Drop) and therefore works on touch devices as well; the move buttons remain because they are what moves a multi-student selection in one action, and because they keep the dialog usable by keyboard alone.
 - To move a student from one event to a different event, the teacher first moves the student from the right list back to the left list (unassigning them), then selects the other event and moves the student from the left list into its right list; no direct move-between-events action exists.
 - Both the left and right lists can be filtered by class (see US-6), by gender, by program (see US-5), by skill level (see US-7), and by a free-text filter that searches the first name and last name.
 - Above each list, a free-text filter field for the name is shown, with a clear button (using a suitable icon) to reset it; below it, a single wrapping row of tags contains all the class, gender, program, and skill level filter options together, in that order.

--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -142,7 +142,7 @@ As a teacher, I can maintain the list of ski/snowboard skill levels so that stud
 
 - A view for maintaining the list of skill levels exists.
 - A teacher can add, edit, and remove skill levels from the list.
-- The list is pre-populated with four skill levels, shown as "Beginner" (complete beginner), "Anfänger" (beginner), "Fortgeschritten" (advanced), and "Profi" (expert). The German wording is fixed: "Beginner" is the absolute first-timer and "Anfänger" already has some experience, which the English names alone would not make clear.
+- The list is pre-populated with four skill levels, shown as "Absoluter Anfänger" (complete beginner), "Anfänger" (beginner), "Fortgeschritten" (advanced), and "Profi" (expert).
 - The skill level a student selects in their master data (US-11) is chosen from this maintained list.
 
 ### US-8: Teacher maintains bus pickup points

--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -202,7 +202,7 @@ As a teacher, I can maintain the list of season pass options so that students ca
 
 - A view for maintaining the list of season pass options exists.
 - A teacher can add, edit, and remove season pass options from the list.
-- The list is pre-populated with the options no, maybe, Golm-Bielerhöhe (Illwerke), and Silvretta-Montafon.
+- The list is pre-populated, in this order, with the options "Keine" (no season pass), "Vielleicht" (maybe), "Golm-Bielerhöhe (Illwerke)", and "Silvretta-Montafon".
 - The season pass option a student selects in their master data (US-11) is chosen from this maintained list.
 
 ### US-11: Student edits own master data

--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -142,7 +142,7 @@ As a teacher, I can maintain the list of ski/snowboard skill levels so that stud
 
 - A view for maintaining the list of skill levels exists.
 - A teacher can add, edit, and remove skill levels from the list.
-- The list is pre-populated with the skill levels complete beginner, beginner, advanced, and expert.
+- The list is pre-populated with four skill levels, shown as "Beginner" (complete beginner), "Anfänger" (beginner), "Fortgeschritten" (advanced), and "Profi" (expert). The German wording is fixed: "Beginner" is the absolute first-timer and "Anfänger" already has some experience, which the English names alone would not make clear.
 - The skill level a student selects in their master data (US-11) is chosen from this maintained list.
 
 ### US-8: Teacher maintains bus pickup points
@@ -153,7 +153,7 @@ As a teacher, I can maintain the list of bus pickup points so that students can 
 
 - A view for maintaining the list of bus pickup points exists.
 - A teacher can add, edit, and remove bus pickup points from the list.
-- The list is pre-populated with the pickup points HTL Dornbirn, Feldkirch station, Bregenz station, and directly at the Tschagguns accommodation.
+- The list is pre-populated with the pickup points "HTL Dornbirn", "Bahnhof Feldkirch", "Bahnhof Bregenz", and "Unterkunft" (boarding at the accommodation itself rather than travelling by bus).
 - The bus pickup point a student selects in their master data (US-11) is chosen from this maintained list.
 
 ### US-9: Teacher maintains food/diet options

--- a/src/app/api/events/route.test.ts
+++ b/src/app/api/events/route.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getUserWithRole = vi.fn();
 const createEvent = vi.fn();
+const reorderEvents = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
   getUserWithRole: () => getUserWithRole(),
@@ -14,9 +15,10 @@ vi.mock("@/lib/auth/guards", () => ({
 
 vi.mock("@/lib/events/event-service", () => ({
   createEvent: (...args: unknown[]) => createEvent(...args),
+  reorderEvents: (...args: unknown[]) => reorderEvents(...args),
 }));
 
-const { POST } = await import("./route");
+const { PATCH, POST } = await import("./route");
 const { ServiceError } = await import("@/lib/service-error");
 
 function postRequest(body: unknown) {
@@ -28,6 +30,7 @@ function postRequest(body: unknown) {
 
 beforeEach(() => {
   getUserWithRole.mockReset();
+  reorderEvents.mockReset();
   createEvent.mockReset();
   getUserWithRole.mockResolvedValue({ uid: "u1", email: "t@htldornbirn.at", role: "teacher" });
   createEvent.mockResolvedValue({ id: "e1", seasonId: "s1", name: "Montafon" });
@@ -75,5 +78,41 @@ describe("POST /api/events", () => {
     const response = await POST(postRequest({ seasonId: "ghost", name: "Montafon" }));
 
     expect(response.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/events", () => {
+  function patchRequest(body: unknown) {
+    return new Request("https://example.com/api/events", {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("reorders within the season it was given", async () => {
+    const response = await PATCH(patchRequest({ seasonId: "s1", order: ["e2", "e1"] }));
+
+    expect(response.status).toBe(204);
+    expect(reorderEvents).toHaveBeenCalledWith("s1", ["e2", "e1"]);
+  });
+
+  it("requires the season, so one season cannot renumber another's events", async () => {
+    const response = await PATCH(patchRequest({ order: ["e1"] }));
+
+    expect(response.status).toBe(400);
+    expect(reorderEvents).not.toHaveBeenCalled();
+  });
+
+  it("rejects a student with 403, so a bypassed client cannot reorder", async () => {
+    getUserWithRole.mockResolvedValue({
+      uid: "u2",
+      email: "s@student.htldornbirn.at",
+      role: "student",
+    });
+
+    const response = await PATCH(patchRequest({ seasonId: "s1", order: ["e1"] }));
+
+    expect(response.status).toBe(403);
+    expect(reorderEvents).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -7,11 +7,18 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { handleServiceFailure, parseJsonBody, requireTeacherOrResponse } from "@/lib/api/handler";
 import { eventSchema } from "@/lib/schemas/season";
-import { createEvent } from "@/lib/events/event-service";
+import { orderSchema } from "@/lib/schemas/order";
+import { createEvent, reorderEvents } from "@/lib/events/event-service";
 
 const createEventSchema = z.strictObject({
   seasonId: eventSchema.shape.seasonId,
   name: eventSchema.shape.name,
+});
+
+// Scoped to a season, so reordering one season's events can never renumber another's.
+const reorderSchema = z.strictObject({
+  seasonId: eventSchema.shape.seasonId,
+  order: orderSchema,
 });
 
 export async function POST(request: Request) {
@@ -26,5 +33,21 @@ export async function POST(request: Request) {
     return NextResponse.json({ event }, { status: 201 });
   } catch (error) {
     return handleServiceFailure(error, "Creating an event");
+  }
+}
+
+/** Reorders one season's events (see Ordering); it changes no name, so it needs no guard. */
+export async function PATCH(request: Request) {
+  const denied = await requireTeacherOrResponse();
+  if (denied) return denied;
+
+  const body = await parseJsonBody(request, reorderSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    await reorderEvents(body.data.seasonId, body.data.order);
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    return handleServiceFailure(error, "Reordering events");
   }
 }

--- a/src/app/api/master-data/[category]/[itemId]/route.test.ts
+++ b/src/app/api/master-data/[category]/[itemId]/route.test.ts
@@ -1,0 +1,149 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getUserWithRole = vi.fn();
+const updateMasterDataItem = vi.fn();
+const deleteMasterDataItem = vi.fn();
+
+vi.mock("@/lib/auth/guards", () => ({
+  getUserWithRole: () => getUserWithRole(),
+}));
+
+vi.mock("@/lib/master-data/master-data-service", () => ({
+  updateMasterDataItem: (...args: unknown[]) => updateMasterDataItem(...args),
+  deleteMasterDataItem: (...args: unknown[]) => deleteMasterDataItem(...args),
+}));
+
+const { PATCH, DELETE } = await import("./route");
+const { ServiceError } = await import("@/lib/service-error");
+const { IN_USE_HINT } = await import("@/lib/master-data/categories");
+
+function patchRequest(body: unknown) {
+  return new Request("https://example.com/api/master-data/classes/c1", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+function context(category: string, itemId = "c1") {
+  return { params: Promise.resolve({ category, itemId }) };
+}
+
+beforeEach(() => {
+  getUserWithRole.mockReset();
+  updateMasterDataItem.mockReset();
+  deleteMasterDataItem.mockReset();
+  getUserWithRole.mockResolvedValue({ uid: "u1", email: "t@htldornbirn.at", role: "teacher" });
+  updateMasterDataItem.mockResolvedValue({ id: "c1", name: "3BHIT", parentId: null });
+  deleteMasterDataItem.mockResolvedValue(undefined);
+});
+
+describe("PATCH /api/master-data/[category]/[itemId]", () => {
+  it("renames the item and returns it", async () => {
+    const response = await PATCH(patchRequest({ name: "3BHIT" }), context("classes"));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ item: { id: "c1", name: "3BHIT", parentId: null } });
+    expect(updateMasterDataItem).toHaveBeenCalledWith("classes", "c1", { name: "3BHIT" });
+  });
+
+  it("rejects an unknown category", async () => {
+    const response = await PATCH(patchRequest({ name: "3BHIT" }), context("users"));
+
+    expect(response.status).toBe(400);
+    expect(updateMasterDataItem).not.toHaveBeenCalled();
+  });
+
+  it("rejects a student with 403, so a bypassed client cannot edit a blocked item", async () => {
+    getUserWithRole.mockResolvedValue({
+      uid: "u2",
+      email: "s@student.htldornbirn.at",
+      role: "student",
+    });
+
+    const response = await PATCH(patchRequest({ name: "3BHIT" }), context("classes"));
+
+    expect(response.status).toBe(403);
+    expect(updateMasterDataItem).not.toHaveBeenCalled();
+  });
+
+  it("returns the shared validation envelope for a blank name", async () => {
+    const response = await PATCH(patchRequest({ name: "  " }), context("classes"));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(body.error.details).toBeDefined();
+  });
+
+  it("rejects an unknown field rather than ignoring it", async () => {
+    const response = await PATCH(
+      patchRequest({ name: "3BHIT", parentId: "elsewhere" }),
+      context("classes"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(updateMasterDataItem).not.toHaveBeenCalled();
+  });
+
+  it("passes the in-use rejection on with its hint intact", async () => {
+    updateMasterDataItem.mockRejectedValue(new ServiceError("CONFLICT", IN_USE_HINT));
+
+    const response = await PATCH(patchRequest({ name: "3BHIT" }), context("classes"));
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: { code: "CONFLICT", message: IN_USE_HINT },
+    });
+  });
+});
+
+describe("DELETE /api/master-data/[category]/[itemId]", () => {
+  it("deletes the item", async () => {
+    const response = await DELETE(new Request("https://example.com"), context("classes"));
+
+    expect(response.status).toBe(204);
+    expect(deleteMasterDataItem).toHaveBeenCalledWith("classes", "c1");
+  });
+
+  it("rejects an unknown category", async () => {
+    const response = await DELETE(new Request("https://example.com"), context("users"));
+
+    expect(response.status).toBe(400);
+    expect(deleteMasterDataItem).not.toHaveBeenCalled();
+  });
+
+  it("rejects a student with 403", async () => {
+    getUserWithRole.mockResolvedValue({
+      uid: "u2",
+      email: "s@student.htldornbirn.at",
+      role: "student",
+    });
+
+    const response = await DELETE(new Request("https://example.com"), context("classes"));
+
+    expect(response.status).toBe(403);
+    expect(deleteMasterDataItem).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing item as 404", async () => {
+    deleteMasterDataItem.mockRejectedValue(new ServiceError("NOT_FOUND", "Gibt es nicht."));
+
+    const response = await DELETE(new Request("https://example.com"), context("classes"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("passes the in-use rejection on with its hint intact", async () => {
+    deleteMasterDataItem.mockRejectedValue(new ServiceError("CONFLICT", IN_USE_HINT));
+
+    const response = await DELETE(new Request("https://example.com"), context("classes"));
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: { code: "CONFLICT", message: IN_USE_HINT } });
+  });
+});

--- a/src/app/api/master-data/[category]/[itemId]/route.test.ts
+++ b/src/app/api/master-data/[category]/[itemId]/route.test.ts
@@ -90,6 +90,41 @@ describe("PATCH /api/master-data/[category]/[itemId]", () => {
     expect(updateMasterDataItem).not.toHaveBeenCalled();
   });
 
+  it("rewrites a program's equipment list in one call", async () => {
+    updateMasterDataItem.mockResolvedValue({
+      id: "ski",
+      name: "Ski",
+      requiredEquipment: ["Helm"],
+    });
+
+    const response = await PATCH(
+      patchRequest({ requiredEquipment: ["Helm"] }),
+      context("programs", "ski"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateMasterDataItem).toHaveBeenCalledWith("programs", "ski", {
+      requiredEquipment: ["Helm"],
+    });
+  });
+
+  it("rejects an empty change set", async () => {
+    const response = await PATCH(patchRequest({}), context("programs", "ski"));
+
+    expect(response.status).toBe(400);
+    expect(updateMasterDataItem).not.toHaveBeenCalled();
+  });
+
+  it("rejects a duplicate equipment entry before it reaches the service", async () => {
+    const response = await PATCH(
+      patchRequest({ requiredEquipment: ["Helm", " helm "] }),
+      context("programs", "ski"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(updateMasterDataItem).not.toHaveBeenCalled();
+  });
+
   it("passes the in-use rejection on with its hint intact", async () => {
     updateMasterDataItem.mockRejectedValue(new ServiceError("CONFLICT", IN_USE_HINT));
 

--- a/src/app/api/master-data/[category]/[itemId]/route.ts
+++ b/src/app/api/master-data/[category]/[itemId]/route.ts
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  errorResponse,
+  handleServiceFailure,
+  parseJsonBody,
+  requireTeacherOrResponse,
+} from "@/lib/api/handler";
+import { ErrorCode } from "@/lib/errors";
+import { namedListItemSchema } from "@/lib/schemas/master-data";
+import { masterDataCategorySchema } from "@/lib/master-data/categories";
+import { deleteMasterDataItem, updateMasterDataItem } from "@/lib/master-data/master-data-service";
+
+// Strict, so a typo or an injected field is reported rather than silently ignored. An item
+// never moves between parents, which is why parentId is not accepted here.
+const updateItemSchema = z.strictObject({ name: namedListItemSchema.shape.name });
+
+type Context = { params: Promise<{ category: string; itemId: string }> };
+
+async function readParams({ params }: Context) {
+  const { category, itemId } = await params;
+  return { category: masterDataCategorySchema.safeParse(category), itemId };
+}
+
+export async function PATCH(request: Request, context: Context) {
+  const denied = await requireTeacherOrResponse();
+  if (denied) return denied;
+
+  const { category, itemId } = await readParams(context);
+  if (!category.success) {
+    return errorResponse(ErrorCode.ValidationError, "Diese Kategorie gibt es nicht.");
+  }
+
+  const body = await parseJsonBody(request, updateItemSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    const item = await updateMasterDataItem(category.data, itemId, body.data);
+    return NextResponse.json({ item });
+  } catch (error) {
+    return handleServiceFailure(error, `Updating ${category.data} item ${itemId}`);
+  }
+}
+
+export async function DELETE(_request: Request, context: Context) {
+  const denied = await requireTeacherOrResponse();
+  if (denied) return denied;
+
+  const { category, itemId } = await readParams(context);
+  if (!category.success) {
+    return errorResponse(ErrorCode.ValidationError, "Diese Kategorie gibt es nicht.");
+  }
+
+  try {
+    await deleteMasterDataItem(category.data, itemId);
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    return handleServiceFailure(error, `Deleting ${category.data} item ${itemId}`);
+  }
+}

--- a/src/app/api/master-data/[category]/[itemId]/route.ts
+++ b/src/app/api/master-data/[category]/[itemId]/route.ts
@@ -12,13 +12,18 @@ import {
   requireTeacherOrResponse,
 } from "@/lib/api/handler";
 import { ErrorCode } from "@/lib/errors";
-import { namedListItemSchema } from "@/lib/schemas/master-data";
+import { namedListItemSchema, requiredEquipmentSchema } from "@/lib/schemas/master-data";
 import { masterDataCategorySchema } from "@/lib/master-data/categories";
 import { deleteMasterDataItem, updateMasterDataItem } from "@/lib/master-data/master-data-service";
 
-// Strict, so a typo or an injected field is reported rather than silently ignored. An item
-// never moves between parents, which is why parentId is not accepted here.
-const updateItemSchema = z.strictObject({ name: namedListItemSchema.shape.name });
+// Strict, so a typo or an injected field is reported rather than silently ignored. The equipment
+// list is rewritten whole, which is what makes adding, renaming and removing one atomic (US-5).
+const updateItemSchema = z
+  .strictObject({
+    name: namedListItemSchema.shape.name.optional(),
+    requiredEquipment: requiredEquipmentSchema.optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, "Es wurde nichts zum Ändern übergeben.");
 
 type Context = { params: Promise<{ category: string; itemId: string }> };
 

--- a/src/app/api/master-data/[category]/route.test.ts
+++ b/src/app/api/master-data/[category]/route.test.ts
@@ -1,0 +1,154 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getUserWithRole = vi.fn();
+const createMasterDataItem = vi.fn();
+const blockedItemIds = vi.fn();
+
+vi.mock("@/lib/auth/guards", () => ({
+  getUserWithRole: () => getUserWithRole(),
+}));
+
+vi.mock("@/lib/master-data/master-data-service", () => ({
+  createMasterDataItem: (...args: unknown[]) => createMasterDataItem(...args),
+}));
+
+vi.mock("@/lib/master-data/usage-guard", () => ({
+  blockedItemIds: (...args: unknown[]) => blockedItemIds(...args),
+}));
+
+const { GET, POST } = await import("./route");
+const { ServiceError } = await import("@/lib/service-error");
+
+function request(body: unknown) {
+  return new Request("https://example.com/api/master-data/classes", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+function context(category: string) {
+  return { params: Promise.resolve({ category }) };
+}
+
+beforeEach(() => {
+  getUserWithRole.mockReset();
+  createMasterDataItem.mockReset();
+  blockedItemIds.mockReset();
+  getUserWithRole.mockResolvedValue({ uid: "u1", email: "t@htldornbirn.at", role: "teacher" });
+  createMasterDataItem.mockResolvedValue({ id: "c1", name: "3AHIT", parentId: null });
+  blockedItemIds.mockResolvedValue(["c1"]);
+});
+
+describe("POST /api/master-data/[category]", () => {
+  it("creates the item and returns it", async () => {
+    const response = await POST(request({ name: "3AHIT" }), context("classes"));
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual({ item: { id: "c1", name: "3AHIT", parentId: null } });
+    expect(createMasterDataItem).toHaveBeenCalledWith("classes", { name: "3AHIT" });
+  });
+
+  it("passes the parent through for a nested list", async () => {
+    await POST(request({ name: "Helm", parentId: "ski" }), context("required-equipment"));
+
+    expect(createMasterDataItem).toHaveBeenCalledWith("required-equipment", {
+      name: "Helm",
+      parentId: "ski",
+    });
+  });
+
+  it("rejects an unknown category, so a URL segment cannot name a collection", async () => {
+    const response = await POST(request({ name: "x" }), context("users"));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: { code: "VALIDATION_ERROR" } });
+    expect(createMasterDataItem).not.toHaveBeenCalled();
+  });
+
+  it("rejects an anonymous caller with 401", async () => {
+    getUserWithRole.mockResolvedValue(null);
+
+    const response = await POST(request({ name: "3AHIT" }), context("classes"));
+
+    expect(response.status).toBe(401);
+    expect(createMasterDataItem).not.toHaveBeenCalled();
+  });
+
+  it("rejects a student with 403, so a bypassed client cannot write", async () => {
+    getUserWithRole.mockResolvedValue({
+      uid: "u2",
+      email: "s@student.htldornbirn.at",
+      role: "student",
+    });
+
+    const response = await POST(request({ name: "3AHIT" }), context("classes"));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: { code: "PERMISSION_DENIED" } });
+    expect(createMasterDataItem).not.toHaveBeenCalled();
+  });
+
+  it("returns the shared validation envelope for a blank name", async () => {
+    const response = await POST(request({ name: "   " }), context("classes"));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(body.error.details).toBeDefined();
+    expect(createMasterDataItem).not.toHaveBeenCalled();
+  });
+
+  it("maps a duplicate name onto 409", async () => {
+    createMasterDataItem.mockRejectedValue(new ServiceError("CONFLICT", "Schon vorhanden."));
+
+    const response = await POST(request({ name: "3AHIT" }), context("classes"));
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: { code: "CONFLICT", message: "Schon vorhanden." },
+    });
+  });
+
+  it("hides an unexpected failure behind a sanitized 500", async () => {
+    createMasterDataItem.mockRejectedValue(new Error("adminDb exploded at line 42"));
+
+    const response = await POST(request({ name: "3AHIT" }), context("classes"));
+
+    expect(response.status).toBe(500);
+    expect(JSON.stringify(await response.json())).not.toContain("line 42");
+  });
+});
+
+describe("GET /api/master-data/[category]", () => {
+  it("reports the items blocked by the in-use guard", async () => {
+    const response = await GET(new Request("https://example.com"), context("classes"));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ blockedIds: ["c1"] });
+  });
+
+  it("rejects a student, since the answer is derived from data they cannot read", async () => {
+    getUserWithRole.mockResolvedValue({
+      uid: "u2",
+      email: "s@student.htldornbirn.at",
+      role: "student",
+    });
+
+    const response = await GET(new Request("https://example.com"), context("classes"));
+
+    expect(response.status).toBe(403);
+    expect(blockedItemIds).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown category", async () => {
+    const response = await GET(new Request("https://example.com"), context("users"));
+
+    expect(response.status).toBe(400);
+    expect(blockedItemIds).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/master-data/[category]/route.test.ts
+++ b/src/app/api/master-data/[category]/route.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getUserWithRole = vi.fn();
 const createMasterDataItem = vi.fn();
+const reorderMasterDataItems = vi.fn();
 const usageReport = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
@@ -15,13 +16,14 @@ vi.mock("@/lib/auth/guards", () => ({
 
 vi.mock("@/lib/master-data/master-data-service", () => ({
   createMasterDataItem: (...args: unknown[]) => createMasterDataItem(...args),
+  reorderMasterDataItems: (...args: unknown[]) => reorderMasterDataItems(...args),
 }));
 
 vi.mock("@/lib/master-data/usage-guard", () => ({
   usageReport: (...args: unknown[]) => usageReport(...args),
 }));
 
-const { GET, POST } = await import("./route");
+const { GET, PATCH, POST } = await import("./route");
 const { ServiceError } = await import("@/lib/service-error");
 
 function request(body: unknown) {
@@ -38,6 +40,7 @@ function context(category: string) {
 beforeEach(() => {
   getUserWithRole.mockReset();
   createMasterDataItem.mockReset();
+  reorderMasterDataItems.mockReset();
   usageReport.mockReset();
   getUserWithRole.mockResolvedValue({ uid: "u1", email: "t@htldornbirn.at", role: "teacher" });
   createMasterDataItem.mockResolvedValue({ id: "c1", name: "3AHIT", parentId: null });
@@ -121,6 +124,60 @@ describe("POST /api/master-data/[category]", () => {
 
     expect(response.status).toBe(500);
     expect(JSON.stringify(await response.json())).not.toContain("line 42");
+  });
+});
+
+describe("PATCH /api/master-data/[category]", () => {
+  function patchRequest(body: unknown) {
+    return new Request("https://example.com/api/master-data/classes", {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("passes the new order to the service", async () => {
+    const response = await PATCH(patchRequest({ order: ["c2", "c1"] }), context("classes"));
+
+    expect(response.status).toBe(204);
+    expect(reorderMasterDataItems).toHaveBeenCalledWith("classes", ["c2", "c1"]);
+  });
+
+  it("rejects a student with 403, so a bypassed client cannot reorder", async () => {
+    getUserWithRole.mockResolvedValue({
+      uid: "u2",
+      email: "s@student.htldornbirn.at",
+      role: "student",
+    });
+
+    const response = await PATCH(patchRequest({ order: ["c1"] }), context("classes"));
+
+    expect(response.status).toBe(403);
+    expect(reorderMasterDataItems).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown category", async () => {
+    const response = await PATCH(patchRequest({ order: ["c1"] }), context("users"));
+
+    expect(response.status).toBe(400);
+    expect(reorderMasterDataItems).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown field rather than ignoring it", async () => {
+    const response = await PATCH(
+      patchRequest({ order: ["c1"], name: "sneaky" }),
+      context("classes"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(reorderMasterDataItems).not.toHaveBeenCalled();
+  });
+
+  it("reports an id that is not in the list as 404", async () => {
+    reorderMasterDataItems.mockRejectedValue(new ServiceError("NOT_FOUND", "Gibt es nicht."));
+
+    const response = await PATCH(patchRequest({ order: ["ghost"] }), context("classes"));
+
+    expect(response.status).toBe(404);
   });
 });
 

--- a/src/app/api/master-data/[category]/route.test.ts
+++ b/src/app/api/master-data/[category]/route.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getUserWithRole = vi.fn();
 const createMasterDataItem = vi.fn();
-const blockedItemIds = vi.fn();
+const usageReport = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
   getUserWithRole: () => getUserWithRole(),
@@ -18,7 +18,7 @@ vi.mock("@/lib/master-data/master-data-service", () => ({
 }));
 
 vi.mock("@/lib/master-data/usage-guard", () => ({
-  blockedItemIds: (...args: unknown[]) => blockedItemIds(...args),
+  usageReport: (...args: unknown[]) => usageReport(...args),
 }));
 
 const { GET, POST } = await import("./route");
@@ -38,10 +38,10 @@ function context(category: string) {
 beforeEach(() => {
   getUserWithRole.mockReset();
   createMasterDataItem.mockReset();
-  blockedItemIds.mockReset();
+  usageReport.mockReset();
   getUserWithRole.mockResolvedValue({ uid: "u1", email: "t@htldornbirn.at", role: "teacher" });
   createMasterDataItem.mockResolvedValue({ id: "c1", name: "3AHIT", parentId: null });
-  blockedItemIds.mockResolvedValue(["c1"]);
+  usageReport.mockResolvedValue({ blockedIds: ["c1"], undeletableIds: ["c1", "c2"] });
 });
 
 describe("POST /api/master-data/[category]", () => {
@@ -53,12 +53,12 @@ describe("POST /api/master-data/[category]", () => {
     expect(createMasterDataItem).toHaveBeenCalledWith("classes", { name: "3AHIT" });
   });
 
-  it("passes the parent through for a nested list", async () => {
-    await POST(request({ name: "Helm", parentId: "ski" }), context("required-equipment"));
+  it("passes the equipment list through for a program", async () => {
+    await POST(request({ name: "Ski", requiredEquipment: ["Helm"] }), context("programs"));
 
-    expect(createMasterDataItem).toHaveBeenCalledWith("required-equipment", {
-      name: "Helm",
-      parentId: "ski",
+    expect(createMasterDataItem).toHaveBeenCalledWith("programs", {
+      name: "Ski",
+      requiredEquipment: ["Helm"],
     });
   });
 
@@ -125,11 +125,11 @@ describe("POST /api/master-data/[category]", () => {
 });
 
 describe("GET /api/master-data/[category]", () => {
-  it("reports the items blocked by the in-use guard", async () => {
+  it("reports what may not be edited and what may not be deleted", async () => {
     const response = await GET(new Request("https://example.com"), context("classes"));
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ blockedIds: ["c1"] });
+    expect(await response.json()).toEqual({ blockedIds: ["c1"], undeletableIds: ["c1", "c2"] });
   });
 
   it("rejects a student, since the answer is derived from data they cannot read", async () => {
@@ -142,13 +142,13 @@ describe("GET /api/master-data/[category]", () => {
     const response = await GET(new Request("https://example.com"), context("classes"));
 
     expect(response.status).toBe(403);
-    expect(blockedItemIds).not.toHaveBeenCalled();
+    expect(usageReport).not.toHaveBeenCalled();
   });
 
   it("rejects an unknown category", async () => {
     const response = await GET(new Request("https://example.com"), context("users"));
 
     expect(response.status).toBe(400);
-    expect(blockedItemIds).not.toHaveBeenCalled();
+    expect(usageReport).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/master-data/[category]/route.ts
+++ b/src/app/api/master-data/[category]/route.ts
@@ -12,15 +12,21 @@ import {
   requireTeacherOrResponse,
 } from "@/lib/api/handler";
 import { ErrorCode } from "@/lib/errors";
+import { orderSchema } from "@/lib/schemas/order";
 import { namedListItemSchema, requiredEquipmentSchema } from "@/lib/schemas/master-data";
 import { categoryOf, masterDataCategorySchema } from "@/lib/master-data/categories";
-import { createMasterDataItem } from "@/lib/master-data/master-data-service";
+import {
+  createMasterDataItem,
+  reorderMasterDataItems,
+} from "@/lib/master-data/master-data-service";
 import { usageReport } from "@/lib/master-data/usage-guard";
 
 const createItemSchema = z.strictObject({
   name: namedListItemSchema.shape.name,
   requiredEquipment: requiredEquipmentSchema.optional(),
 });
+
+const reorderSchema = z.strictObject({ order: orderSchema });
 
 type Context = { params: Promise<{ category: string }> };
 
@@ -47,6 +53,30 @@ export async function POST(request: Request, context: Context) {
     return NextResponse.json({ item }, { status: 201 });
   } catch (error) {
     return handleServiceFailure(error, `Creating a ${category.data} item`);
+  }
+}
+
+/**
+ * Reorders the whole list (see Ordering). Deliberately free of the in-use guard the item writes
+ * carry: moving an item changes no stored name, so no master data record can be affected.
+ */
+export async function PATCH(request: Request, context: Context) {
+  const denied = await requireTeacherOrResponse();
+  if (denied) return denied;
+
+  const category = await readCategory(context);
+  if (!category.success) {
+    return errorResponse(ErrorCode.ValidationError, "Diese Kategorie gibt es nicht.");
+  }
+
+  const body = await parseJsonBody(request, reorderSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    await reorderMasterDataItems(category.data, body.data.order);
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    return handleServiceFailure(error, `Reordering ${category.data}`);
   }
 }
 

--- a/src/app/api/master-data/[category]/route.ts
+++ b/src/app/api/master-data/[category]/route.ts
@@ -12,15 +12,14 @@ import {
   requireTeacherOrResponse,
 } from "@/lib/api/handler";
 import { ErrorCode } from "@/lib/errors";
-import { documentIdSchema } from "@/lib/schemas/common";
-import { namedListItemSchema } from "@/lib/schemas/master-data";
+import { namedListItemSchema, requiredEquipmentSchema } from "@/lib/schemas/master-data";
 import { categoryOf, masterDataCategorySchema } from "@/lib/master-data/categories";
 import { createMasterDataItem } from "@/lib/master-data/master-data-service";
-import { blockedItemIds } from "@/lib/master-data/usage-guard";
+import { usageReport } from "@/lib/master-data/usage-guard";
 
 const createItemSchema = z.strictObject({
   name: namedListItemSchema.shape.name,
-  parentId: documentIdSchema.optional(),
+  requiredEquipment: requiredEquipmentSchema.optional(),
 });
 
 type Context = { params: Promise<{ category: string }> };
@@ -66,8 +65,7 @@ export async function GET(_request: Request, context: Context) {
   }
 
   try {
-    const blockedIds = await blockedItemIds(categoryOf(category.data));
-    return NextResponse.json({ blockedIds });
+    return NextResponse.json(await usageReport(categoryOf(category.data)));
   } catch (error) {
     return handleServiceFailure(error, `Reading ${category.data} usage`);
   }

--- a/src/app/api/master-data/[category]/route.ts
+++ b/src/app/api/master-data/[category]/route.ts
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  errorResponse,
+  handleServiceFailure,
+  parseJsonBody,
+  requireTeacherOrResponse,
+} from "@/lib/api/handler";
+import { ErrorCode } from "@/lib/errors";
+import { documentIdSchema } from "@/lib/schemas/common";
+import { namedListItemSchema } from "@/lib/schemas/master-data";
+import { categoryOf, masterDataCategorySchema } from "@/lib/master-data/categories";
+import { createMasterDataItem } from "@/lib/master-data/master-data-service";
+import { blockedItemIds } from "@/lib/master-data/usage-guard";
+
+const createItemSchema = z.strictObject({
+  name: namedListItemSchema.shape.name,
+  parentId: documentIdSchema.optional(),
+});
+
+type Context = { params: Promise<{ category: string }> };
+
+/** The segment is untrusted input, so it is validated before it is allowed to name a collection. */
+async function readCategory({ params }: Context) {
+  const { category } = await params;
+  return masterDataCategorySchema.safeParse(category);
+}
+
+export async function POST(request: Request, context: Context) {
+  const denied = await requireTeacherOrResponse();
+  if (denied) return denied;
+
+  const category = await readCategory(context);
+  if (!category.success) {
+    return errorResponse(ErrorCode.ValidationError, "Diese Kategorie gibt es nicht.");
+  }
+
+  const body = await parseJsonBody(request, createItemSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    const item = await createMasterDataItem(category.data, body.data);
+    return NextResponse.json({ item }, { status: 201 });
+  } catch (error) {
+    return handleServiceFailure(error, `Creating a ${category.data} item`);
+  }
+}
+
+/**
+ * Which items the in-use guard currently blocks (US-5 to US-10). It is derived from student
+ * master data, which clients may not read at all (see firestore.rules), so the list cannot work
+ * this out for itself — and a teacher is the only role that ever sees these views.
+ */
+export async function GET(_request: Request, context: Context) {
+  const denied = await requireTeacherOrResponse();
+  if (denied) return denied;
+
+  const category = await readCategory(context);
+  if (!category.success) {
+    return errorResponse(ErrorCode.ValidationError, "Diese Kategorie gibt es nicht.");
+  }
+
+  try {
+    const blockedIds = await blockedItemIds(categoryOf(category.data));
+    return NextResponse.json({ blockedIds });
+  } catch (error) {
+    return handleServiceFailure(error, `Reading ${category.data} usage`);
+  }
+}

--- a/src/app/api/seasons/route.test.ts
+++ b/src/app/api/seasons/route.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getUserWithRole = vi.fn();
 const createSeason = vi.fn();
+const reorderSeasons = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
   getUserWithRole: () => getUserWithRole(),
@@ -14,9 +15,10 @@ vi.mock("@/lib/auth/guards", () => ({
 
 vi.mock("@/lib/seasons/season-service", () => ({
   createSeason: (...args: unknown[]) => createSeason(...args),
+  reorderSeasons: (...args: unknown[]) => reorderSeasons(...args),
 }));
 
-const { POST } = await import("./route");
+const { PATCH, POST } = await import("./route");
 const { ServiceError } = await import("@/lib/service-error");
 
 function postRequest(body: unknown) {
@@ -29,6 +31,7 @@ function postRequest(body: unknown) {
 beforeEach(() => {
   getUserWithRole.mockReset();
   createSeason.mockReset();
+  reorderSeasons.mockReset();
   getUserWithRole.mockResolvedValue({ uid: "u1", email: "t@htldornbirn.at", role: "teacher" });
   createSeason.mockResolvedValue({
     id: "s1",
@@ -114,5 +117,41 @@ describe("POST /api/seasons", () => {
     const body = await response.json();
     expect(body.error.code).toBe("INTERNAL_ERROR");
     expect(JSON.stringify(body)).not.toContain("line 42");
+  });
+});
+
+describe("PATCH /api/seasons", () => {
+  function patchRequest(body: unknown) {
+    return new Request("https://example.com/api/seasons", {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("passes the new order to the service", async () => {
+    const response = await PATCH(patchRequest({ order: ["s2", "s1"] }));
+
+    expect(response.status).toBe(204);
+    expect(reorderSeasons).toHaveBeenCalledWith(["s2", "s1"]);
+  });
+
+  it("rejects a student with 403, so a bypassed client cannot reorder", async () => {
+    getUserWithRole.mockResolvedValue({
+      uid: "u2",
+      email: "s@student.htldornbirn.at",
+      role: "student",
+    });
+
+    const response = await PATCH(patchRequest({ order: ["s1"] }));
+
+    expect(response.status).toBe(403);
+    expect(reorderSeasons).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown field rather than ignoring it", async () => {
+    const response = await PATCH(patchRequest({ order: ["s1"], name: "sneaky" }));
+
+    expect(response.status).toBe(400);
+    expect(reorderSeasons).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/seasons/route.ts
+++ b/src/app/api/seasons/route.ts
@@ -6,10 +6,13 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { handleServiceFailure, parseJsonBody, requireTeacherOrResponse } from "@/lib/api/handler";
+import { orderSchema } from "@/lib/schemas/order";
 import { seasonSchema } from "@/lib/schemas/season";
-import { createSeason } from "@/lib/seasons/season-service";
+import { createSeason, reorderSeasons } from "@/lib/seasons/season-service";
 
 const createSeasonSchema = z.strictObject({ name: seasonSchema.shape.name });
+
+const reorderSchema = z.strictObject({ order: orderSchema });
 
 export async function POST(request: Request) {
   const denied = await requireTeacherOrResponse();
@@ -23,5 +26,21 @@ export async function POST(request: Request) {
     return NextResponse.json({ season }, { status: 201 });
   } catch (error) {
     return handleServiceFailure(error, "Creating a season");
+  }
+}
+
+/** Reorders the season list (see Ordering); it changes no name or flag, so it needs no guard. */
+export async function PATCH(request: Request) {
+  const denied = await requireTeacherOrResponse();
+  if (denied) return denied;
+
+  const body = await parseJsonBody(request, reorderSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    await reorderSeasons(body.data.order);
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    return handleServiceFailure(error, "Reordering seasons");
   }
 }

--- a/src/app/app/(teacher)/master-data/bus-pickup-points/page.tsx
+++ b/src/app/app/(teacher)/master-data/bus-pickup-points/page.tsx
@@ -3,9 +3,8 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { SectionPlaceholder } from "@/components/layout/section-placeholder";
+import { MasterDataView } from "@/components/master-data/master-data-view";
 
-// Replaced by the bus pickup points list in #29.
 export default function BusPickupPointsPage() {
-  return <SectionPlaceholder title="Zustiegsstellen" />;
+  return <MasterDataView category="bus-pickup-points" />;
 }

--- a/src/app/app/(teacher)/master-data/classes/page.tsx
+++ b/src/app/app/(teacher)/master-data/classes/page.tsx
@@ -3,9 +3,8 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { SectionPlaceholder } from "@/components/layout/section-placeholder";
+import { MasterDataView } from "@/components/master-data/master-data-view";
 
-// Replaced by the classes list in #26.
 export default function ClassesPage() {
-  return <SectionPlaceholder title="Klassen" />;
+  return <MasterDataView category="classes" />;
 }

--- a/src/app/app/(teacher)/master-data/food-options/page.tsx
+++ b/src/app/app/(teacher)/master-data/food-options/page.tsx
@@ -3,9 +3,19 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { SectionPlaceholder } from "@/components/layout/section-placeholder";
+import { MasterDataView } from "@/components/master-data/master-data-view";
+import { FOOD_OPTION_OTHER_LABEL } from "@/lib/schemas/master-data";
 
-// Replaced by the food/diet options list in #27.
+const OTHER_HINT =
+  "Diese Option steht immer zur Verfügung und kann nicht bearbeitet oder gelöscht werden. " +
+  "Wer sie wählt, muss die Unverträglichkeit angeben.";
+
 export default function FoodOptionsPage() {
-  return <SectionPlaceholder title="Verpflegung" />;
+  return (
+    <MasterDataView
+      category="food-options"
+      fixedItems={[FOOD_OPTION_OTHER_LABEL]}
+      fixedItemsHint={OTHER_HINT}
+    />
+  );
 }

--- a/src/app/app/(teacher)/master-data/layout.tsx
+++ b/src/app/app/(teacher)/master-data/layout.tsx
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import type { ReactNode } from "react";
+import { seedMasterDataDefaults } from "@/lib/master-data/seed-defaults";
+
+/**
+ * Brings a fresh environment up with the documented defaults (US-5, US-7 to US-10) the first
+ * time a teacher opens this section. Seeding is idempotent and costs a single read once it has
+ * run, and a failure only means missing defaults — not a section the teacher cannot open.
+ */
+export default async function MasterDataLayout({ children }: { children: ReactNode }) {
+  try {
+    await seedMasterDataDefaults();
+  } catch (error) {
+    console.error("Seeding the master data defaults failed:", error);
+  }
+
+  return children;
+}

--- a/src/app/app/(teacher)/master-data/programs/[programId]/page.tsx
+++ b/src/app/app/(teacher)/master-data/programs/[programId]/page.tsx
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { ProgramEquipmentView } from "@/components/master-data/program-equipment-view";
+
+export default async function ProgramEquipmentPage({
+  params,
+}: {
+  params: Promise<{ programId: string }>;
+}) {
+  const { programId } = await params;
+
+  return <ProgramEquipmentView programId={programId} />;
+}

--- a/src/app/app/(teacher)/master-data/programs/page.tsx
+++ b/src/app/app/(teacher)/master-data/programs/page.tsx
@@ -3,9 +3,8 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { SectionPlaceholder } from "@/components/layout/section-placeholder";
+import { ProgramsView } from "@/components/master-data/programs-view";
 
-// Replaced by the programs list in #30.
 export default function ProgramsPage() {
-  return <SectionPlaceholder title="Programme" />;
+  return <ProgramsView />;
 }

--- a/src/app/app/(teacher)/master-data/season-pass-options/page.tsx
+++ b/src/app/app/(teacher)/master-data/season-pass-options/page.tsx
@@ -3,9 +3,8 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { SectionPlaceholder } from "@/components/layout/section-placeholder";
+import { MasterDataView } from "@/components/master-data/master-data-view";
 
-// Replaced by the season pass options list in #28.
 export default function SeasonPassOptionsPage() {
-  return <SectionPlaceholder title="Saisonkarten" />;
+  return <MasterDataView category="season-pass-options" />;
 }

--- a/src/app/app/(teacher)/master-data/skill-levels/page.tsx
+++ b/src/app/app/(teacher)/master-data/skill-levels/page.tsx
@@ -3,9 +3,8 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { SectionPlaceholder } from "@/components/layout/section-placeholder";
+import { MasterDataView } from "@/components/master-data/master-data-view";
 
-// Replaced by the skill levels list in #25.
 export default function SkillLevelsPage() {
-  return <SectionPlaceholder title="Könnensstufen" />;
+  return <MasterDataView category="skill-levels" />;
 }

--- a/src/components/events/events-view.tsx
+++ b/src/components/events/events-view.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Dialog } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { SortableList } from "@/components/ui/sortable-list";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Label } from "@/components/ui/label";
 import { apiRequest, ApiRequestError } from "@/lib/api/client";
@@ -63,6 +64,9 @@ export function EventsView({ seasonId }: { seasonId: string }) {
         readOnly={season?.isArchived ?? false}
         onEdit={(event) => setDialog({ kind: "form", event })}
         onDelete={(event) => setDialog({ kind: "delete", event })}
+        onReorder={(order) => {
+          void apiRequest("/api/events", { method: "PATCH", body: { seasonId, order } });
+        }}
       />
 
       {dialog.kind === "form" ? (
@@ -87,9 +91,18 @@ type EventListProps = {
   readOnly: boolean;
   onEdit: (event: Event) => void;
   onDelete: (event: Event) => void;
+  onReorder: (orderedIds: string[]) => void;
 };
 
-function EventList({ events, loading, error, readOnly, onEdit, onDelete }: EventListProps) {
+function EventList({
+  events,
+  loading,
+  error,
+  readOnly,
+  onEdit,
+  onDelete,
+  onReorder,
+}: EventListProps) {
   if (loading) {
     return (
       <Card className="items-center">
@@ -122,12 +135,14 @@ function EventList({ events, loading, error, readOnly, onEdit, onDelete }: Event
 
   return (
     <Card className="[--card-spacing:--spacing(0)]">
-      <ul>
-        {events.map((event) => (
-          <li
-            key={event.id}
-            className="border-border flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0"
-          >
+      <SortableList
+        items={events}
+        onReorder={onReorder}
+        // An archived season is read-only, so its order is frozen along with everything else.
+        disabled={readOnly}
+        className="[&>li]:border-border [&>li]:border-b [&>li:last-child]:border-b-0"
+        renderItem={(event) => (
+          <div className="flex items-center justify-between gap-4 py-3 pr-4 pl-2">
             <span className="text-sm font-medium">{event.name}</span>
 
             {readOnly ? null : (
@@ -155,9 +170,9 @@ function EventList({ events, loading, error, readOnly, onEdit, onDelete }: Event
                 </Tooltip>
               </div>
             )}
-          </li>
-        ))}
-      </ul>
+          </div>
+        )}
+      />
     </Card>
   );
 }

--- a/src/components/events/events-view.tsx
+++ b/src/components/events/events-view.tsx
@@ -64,9 +64,9 @@ export function EventsView({ seasonId }: { seasonId: string }) {
         readOnly={season?.isArchived ?? false}
         onEdit={(event) => setDialog({ kind: "form", event })}
         onDelete={(event) => setDialog({ kind: "delete", event })}
-        onReorder={(order) => {
-          void apiRequest("/api/events", { method: "PATCH", body: { seasonId, order } });
-        }}
+        onReorder={(order) =>
+          apiRequest("/api/events", { method: "PATCH", body: { seasonId, order } }).then(() => {})
+        }
       />
 
       {dialog.kind === "form" ? (
@@ -91,7 +91,7 @@ type EventListProps = {
   readOnly: boolean;
   onEdit: (event: Event) => void;
   onDelete: (event: Event) => void;
-  onReorder: (orderedIds: string[]) => void;
+  onReorder: (orderedIds: string[]) => void | Promise<void>;
 };
 
 function EventList({

--- a/src/components/master-data/crud-list.tsx
+++ b/src/components/master-data/crud-list.tsx
@@ -59,7 +59,7 @@ type CrudListProps = {
   onSubmit: (name: string, item: CrudItem | null) => Promise<void>;
   onDelete: (item: CrudItem) => Promise<void>;
   /** Receives the ids in their new order after a drag (see Ordering). */
-  onReorder: (orderedIds: string[]) => void;
+  onReorder: (orderedIds: string[]) => void | Promise<void>;
   deleteNote: (item: CrudItem) => React.ReactNode;
 };
 
@@ -153,7 +153,7 @@ type ItemListProps = Required<
   renderRowAction?: (item: CrudItem) => React.ReactNode;
   onEdit: (item: CrudItem) => void;
   onDelete: (item: CrudItem) => void;
-  onReorder: (orderedIds: string[]) => void;
+  onReorder: (orderedIds: string[]) => void | Promise<void>;
 };
 
 function ItemList({

--- a/src/components/master-data/crud-list.tsx
+++ b/src/components/master-data/crud-list.tsx
@@ -1,0 +1,421 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { LoaderCircle, Lock, Pencil, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Dialog } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tooltip } from "@/components/ui/tooltip";
+import { ApiRequestError } from "@/lib/api/client";
+import { namedListItemSchema } from "@/lib/schemas/master-data";
+import { IN_USE_HINT } from "@/lib/master-data/categories";
+
+const formSchema = z.object({ name: namedListItemSchema.shape.name });
+type FormValues = z.infer<typeof formSchema>;
+
+export type CrudItem = { id: string; name: string };
+
+export type CrudLabels = {
+  title: string;
+  singular: string;
+  add: string;
+  empty: string;
+};
+
+type OpenDialog =
+  { kind: "none" } | { kind: "form"; item: CrudItem | null } | { kind: "delete"; item: CrudItem };
+
+type CrudListProps = {
+  labels: CrudLabels;
+  /** Overrides the heading, so a program's equipment list can name the program. */
+  title?: string;
+  /** Rendered above the heading, e.g. the way back out of a nested list. */
+  children?: React.ReactNode;
+  items: CrudItem[];
+  loading: boolean;
+  error: string | null;
+  /** In use itself: neither editable nor deletable. */
+  blockedIds?: Set<string>;
+  /** Deletable no longer, but still renameable — its own list holds something in use. */
+  undeletableIds?: Set<string>;
+  undeletableHint?: string;
+  /** Options offered to students that the teacher does not maintain, such as "Sonstiges" (US-9). */
+  fixedItems?: readonly string[];
+  fixedItemsHint?: string;
+  /** One extra control per row, ahead of edit and delete — the programs list uses it. */
+  renderRowAction?: (item: CrudItem) => React.ReactNode;
+  /** Rejects with an ApiRequestError; a CONFLICT is reported on the name field. */
+  onSubmit: (name: string, item: CrudItem | null) => Promise<void>;
+  onDelete: (item: CrudItem) => Promise<void>;
+  deleteNote: (item: CrudItem) => React.ReactNode;
+};
+
+/**
+ * The one CRUD list every teacher-maintained category uses (US-5 to US-10), and the one a
+ * program's required equipment uses too. It takes items and callbacks rather than reading
+ * anything itself, which is what lets a Firestore collection and a field on a single document
+ * present the identical pattern the requirements ask for.
+ */
+export function CrudList({
+  labels,
+  title,
+  children,
+  items,
+  loading,
+  error,
+  blockedIds = new Set(),
+  undeletableIds = new Set(),
+  undeletableHint = IN_USE_HINT,
+  fixedItems = [],
+  fixedItemsHint,
+  renderRowAction,
+  onSubmit,
+  onDelete,
+  deleteNote,
+}: CrudListProps) {
+  const [dialog, setDialog] = React.useState<OpenDialog>({ kind: "none" });
+
+  const closeDialog = () => setDialog({ kind: "none" });
+
+  return (
+    <div className="flex flex-col gap-4 p-4 md:p-6">
+      {children}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="font-heading text-lg font-semibold">{title ?? labels.title}</h1>
+        <Button onClick={() => setDialog({ kind: "form", item: null })}>
+          <Plus aria-hidden data-icon="inline-start" />
+          {labels.add}
+        </Button>
+      </div>
+
+      <ItemList
+        labels={labels}
+        items={items}
+        loading={loading}
+        error={error}
+        blockedIds={blockedIds}
+        undeletableIds={undeletableIds}
+        undeletableHint={undeletableHint}
+        fixedItems={fixedItems}
+        fixedItemsHint={fixedItemsHint}
+        renderRowAction={renderRowAction}
+        onEdit={(item) => setDialog({ kind: "form", item })}
+        onDelete={(item) => setDialog({ kind: "delete", item })}
+      />
+
+      {dialog.kind === "form" ? (
+        <ItemFormDialog
+          key={dialog.item?.id ?? "new"}
+          labels={labels}
+          item={dialog.item}
+          onSubmit={onSubmit}
+          onClose={closeDialog}
+        />
+      ) : null}
+
+      {dialog.kind === "delete" ? (
+        <DeleteItemDialog
+          key={dialog.item.id}
+          labels={labels}
+          item={dialog.item}
+          note={deleteNote(dialog.item)}
+          onDelete={onDelete}
+          onClose={closeDialog}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+type ItemListProps = Required<
+  Pick<CrudListProps, "labels" | "items" | "loading" | "blockedIds" | "undeletableIds">
+> & {
+  error: string | null;
+  undeletableHint: string;
+  fixedItems: readonly string[];
+  fixedItemsHint?: string;
+  renderRowAction?: (item: CrudItem) => React.ReactNode;
+  onEdit: (item: CrudItem) => void;
+  onDelete: (item: CrudItem) => void;
+};
+
+function ItemList({
+  labels,
+  items,
+  loading,
+  error,
+  blockedIds,
+  undeletableIds,
+  undeletableHint,
+  fixedItems,
+  fixedItemsHint,
+  renderRowAction,
+  onEdit,
+  onDelete,
+}: ItemListProps) {
+  const { title, singular, empty } = labels;
+
+  if (loading) {
+    return (
+      <Card className="items-center">
+        <div role="status" aria-label={`${title} werden geladen`} className="text-muted-foreground">
+          <LoaderCircle aria-hidden className="size-5 animate-spin" />
+        </div>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <p role="alert" className="text-destructive px-(--card-spacing) text-sm">
+          {title} konnten nicht geladen werden.
+        </p>
+      </Card>
+    );
+  }
+
+  if (items.length === 0 && fixedItems.length === 0) {
+    return (
+      <Card>
+        <p className="text-muted-foreground px-(--card-spacing) text-sm">{empty}</p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="[--card-spacing:--spacing(0)]">
+      <ul>
+        {items.map((item) => {
+          const blocked = blockedIds.has(item.id);
+          const undeletable = blocked || undeletableIds.has(item.id);
+          const deleteHint = blocked ? IN_USE_HINT : undeletableHint;
+          const hintId = `${item.id}-in-use-hint`;
+
+          return (
+            <li
+              key={item.id}
+              className="border-border flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0"
+            >
+              <span className="text-sm font-medium">{item.name}</span>
+
+              <div className="flex shrink-0 items-center gap-1">
+                {renderRowAction?.(item)}
+
+                {/* Wrapped in a span because a disabled button emits no pointer events, and the
+                    reason it is disabled is exactly what needs explaining here. */}
+                <Tooltip label={blocked ? IN_USE_HINT : "Bearbeiten"}>
+                  <span className="inline-flex">
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      disabled={blocked}
+                      aria-label={`${singular} ${item.name} bearbeiten`}
+                      aria-describedby={blocked ? hintId : undefined}
+                      onClick={() => onEdit(item)}
+                    >
+                      <Pencil aria-hidden />
+                    </Button>
+                  </span>
+                </Tooltip>
+
+                <Tooltip label={undeletable ? deleteHint : "Löschen"}>
+                  <span className="inline-flex">
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      disabled={undeletable}
+                      aria-label={`${singular} ${item.name} löschen`}
+                      aria-describedby={undeletable ? hintId : undefined}
+                      onClick={() => onDelete(item)}
+                      className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    >
+                      <Trash2 aria-hidden />
+                    </Button>
+                  </span>
+                </Tooltip>
+
+                {undeletable ? (
+                  <span id={hintId} className="sr-only">
+                    {deleteHint}
+                  </span>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+
+        {/* Always offered to students and never a row of its own, so it carries no controls (US-9). */}
+        {fixedItems.map((name) => {
+          const hint = fixedItemsHint ?? "Diese Option ist fix und kann nicht geändert werden.";
+
+          return (
+            <li
+              key={name}
+              className="border-border text-muted-foreground flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0"
+            >
+              <span className="text-sm font-medium">{name}</span>
+              <Tooltip label={hint}>
+                <span className="inline-flex p-1.5">
+                  <Lock aria-hidden className="size-4" />
+                  <span className="sr-only">{hint}</span>
+                </span>
+              </Tooltip>
+            </li>
+          );
+        })}
+      </ul>
+    </Card>
+  );
+}
+
+function ItemFormDialog({
+  labels,
+  item,
+  onSubmit,
+  onClose,
+}: {
+  labels: CrudLabels;
+  item: CrudItem | null;
+  onSubmit: (name: string, item: CrudItem | null) => Promise<void>;
+  onClose: () => void;
+}) {
+  const isEdit = item !== null;
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+  const nameId = React.useId();
+  const errorId = React.useId();
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { name: item?.name ?? "" },
+  });
+
+  const submit = handleSubmit(async (values) => {
+    setSubmitError(null);
+    try {
+      await onSubmit(values.name, item);
+      onClose();
+    } catch (caught) {
+      // A duplicate name, and an item that turned out to be in use, are both problems with what
+      // is in the field — so they are reported there rather than as a detached alert.
+      if (caught instanceof ApiRequestError && caught.code === "CONFLICT") {
+        setError("name", { message: caught.message });
+        return;
+      }
+      setSubmitError(
+        caught instanceof ApiRequestError ? caught.message : "Das hat leider nicht geklappt.",
+      );
+    }
+  });
+
+  return (
+    <Dialog open title={isEdit ? `${labels.singular} bearbeiten` : labels.add} onClose={onClose}>
+      <form onSubmit={submit} className="flex flex-col gap-4" noValidate>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={nameId}>Name</Label>
+          <Input
+            id={nameId}
+            autoFocus
+            aria-invalid={errors.name ? true : undefined}
+            aria-describedby={errors.name ? errorId : undefined}
+            {...register("name")}
+          />
+          {errors.name ? (
+            <p id={errorId} className="text-destructive text-sm">
+              {errors.name.message}
+            </p>
+          ) : null}
+        </div>
+
+        {submitError ? (
+          <p role="alert" className="text-destructive text-sm">
+            {submitError}
+          </p>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Abbrechen
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isEdit ? "Speichern" : "Anlegen"}
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}
+
+function DeleteItemDialog({
+  labels,
+  item,
+  note,
+  onDelete,
+  onClose,
+}: {
+  labels: CrudLabels;
+  item: CrudItem;
+  note: React.ReactNode;
+  onDelete: (item: CrudItem) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [error, setError] = React.useState<string | null>(null);
+  const [deleting, setDeleting] = React.useState(false);
+
+  async function handleDelete() {
+    setDeleting(true);
+    setError(null);
+    try {
+      await onDelete(item);
+      onClose();
+    } catch (caught) {
+      setError(
+        caught instanceof ApiRequestError ? caught.message : "Das hat leider nicht geklappt.",
+      );
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open
+      tone="destructive"
+      title={`${labels.singular} löschen`}
+      onClose={onClose}
+      footer={
+        <>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Abbrechen
+          </Button>
+          <Button type="button" variant="destructive" disabled={deleting} onClick={handleDelete}>
+            Löschen
+          </Button>
+        </>
+      }
+    >
+      <p className="text-sm">{note}</p>
+      {error ? (
+        <p role="alert" className="text-destructive mt-2 text-sm">
+          {error}
+        </p>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/src/components/master-data/crud-list.tsx
+++ b/src/components/master-data/crud-list.tsx
@@ -15,6 +15,7 @@ import { Card } from "@/components/ui/card";
 import { Dialog } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SortableList } from "@/components/ui/sortable-list";
 import { Tooltip } from "@/components/ui/tooltip";
 import { ApiRequestError } from "@/lib/api/client";
 import { namedListItemSchema } from "@/lib/schemas/master-data";
@@ -57,6 +58,8 @@ type CrudListProps = {
   /** Rejects with an ApiRequestError; a CONFLICT is reported on the name field. */
   onSubmit: (name: string, item: CrudItem | null) => Promise<void>;
   onDelete: (item: CrudItem) => Promise<void>;
+  /** Receives the ids in their new order after a drag (see Ordering). */
+  onReorder: (orderedIds: string[]) => void;
   deleteNote: (item: CrudItem) => React.ReactNode;
 };
 
@@ -81,6 +84,7 @@ export function CrudList({
   renderRowAction,
   onSubmit,
   onDelete,
+  onReorder,
   deleteNote,
 }: CrudListProps) {
   const [dialog, setDialog] = React.useState<OpenDialog>({ kind: "none" });
@@ -112,6 +116,7 @@ export function CrudList({
         renderRowAction={renderRowAction}
         onEdit={(item) => setDialog({ kind: "form", item })}
         onDelete={(item) => setDialog({ kind: "delete", item })}
+        onReorder={onReorder}
       />
 
       {dialog.kind === "form" ? (
@@ -148,6 +153,7 @@ type ItemListProps = Required<
   renderRowAction?: (item: CrudItem) => React.ReactNode;
   onEdit: (item: CrudItem) => void;
   onDelete: (item: CrudItem) => void;
+  onReorder: (orderedIds: string[]) => void;
 };
 
 function ItemList({
@@ -163,6 +169,7 @@ function ItemList({
   renderRowAction,
   onEdit,
   onDelete,
+  onReorder,
 }: ItemListProps) {
   const { title, singular, empty } = labels;
 
@@ -196,19 +203,18 @@ function ItemList({
 
   return (
     <Card className="[--card-spacing:--spacing(0)]">
-      <ul>
-        {items.map((item) => {
+      <SortableList
+        items={items}
+        onReorder={onReorder}
+        renderItem={(item) => {
           const blocked = blockedIds.has(item.id);
           const undeletable = blocked || undeletableIds.has(item.id);
           const deleteHint = blocked ? IN_USE_HINT : undeletableHint;
           const hintId = `${item.id}-in-use-hint`;
 
           return (
-            <li
-              key={item.id}
-              className="border-border flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0"
-            >
-              <span className="text-sm font-medium">{item.name}</span>
+            <div className="flex items-center justify-between gap-4 py-3 pr-4 pl-2">
+              <span className="truncate text-sm font-medium">{item.name}</span>
 
               <div className="flex shrink-0 items-center gap-1">
                 {renderRowAction?.(item)}
@@ -252,10 +258,13 @@ function ItemList({
                   </span>
                 ) : null}
               </div>
-            </li>
+            </div>
           );
-        })}
+        }}
+        className="[&>li]:border-border [&>li]:border-b [&>li:last-child]:border-b-0"
+      />
 
+      <ul className="border-border [&>li]:border-border empty:hidden [&>li]:border-t">
         {/* Always offered to students and never a row of its own, so it carries no controls (US-9). */}
         {fixedItems.map((name) => {
           const hint = fixedItemsHint ?? "Diese Option ist fix und kann nicht geändert werden.";
@@ -263,7 +272,7 @@ function ItemList({
           return (
             <li
               key={name}
-              className="border-border text-muted-foreground flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0"
+              className="text-muted-foreground flex items-center justify-between gap-4 py-3 pr-4 pl-9"
             >
               <span className="text-sm font-medium">{name}</span>
               <Tooltip label={hint}>

--- a/src/components/master-data/master-data-view.test.tsx
+++ b/src/components/master-data/master-data-view.test.tsx
@@ -6,14 +6,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { IN_USE_HINT } from "@/lib/master-data/categories";
+import { CHILD_IN_USE_HINT, IN_USE_HINT } from "@/lib/master-data/categories";
 
 const useMasterData = vi.fn();
-const useBlockedItemIds = vi.fn();
+const useUsageReport = vi.fn();
 
 vi.mock("@/lib/master-data/use-master-data", () => ({
   useMasterData: (...args: unknown[]) => useMasterData(...args),
-  useBlockedItemIds: (...args: unknown[]) => useBlockedItemIds(...args),
+  useUsageReport: (...args: unknown[]) => useUsageReport(...args),
 }));
 
 const { MasterDataView } = await import("./master-data-view");
@@ -47,7 +47,7 @@ const conflict = (message: string) =>
 
 beforeEach(() => {
   useMasterData.mockReturnValue({ items, loading: false, error: null });
-  useBlockedItemIds.mockReturnValue(new Set<string>());
+  useUsageReport.mockReturnValue({ blockedIds: new Set<string>(), blockedEquipment: {} });
 });
 
 afterEach(() => {
@@ -98,7 +98,7 @@ describe("MasterDataView — reading the list", () => {
   it("subscribes to the category it was configured with", () => {
     render(<MasterDataView category="skill-levels" />);
 
-    expect(useMasterData).toHaveBeenCalledWith("skill-levels", undefined);
+    expect(useMasterData).toHaveBeenCalledWith("skill-levels");
     expect(screen.getByRole("heading", { name: "Könnensstufen" })).toBeInTheDocument();
   });
 });
@@ -117,19 +117,6 @@ describe("MasterDataView — adding", () => {
     expect(url).toBe("/api/master-data/classes");
     expect(init.method).toBe("POST");
     expect(JSON.parse(String(init.body))).toEqual({ name: "5CHIT" });
-  });
-
-  it("sends the parent along for a nested list", async () => {
-    const fetchMock = stubFetch(created);
-    render(<MasterDataView category="required-equipment" parentId="ski" />);
-
-    await userEvent.click(screen.getByRole("button", { name: /neuer ausrüstungsgegenstand/i }));
-    await userEvent.type(screen.getByLabelText("Name"), "Helm");
-    await userEvent.click(screen.getByRole("button", { name: "Anlegen" }));
-
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(JSON.parse(String(init.body))).toEqual({ name: "Helm", parentId: "ski" });
   });
 
   it("refuses a blank name without calling the server", async () => {
@@ -225,7 +212,9 @@ describe("MasterDataView — deleting", () => {
 });
 
 describe("MasterDataView — the in-use restriction", () => {
-  beforeEach(() => useBlockedItemIds.mockReturnValue(new Set(["c1"])));
+  beforeEach(() =>
+    useUsageReport.mockReturnValue({ blockedIds: new Set(["c1"]), blockedEquipment: {} }),
+  );
 
   it("disables editing and deleting for an item still in use", () => {
     renderView();
@@ -250,7 +239,34 @@ describe("MasterDataView — the in-use restriction", () => {
   it("asks the guard about the category it is showing", () => {
     renderView();
 
-    expect(useBlockedItemIds).toHaveBeenCalledWith("classes");
+    expect(useUsageReport).toHaveBeenCalledWith("classes");
+  });
+});
+
+describe("MasterDataView — an item whose own list is in use", () => {
+  beforeEach(() =>
+    useUsageReport.mockReturnValue({
+      blockedIds: new Set<string>(),
+      blockedEquipment: { c1: ["Helm"] },
+    }),
+  );
+
+  it("blocks deleting it, since deleting would take that entry along", () => {
+    renderView();
+
+    expect(screen.getByRole("button", { name: "Klasse 3AHIT löschen" })).toBeDisabled();
+  });
+
+  it("still allows renaming it, which touches no entry", () => {
+    renderView();
+
+    expect(screen.getByRole("button", { name: "Klasse 3AHIT bearbeiten" })).toBeEnabled();
+  });
+
+  it("says why deleting is blocked", () => {
+    renderView();
+
+    expect(screen.getAllByText(CHILD_IN_USE_HINT).length).toBeGreaterThan(0);
   });
 });
 
@@ -285,7 +301,7 @@ describe("MasterDataView — per-row actions", () => {
   });
 
   it("leaves the extra action reachable for an item the in-use guard blocks", () => {
-    useBlockedItemIds.mockReturnValue(new Set(["c1"]));
+    useUsageReport.mockReturnValue({ blockedIds: new Set(["c1"]), blockedEquipment: {} });
     renderView({
       renderRowAction: (item: { id: string; name: string }) => (
         <a href={`/detail/${item.id}`}>Details zu {item.name}</a>

--- a/src/components/master-data/master-data-view.test.tsx
+++ b/src/components/master-data/master-data-view.test.tsx
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { stubRowLayout } from "@/test/stub-row-layout";
 import { CHILD_IN_USE_HINT, IN_USE_HINT } from "@/lib/master-data/categories";
 
 const useMasterData = vi.fn();
@@ -46,12 +47,14 @@ const conflict = (message: string) =>
   );
 
 beforeEach(() => {
+  stubRowLayout();
   useMasterData.mockReturnValue({ items, loading: false, error: null });
   useUsageReport.mockReturnValue({ blockedIds: new Set<string>(), blockedEquipment: {} });
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 
@@ -309,5 +312,38 @@ describe("MasterDataView — per-row actions", () => {
     });
 
     expect(screen.getByRole("link", { name: "Details zu 3AHIT" })).toBeInTheDocument();
+  });
+});
+
+describe("MasterDataView — ordering", () => {
+  it("gives every item a grip handle, so the order can be changed by dragging", () => {
+    renderView();
+
+    expect(screen.getByRole("button", { name: "3AHIT verschieben" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "4BHIT verschieben" })).toBeInTheDocument();
+  });
+
+  it("offers the handle even for an item the in-use guard blocks, since ordering is always allowed", () => {
+    useUsageReport.mockReturnValue({ blockedIds: new Set(["c1"]), blockedEquipment: {} });
+    renderView();
+
+    expect(screen.getByRole("button", { name: "3AHIT verschieben" })).toBeEnabled();
+  });
+
+  it("sends the new order to its category's handler", async () => {
+    const fetchMock = stubFetch(() => Promise.resolve(new Response(null, { status: 204 })));
+    renderView();
+
+    const handle = screen.getByRole("button", { name: "3AHIT verschieben" });
+    handle.focus();
+    await userEvent.keyboard("{ }");
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("{ }");
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/master-data/classes");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(String(init.body))).toEqual({ order: ["c2", "c1"] });
   });
 });

--- a/src/components/master-data/master-data-view.test.tsx
+++ b/src/components/master-data/master-data-view.test.tsx
@@ -1,0 +1,297 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IN_USE_HINT } from "@/lib/master-data/categories";
+
+const useMasterData = vi.fn();
+const useBlockedItemIds = vi.fn();
+
+vi.mock("@/lib/master-data/use-master-data", () => ({
+  useMasterData: (...args: unknown[]) => useMasterData(...args),
+  useBlockedItemIds: (...args: unknown[]) => useBlockedItemIds(...args),
+}));
+
+const { MasterDataView } = await import("./master-data-view");
+
+const items = [
+  { id: "c1", name: "3AHIT" },
+  { id: "c2", name: "4BHIT" },
+];
+
+function stubFetch(implementation: (...args: unknown[]) => unknown) {
+  const fetchMock = vi.fn(implementation);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+const created = () =>
+  Promise.resolve(
+    new Response(JSON.stringify({ item: { id: "c3", name: "5CHIT", parentId: null } }), {
+      status: 201,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+
+const conflict = (message: string) =>
+  Promise.resolve(
+    new Response(JSON.stringify({ error: { code: "CONFLICT", message } }), {
+      status: 409,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+
+beforeEach(() => {
+  useMasterData.mockReturnValue({ items, loading: false, error: null });
+  useBlockedItemIds.mockReturnValue(new Set<string>());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function renderView(props: Record<string, unknown> = {}) {
+  render(<MasterDataView category="classes" {...props} />);
+}
+
+describe("MasterDataView — reading the list", () => {
+  it("titles the view from the category", () => {
+    renderView();
+
+    expect(screen.getByRole("heading", { name: "Klassen" })).toBeInTheDocument();
+  });
+
+  it("lists every item", () => {
+    renderView();
+
+    expect(screen.getByText("3AHIT")).toBeInTheDocument();
+    expect(screen.getByText("4BHIT")).toBeInTheDocument();
+  });
+
+  it("shows a loading state while the subscription settles", () => {
+    useMasterData.mockReturnValue({ items: [], loading: true, error: null });
+    renderView();
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("reports a failed subscription instead of pretending the list is empty", () => {
+    useMasterData.mockReturnValue({ items: [], loading: false, error: "permission-denied" });
+    renderView();
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.queryByText(/noch keine Klasse/i)).not.toBeInTheDocument();
+  });
+
+  it("names the category in its empty state", () => {
+    useMasterData.mockReturnValue({ items: [], loading: false, error: null });
+    renderView();
+
+    expect(screen.getByText("Es gibt noch keine Klasse.")).toBeInTheDocument();
+  });
+
+  it("subscribes to the category it was configured with", () => {
+    render(<MasterDataView category="skill-levels" />);
+
+    expect(useMasterData).toHaveBeenCalledWith("skill-levels", undefined);
+    expect(screen.getByRole("heading", { name: "Könnensstufen" })).toBeInTheDocument();
+  });
+});
+
+describe("MasterDataView — adding", () => {
+  it("posts the new item to its category's handler", async () => {
+    const fetchMock = stubFetch(created);
+    renderView();
+
+    await userEvent.click(screen.getByRole("button", { name: /neue klasse/i }));
+    await userEvent.type(screen.getByLabelText("Name"), "5CHIT");
+    await userEvent.click(screen.getByRole("button", { name: "Anlegen" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/master-data/classes");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({ name: "5CHIT" });
+  });
+
+  it("sends the parent along for a nested list", async () => {
+    const fetchMock = stubFetch(created);
+    render(<MasterDataView category="required-equipment" parentId="ski" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /neuer ausrüstungsgegenstand/i }));
+    await userEvent.type(screen.getByLabelText("Name"), "Helm");
+    await userEvent.click(screen.getByRole("button", { name: "Anlegen" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({ name: "Helm", parentId: "ski" });
+  });
+
+  it("refuses a blank name without calling the server", async () => {
+    const fetchMock = stubFetch(created);
+    renderView();
+
+    await userEvent.click(screen.getByRole("button", { name: /neue klasse/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Anlegen" }));
+
+    expect(await screen.findByText("Pflichtfeld.")).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a duplicate name on the name field, where the teacher can fix it", async () => {
+    stubFetch(() => conflict("Den Namen „3AHIT\u201c gibt es bereits."));
+    renderView();
+
+    await userEvent.click(screen.getByRole("button", { name: /neue klasse/i }));
+    await userEvent.type(screen.getByLabelText("Name"), "3AHIT");
+    await userEvent.click(screen.getByRole("button", { name: "Anlegen" }));
+
+    const field = await screen.findByLabelText("Name");
+    expect(field).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText(/gibt es bereits/)).toBeInTheDocument();
+  });
+});
+
+describe("MasterDataView — editing", () => {
+  it("patches the item under its own id", async () => {
+    const fetchMock = stubFetch(created);
+    renderView();
+
+    await userEvent.click(screen.getByRole("button", { name: "Klasse 3AHIT bearbeiten" }));
+    const field = screen.getByLabelText("Name");
+    await userEvent.clear(field);
+    await userEvent.type(field, "3BHIT");
+    await userEvent.click(screen.getByRole("button", { name: "Speichern" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/master-data/classes/c1");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(String(init.body))).toEqual({ name: "3BHIT" });
+  });
+
+  it("opens the dialog with the current name already filled in", async () => {
+    stubFetch(created);
+    renderView();
+
+    await userEvent.click(screen.getByRole("button", { name: "Klasse 3AHIT bearbeiten" }));
+
+    expect(screen.getByLabelText("Name")).toHaveValue("3AHIT");
+  });
+});
+
+describe("MasterDataView — deleting", () => {
+  it("asks before deleting, naming the item", async () => {
+    stubFetch(created);
+    renderView();
+
+    await userEvent.click(screen.getByRole("button", { name: "Klasse 3AHIT löschen" }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("3AHIT")).toBeInTheDocument();
+  });
+
+  it("deletes only once the teacher confirms", async () => {
+    const fetchMock = stubFetch(() => Promise.resolve(new Response(null, { status: 204 })));
+    renderView();
+
+    await userEvent.click(screen.getByRole("button", { name: "Klasse 3AHIT löschen" }));
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Löschen" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/master-data/classes/c1");
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("keeps the item when the teacher cancels", async () => {
+    const fetchMock = stubFetch(() => Promise.resolve(new Response(null, { status: 204 })));
+    renderView();
+
+    await userEvent.click(screen.getByRole("button", { name: "Klasse 3AHIT löschen" }));
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Abbrechen" }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("MasterDataView — the in-use restriction", () => {
+  beforeEach(() => useBlockedItemIds.mockReturnValue(new Set(["c1"])));
+
+  it("disables editing and deleting for an item still in use", () => {
+    renderView();
+
+    expect(screen.getByRole("button", { name: "Klasse 3AHIT bearbeiten" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Klasse 3AHIT löschen" })).toBeDisabled();
+  });
+
+  it("explains that the season has to be archived first", () => {
+    renderView();
+
+    expect(screen.getAllByText(IN_USE_HINT).length).toBeGreaterThan(0);
+  });
+
+  it("leaves the other items alone", () => {
+    renderView();
+
+    expect(screen.getByRole("button", { name: "Klasse 4BHIT bearbeiten" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Klasse 4BHIT löschen" })).toBeEnabled();
+  });
+
+  it("asks the guard about the category it is showing", () => {
+    renderView();
+
+    expect(useBlockedItemIds).toHaveBeenCalledWith("classes");
+  });
+});
+
+describe("MasterDataView — fixed options", () => {
+  it("lists an option that is always available alongside the maintained ones", () => {
+    renderView({ fixedItems: ["Sonstiges"] });
+
+    expect(screen.getByText("Sonstiges")).toBeInTheDocument();
+  });
+
+  it("gives a fixed option no edit or delete control", () => {
+    renderView({ fixedItems: ["Sonstiges"] });
+
+    expect(screen.queryByRole("button", { name: /Sonstiges bearbeiten/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Sonstiges löschen/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("MasterDataView — per-row actions", () => {
+  it("renders the extra action a category contributes, once per item", () => {
+    renderView({
+      renderRowAction: (item: { id: string; name: string }) => (
+        <a href={`/detail/${item.id}`}>Details zu {item.name}</a>
+      ),
+    });
+
+    expect(screen.getByRole("link", { name: "Details zu 3AHIT" })).toHaveAttribute(
+      "href",
+      "/detail/c1",
+    );
+    expect(screen.getByRole("link", { name: "Details zu 4BHIT" })).toBeInTheDocument();
+  });
+
+  it("leaves the extra action reachable for an item the in-use guard blocks", () => {
+    useBlockedItemIds.mockReturnValue(new Set(["c1"]));
+    renderView({
+      renderRowAction: (item: { id: string; name: string }) => (
+        <a href={`/detail/${item.id}`}>Details zu {item.name}</a>
+      ),
+    });
+
+    expect(screen.getByRole("link", { name: "Details zu 3AHIT" })).toBeInTheDocument();
+  });
+});

--- a/src/components/master-data/master-data-view.tsx
+++ b/src/components/master-data/master-data-view.tsx
@@ -57,9 +57,9 @@ export function MasterDataView({
       onDelete={(item) =>
         apiRequest(`/api/master-data/${key}/${item.id}`, { method: "DELETE" }).then(() => {})
       }
-      onReorder={(order) => {
-        void apiRequest(`/api/master-data/${key}`, { method: "PATCH", body: { order } });
-      }}
+      onReorder={(order) =>
+        apiRequest(`/api/master-data/${key}`, { method: "PATCH", body: { order } }).then(() => {})
+      }
       deleteNote={(item) => (
         <>
           <strong>{item.name}</strong> wird aus der Liste entfernt. Bereits gespeicherte

--- a/src/components/master-data/master-data-view.tsx
+++ b/src/components/master-data/master-data-view.tsx
@@ -1,0 +1,416 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { LoaderCircle, Lock, Pencil, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Dialog } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tooltip } from "@/components/ui/tooltip";
+import { apiRequest, ApiRequestError } from "@/lib/api/client";
+import { namedListItemSchema, type NamedListItem } from "@/lib/schemas/master-data";
+import {
+  categoryOf,
+  IN_USE_HINT,
+  type MasterDataCategory,
+  type MasterDataCategoryKey,
+} from "@/lib/master-data/categories";
+import { useBlockedItemIds, useMasterData } from "@/lib/master-data/use-master-data";
+
+const formSchema = z.object({ name: namedListItemSchema.shape.name });
+type FormValues = z.infer<typeof formSchema>;
+
+type OpenDialog =
+  | { kind: "none" }
+  | { kind: "form"; item: NamedListItem | null }
+  | { kind: "delete"; item: NamedListItem };
+
+type MasterDataViewProps = {
+  category: MasterDataCategoryKey;
+  /** Required for a nested list: the program its items belong to (US-5). */
+  parentId?: string;
+  /** Overrides the category title, so a nested list can name its parent. */
+  title?: string;
+  /** Rendered above the heading, e.g. the way back out of a nested list. */
+  children?: React.ReactNode;
+  /** Options offered to students that the teacher does not maintain, such as "Sonstiges" (US-9). */
+  fixedItems?: readonly string[];
+  fixedItemsHint?: string;
+  /** One extra control per row, ahead of edit and delete — a program's equipment list uses it. */
+  renderRowAction?: (item: NamedListItem) => React.ReactNode;
+};
+
+/**
+ * The one CRUD list every teacher-maintained category uses (US-5 to US-10). Categories differ
+ * only in their configuration — writing six near-identical views is exactly what the shared
+ * pattern the requirements ask for rules out.
+ */
+export function MasterDataView({
+  category: key,
+  parentId,
+  title,
+  children,
+  fixedItems = [],
+  fixedItemsHint,
+  renderRowAction,
+}: MasterDataViewProps) {
+  const category = categoryOf(key);
+  const { items, loading, error } = useMasterData(key, parentId);
+  const blockedIds = useBlockedItemIds(key);
+  const [dialog, setDialog] = React.useState<OpenDialog>({ kind: "none" });
+
+  const closeDialog = () => setDialog({ kind: "none" });
+
+  return (
+    <div className="flex flex-col gap-4 p-4 md:p-6">
+      {children}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="font-heading text-lg font-semibold">{title ?? category.labels.title}</h1>
+        <Button onClick={() => setDialog({ kind: "form", item: null })}>
+          <Plus aria-hidden data-icon="inline-start" />
+          {category.labels.add}
+        </Button>
+      </div>
+
+      <ItemList
+        category={category}
+        items={items}
+        loading={loading}
+        error={error}
+        blockedIds={blockedIds}
+        fixedItems={fixedItems}
+        fixedItemsHint={fixedItemsHint}
+        renderRowAction={renderRowAction}
+        onEdit={(item) => setDialog({ kind: "form", item })}
+        onDelete={(item) => setDialog({ kind: "delete", item })}
+      />
+
+      {dialog.kind === "form" ? (
+        <ItemFormDialog
+          key={dialog.item?.id ?? "new"}
+          categoryKey={key}
+          category={category}
+          parentId={parentId}
+          item={dialog.item}
+          onClose={closeDialog}
+        />
+      ) : null}
+
+      {dialog.kind === "delete" ? (
+        <DeleteItemDialog
+          key={dialog.item.id}
+          categoryKey={key}
+          category={category}
+          item={dialog.item}
+          onClose={closeDialog}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+type ItemListProps = {
+  category: MasterDataCategory;
+  items: NamedListItem[];
+  loading: boolean;
+  error: string | null;
+  blockedIds: Set<string>;
+  fixedItems: readonly string[];
+  fixedItemsHint?: string;
+  renderRowAction?: (item: NamedListItem) => React.ReactNode;
+  onEdit: (item: NamedListItem) => void;
+  onDelete: (item: NamedListItem) => void;
+};
+
+function ItemList({
+  category,
+  items,
+  loading,
+  error,
+  blockedIds,
+  fixedItems,
+  fixedItemsHint,
+  renderRowAction,
+  onEdit,
+  onDelete,
+}: ItemListProps) {
+  const { title, singular, empty } = category.labels;
+
+  if (loading) {
+    return (
+      <Card className="items-center">
+        <div role="status" aria-label={`${title} werden geladen`} className="text-muted-foreground">
+          <LoaderCircle aria-hidden className="size-5 animate-spin" />
+        </div>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <p role="alert" className="text-destructive px-(--card-spacing) text-sm">
+          {title} konnten nicht geladen werden.
+        </p>
+      </Card>
+    );
+  }
+
+  if (items.length === 0 && fixedItems.length === 0) {
+    return (
+      <Card>
+        <p className="text-muted-foreground px-(--card-spacing) text-sm">{empty}</p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="[--card-spacing:--spacing(0)]">
+      <ul>
+        {items.map((item) => {
+          const blocked = blockedIds.has(item.id);
+          const hintId = `${item.id}-in-use-hint`;
+
+          return (
+            <li
+              key={item.id}
+              className="border-border flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0"
+            >
+              <span className="text-sm font-medium">{item.name}</span>
+
+              <div className="flex shrink-0 items-center gap-1">
+                {renderRowAction?.(item)}
+
+                {/* Wrapped in a span because a disabled button emits no pointer events, and the
+                    reason it is disabled is exactly what needs explaining here. */}
+                <Tooltip label={blocked ? IN_USE_HINT : "Bearbeiten"}>
+                  <span className="inline-flex">
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      disabled={blocked}
+                      aria-label={`${singular} ${item.name} bearbeiten`}
+                      aria-describedby={blocked ? hintId : undefined}
+                      onClick={() => onEdit(item)}
+                    >
+                      <Pencil aria-hidden />
+                    </Button>
+                  </span>
+                </Tooltip>
+
+                <Tooltip label={blocked ? IN_USE_HINT : "Löschen"}>
+                  <span className="inline-flex">
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      disabled={blocked}
+                      aria-label={`${singular} ${item.name} löschen`}
+                      aria-describedby={blocked ? hintId : undefined}
+                      onClick={() => onDelete(item)}
+                      className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    >
+                      <Trash2 aria-hidden />
+                    </Button>
+                  </span>
+                </Tooltip>
+
+                {blocked ? (
+                  <span id={hintId} className="sr-only">
+                    {IN_USE_HINT}
+                  </span>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+
+        {/* Always offered to students and never a row of its own, so it carries no controls (US-9). */}
+        {fixedItems.map((name) => (
+          <li
+            key={name}
+            className="border-border text-muted-foreground flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0"
+          >
+            <span className="text-sm font-medium">{name}</span>
+            <Tooltip
+              label={fixedItemsHint ?? "Diese Option ist fix und kann nicht geändert werden."}
+            >
+              <span className="inline-flex p-1.5">
+                <Lock aria-hidden className="size-4" />
+                <span className="sr-only">
+                  {fixedItemsHint ?? "Diese Option ist fix und kann nicht geändert werden."}
+                </span>
+              </span>
+            </Tooltip>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}
+
+function ItemFormDialog({
+  categoryKey,
+  category,
+  parentId,
+  item,
+  onClose,
+}: {
+  categoryKey: MasterDataCategoryKey;
+  category: MasterDataCategory;
+  parentId?: string;
+  item: NamedListItem | null;
+  onClose: () => void;
+}) {
+  const isEdit = item !== null;
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+  const nameId = React.useId();
+  const errorId = React.useId();
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { name: item?.name ?? "" },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    setSubmitError(null);
+    try {
+      if (isEdit) {
+        await apiRequest(`/api/master-data/${categoryKey}/${item.id}`, {
+          method: "PATCH",
+          body: values,
+        });
+      } else {
+        await apiRequest(`/api/master-data/${categoryKey}`, {
+          method: "POST",
+          body: parentId === undefined ? values : { ...values, parentId },
+        });
+      }
+      onClose();
+    } catch (caught) {
+      // A duplicate name, and an item that turned out to be in use, are both problems with what
+      // is in the field — so they are reported there rather than as a detached alert.
+      if (caught instanceof ApiRequestError && caught.code === "CONFLICT") {
+        setError("name", { message: caught.message });
+        return;
+      }
+      setSubmitError(
+        caught instanceof ApiRequestError ? caught.message : "Das hat leider nicht geklappt.",
+      );
+    }
+  });
+
+  return (
+    <Dialog
+      open
+      title={isEdit ? `${category.labels.singular} bearbeiten` : category.labels.add}
+      onClose={onClose}
+    >
+      <form onSubmit={onSubmit} className="flex flex-col gap-4" noValidate>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={nameId}>Name</Label>
+          <Input
+            id={nameId}
+            autoFocus
+            aria-invalid={errors.name ? true : undefined}
+            aria-describedby={errors.name ? errorId : undefined}
+            {...register("name")}
+          />
+          {errors.name ? (
+            <p id={errorId} className="text-destructive text-sm">
+              {errors.name.message}
+            </p>
+          ) : null}
+        </div>
+
+        {submitError ? (
+          <p role="alert" className="text-destructive text-sm">
+            {submitError}
+          </p>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Abbrechen
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isEdit ? "Speichern" : "Anlegen"}
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}
+
+function DeleteItemDialog({
+  categoryKey,
+  category,
+  item,
+  onClose,
+}: {
+  categoryKey: MasterDataCategoryKey;
+  category: MasterDataCategory;
+  item: NamedListItem;
+  onClose: () => void;
+}) {
+  const [error, setError] = React.useState<string | null>(null);
+  const [deleting, setDeleting] = React.useState(false);
+
+  async function handleDelete() {
+    setDeleting(true);
+    setError(null);
+    try {
+      await apiRequest(`/api/master-data/${categoryKey}/${item.id}`, { method: "DELETE" });
+      onClose();
+    } catch (caught) {
+      setError(
+        caught instanceof ApiRequestError ? caught.message : "Das hat leider nicht geklappt.",
+      );
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open
+      tone="destructive"
+      title={`${category.labels.singular} löschen`}
+      onClose={onClose}
+      footer={
+        <>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Abbrechen
+          </Button>
+          <Button type="button" variant="destructive" disabled={deleting} onClick={handleDelete}>
+            Löschen
+          </Button>
+        </>
+      }
+    >
+      <p className="text-sm">
+        <strong>{item.name}</strong> wird aus der Liste entfernt. Bereits gespeicherte Schülerdaten
+        bleiben unverändert.
+      </p>
+      {error ? (
+        <p role="alert" className="text-destructive mt-2 text-sm">
+          {error}
+        </p>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/src/components/master-data/master-data-view.tsx
+++ b/src/components/master-data/master-data-view.tsx
@@ -6,411 +6,63 @@
 "use client";
 
 import * as React from "react";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import { LoaderCircle, Lock, Pencil, Plus, Trash2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import { Dialog } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Tooltip } from "@/components/ui/tooltip";
-import { apiRequest, ApiRequestError } from "@/lib/api/client";
-import { namedListItemSchema, type NamedListItem } from "@/lib/schemas/master-data";
+import { CrudList, type CrudItem } from "@/components/master-data/crud-list";
+import { apiRequest } from "@/lib/api/client";
 import {
   categoryOf,
-  IN_USE_HINT,
-  type MasterDataCategory,
+  CHILD_IN_USE_HINT,
   type MasterDataCategoryKey,
 } from "@/lib/master-data/categories";
-import { useBlockedItemIds, useMasterData } from "@/lib/master-data/use-master-data";
-
-const formSchema = z.object({ name: namedListItemSchema.shape.name });
-type FormValues = z.infer<typeof formSchema>;
-
-type OpenDialog =
-  | { kind: "none" }
-  | { kind: "form"; item: NamedListItem | null }
-  | { kind: "delete"; item: NamedListItem };
+import { useMasterData, useUsageReport } from "@/lib/master-data/use-master-data";
 
 type MasterDataViewProps = {
   category: MasterDataCategoryKey;
-  /** Required for a nested list: the program its items belong to (US-5). */
-  parentId?: string;
-  /** Overrides the category title, so a nested list can name its parent. */
-  title?: string;
-  /** Rendered above the heading, e.g. the way back out of a nested list. */
-  children?: React.ReactNode;
   /** Options offered to students that the teacher does not maintain, such as "Sonstiges" (US-9). */
   fixedItems?: readonly string[];
   fixedItemsHint?: string;
-  /** One extra control per row, ahead of edit and delete — a program's equipment list uses it. */
-  renderRowAction?: (item: NamedListItem) => React.ReactNode;
+  renderRowAction?: (item: CrudItem) => React.ReactNode;
 };
 
-/**
- * The one CRUD list every teacher-maintained category uses (US-5 to US-10). Categories differ
- * only in their configuration — writing six near-identical views is exactly what the shared
- * pattern the requirements ask for rules out.
- */
+/** A teacher-maintained collection on the shared CRUD list (US-5 to US-10). */
 export function MasterDataView({
   category: key,
-  parentId,
-  title,
-  children,
-  fixedItems = [],
+  fixedItems,
   fixedItemsHint,
   renderRowAction,
 }: MasterDataViewProps) {
   const category = categoryOf(key);
-  const { items, loading, error } = useMasterData(key, parentId);
-  const blockedIds = useBlockedItemIds(key);
-  const [dialog, setDialog] = React.useState<OpenDialog>({ kind: "none" });
-
-  const closeDialog = () => setDialog({ kind: "none" });
+  const { items, loading, error } = useMasterData(key);
+  const report = useUsageReport(key);
 
   return (
-    <div className="flex flex-col gap-4 p-4 md:p-6">
-      {children}
-
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="font-heading text-lg font-semibold">{title ?? category.labels.title}</h1>
-        <Button onClick={() => setDialog({ kind: "form", item: null })}>
-          <Plus aria-hidden data-icon="inline-start" />
-          {category.labels.add}
-        </Button>
-      </div>
-
-      <ItemList
-        category={category}
-        items={items}
-        loading={loading}
-        error={error}
-        blockedIds={blockedIds}
-        fixedItems={fixedItems}
-        fixedItemsHint={fixedItemsHint}
-        renderRowAction={renderRowAction}
-        onEdit={(item) => setDialog({ kind: "form", item })}
-        onDelete={(item) => setDialog({ kind: "delete", item })}
-      />
-
-      {dialog.kind === "form" ? (
-        <ItemFormDialog
-          key={dialog.item?.id ?? "new"}
-          categoryKey={key}
-          category={category}
-          parentId={parentId}
-          item={dialog.item}
-          onClose={closeDialog}
-        />
-      ) : null}
-
-      {dialog.kind === "delete" ? (
-        <DeleteItemDialog
-          key={dialog.item.id}
-          categoryKey={key}
-          category={category}
-          item={dialog.item}
-          onClose={closeDialog}
-        />
-      ) : null}
-    </div>
-  );
-}
-
-type ItemListProps = {
-  category: MasterDataCategory;
-  items: NamedListItem[];
-  loading: boolean;
-  error: string | null;
-  blockedIds: Set<string>;
-  fixedItems: readonly string[];
-  fixedItemsHint?: string;
-  renderRowAction?: (item: NamedListItem) => React.ReactNode;
-  onEdit: (item: NamedListItem) => void;
-  onDelete: (item: NamedListItem) => void;
-};
-
-function ItemList({
-  category,
-  items,
-  loading,
-  error,
-  blockedIds,
-  fixedItems,
-  fixedItemsHint,
-  renderRowAction,
-  onEdit,
-  onDelete,
-}: ItemListProps) {
-  const { title, singular, empty } = category.labels;
-
-  if (loading) {
-    return (
-      <Card className="items-center">
-        <div role="status" aria-label={`${title} werden geladen`} className="text-muted-foreground">
-          <LoaderCircle aria-hidden className="size-5 animate-spin" />
-        </div>
-      </Card>
-    );
-  }
-
-  if (error) {
-    return (
-      <Card>
-        <p role="alert" className="text-destructive px-(--card-spacing) text-sm">
-          {title} konnten nicht geladen werden.
-        </p>
-      </Card>
-    );
-  }
-
-  if (items.length === 0 && fixedItems.length === 0) {
-    return (
-      <Card>
-        <p className="text-muted-foreground px-(--card-spacing) text-sm">{empty}</p>
-      </Card>
-    );
-  }
-
-  return (
-    <Card className="[--card-spacing:--spacing(0)]">
-      <ul>
-        {items.map((item) => {
-          const blocked = blockedIds.has(item.id);
-          const hintId = `${item.id}-in-use-hint`;
-
-          return (
-            <li
-              key={item.id}
-              className="border-border flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0"
-            >
-              <span className="text-sm font-medium">{item.name}</span>
-
-              <div className="flex shrink-0 items-center gap-1">
-                {renderRowAction?.(item)}
-
-                {/* Wrapped in a span because a disabled button emits no pointer events, and the
-                    reason it is disabled is exactly what needs explaining here. */}
-                <Tooltip label={blocked ? IN_USE_HINT : "Bearbeiten"}>
-                  <span className="inline-flex">
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      disabled={blocked}
-                      aria-label={`${singular} ${item.name} bearbeiten`}
-                      aria-describedby={blocked ? hintId : undefined}
-                      onClick={() => onEdit(item)}
-                    >
-                      <Pencil aria-hidden />
-                    </Button>
-                  </span>
-                </Tooltip>
-
-                <Tooltip label={blocked ? IN_USE_HINT : "Löschen"}>
-                  <span className="inline-flex">
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      disabled={blocked}
-                      aria-label={`${singular} ${item.name} löschen`}
-                      aria-describedby={blocked ? hintId : undefined}
-                      onClick={() => onDelete(item)}
-                      className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                    >
-                      <Trash2 aria-hidden />
-                    </Button>
-                  </span>
-                </Tooltip>
-
-                {blocked ? (
-                  <span id={hintId} className="sr-only">
-                    {IN_USE_HINT}
-                  </span>
-                ) : null}
-              </div>
-            </li>
-          );
-        })}
-
-        {/* Always offered to students and never a row of its own, so it carries no controls (US-9). */}
-        {fixedItems.map((name) => (
-          <li
-            key={name}
-            className="border-border text-muted-foreground flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0"
-          >
-            <span className="text-sm font-medium">{name}</span>
-            <Tooltip
-              label={fixedItemsHint ?? "Diese Option ist fix und kann nicht geändert werden."}
-            >
-              <span className="inline-flex p-1.5">
-                <Lock aria-hidden className="size-4" />
-                <span className="sr-only">
-                  {fixedItemsHint ?? "Diese Option ist fix und kann nicht geändert werden."}
-                </span>
-              </span>
-            </Tooltip>
-          </li>
-        ))}
-      </ul>
-    </Card>
-  );
-}
-
-function ItemFormDialog({
-  categoryKey,
-  category,
-  parentId,
-  item,
-  onClose,
-}: {
-  categoryKey: MasterDataCategoryKey;
-  category: MasterDataCategory;
-  parentId?: string;
-  item: NamedListItem | null;
-  onClose: () => void;
-}) {
-  const isEdit = item !== null;
-  const [submitError, setSubmitError] = React.useState<string | null>(null);
-  const nameId = React.useId();
-  const errorId = React.useId();
-
-  const {
-    register,
-    handleSubmit,
-    setError,
-    formState: { errors, isSubmitting },
-  } = useForm<FormValues>({
-    resolver: zodResolver(formSchema),
-    defaultValues: { name: item?.name ?? "" },
-  });
-
-  const onSubmit = handleSubmit(async (values) => {
-    setSubmitError(null);
-    try {
-      if (isEdit) {
-        await apiRequest(`/api/master-data/${categoryKey}/${item.id}`, {
-          method: "PATCH",
-          body: values,
-        });
-      } else {
-        await apiRequest(`/api/master-data/${categoryKey}`, {
-          method: "POST",
-          body: parentId === undefined ? values : { ...values, parentId },
-        });
+    <CrudList
+      labels={category.labels}
+      items={items}
+      loading={loading}
+      error={error}
+      blockedIds={report.blockedIds}
+      undeletableIds={new Set(Object.keys(report.blockedEquipment))}
+      undeletableHint={CHILD_IN_USE_HINT}
+      fixedItems={fixedItems}
+      fixedItemsHint={fixedItemsHint}
+      renderRowAction={renderRowAction}
+      onSubmit={(name, item) =>
+        item === null
+          ? apiRequest(`/api/master-data/${key}`, { method: "POST", body: { name } }).then(() => {})
+          : apiRequest(`/api/master-data/${key}/${item.id}`, {
+              method: "PATCH",
+              body: { name },
+            }).then(() => {})
       }
-      onClose();
-    } catch (caught) {
-      // A duplicate name, and an item that turned out to be in use, are both problems with what
-      // is in the field — so they are reported there rather than as a detached alert.
-      if (caught instanceof ApiRequestError && caught.code === "CONFLICT") {
-        setError("name", { message: caught.message });
-        return;
+      onDelete={(item) =>
+        apiRequest(`/api/master-data/${key}/${item.id}`, { method: "DELETE" }).then(() => {})
       }
-      setSubmitError(
-        caught instanceof ApiRequestError ? caught.message : "Das hat leider nicht geklappt.",
-      );
-    }
-  });
-
-  return (
-    <Dialog
-      open
-      title={isEdit ? `${category.labels.singular} bearbeiten` : category.labels.add}
-      onClose={onClose}
-    >
-      <form onSubmit={onSubmit} className="flex flex-col gap-4" noValidate>
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor={nameId}>Name</Label>
-          <Input
-            id={nameId}
-            autoFocus
-            aria-invalid={errors.name ? true : undefined}
-            aria-describedby={errors.name ? errorId : undefined}
-            {...register("name")}
-          />
-          {errors.name ? (
-            <p id={errorId} className="text-destructive text-sm">
-              {errors.name.message}
-            </p>
-          ) : null}
-        </div>
-
-        {submitError ? (
-          <p role="alert" className="text-destructive text-sm">
-            {submitError}
-          </p>
-        ) : null}
-
-        <div className="flex items-center justify-end gap-2">
-          <Button type="button" variant="outline" onClick={onClose}>
-            Abbrechen
-          </Button>
-          <Button type="submit" disabled={isSubmitting}>
-            {isEdit ? "Speichern" : "Anlegen"}
-          </Button>
-        </div>
-      </form>
-    </Dialog>
-  );
-}
-
-function DeleteItemDialog({
-  categoryKey,
-  category,
-  item,
-  onClose,
-}: {
-  categoryKey: MasterDataCategoryKey;
-  category: MasterDataCategory;
-  item: NamedListItem;
-  onClose: () => void;
-}) {
-  const [error, setError] = React.useState<string | null>(null);
-  const [deleting, setDeleting] = React.useState(false);
-
-  async function handleDelete() {
-    setDeleting(true);
-    setError(null);
-    try {
-      await apiRequest(`/api/master-data/${categoryKey}/${item.id}`, { method: "DELETE" });
-      onClose();
-    } catch (caught) {
-      setError(
-        caught instanceof ApiRequestError ? caught.message : "Das hat leider nicht geklappt.",
-      );
-    } finally {
-      setDeleting(false);
-    }
-  }
-
-  return (
-    <Dialog
-      open
-      tone="destructive"
-      title={`${category.labels.singular} löschen`}
-      onClose={onClose}
-      footer={
+      deleteNote={(item) => (
         <>
-          <Button type="button" variant="outline" onClick={onClose}>
-            Abbrechen
-          </Button>
-          <Button type="button" variant="destructive" disabled={deleting} onClick={handleDelete}>
-            Löschen
-          </Button>
+          <strong>{item.name}</strong> wird aus der Liste entfernt. Bereits gespeicherte
+          Schülerdaten bleiben unverändert.
         </>
-      }
-    >
-      <p className="text-sm">
-        <strong>{item.name}</strong> wird aus der Liste entfernt. Bereits gespeicherte Schülerdaten
-        bleiben unverändert.
-      </p>
-      {error ? (
-        <p role="alert" className="text-destructive mt-2 text-sm">
-          {error}
-        </p>
-      ) : null}
-    </Dialog>
+      )}
+    />
   );
 }

--- a/src/components/master-data/master-data-view.tsx
+++ b/src/components/master-data/master-data-view.tsx
@@ -57,6 +57,9 @@ export function MasterDataView({
       onDelete={(item) =>
         apiRequest(`/api/master-data/${key}/${item.id}`, { method: "DELETE" }).then(() => {})
       }
+      onReorder={(order) => {
+        void apiRequest(`/api/master-data/${key}`, { method: "PATCH", body: { order } });
+      }}
       deleteNote={(item) => (
         <>
           <strong>{item.name}</strong> wird aus der Liste entfernt. Bereits gespeicherte

--- a/src/components/master-data/program-equipment-view.tsx
+++ b/src/components/master-data/program-equipment-view.tsx
@@ -47,6 +47,7 @@ export function ProgramEquipmentView({ programId }: { programId: string }) {
         )
       }
       onDelete={(item) => save(equipment.filter((entry) => entry !== item.id))}
+      onReorder={(order) => void save(order)}
       deleteNote={(item) => (
         <>
           <strong>{item.name}</strong> wird aus der Ausrüstungsliste dieses Programms entfernt.

--- a/src/components/master-data/program-equipment-view.tsx
+++ b/src/components/master-data/program-equipment-view.tsx
@@ -47,7 +47,7 @@ export function ProgramEquipmentView({ programId }: { programId: string }) {
         )
       }
       onDelete={(item) => save(equipment.filter((entry) => entry !== item.id))}
-      onReorder={(order) => void save(order)}
+      onReorder={(order) => save(order)}
       deleteNote={(item) => (
         <>
           <strong>{item.name}</strong> wird aus der Ausrüstungsliste dieses Programms entfernt.

--- a/src/components/master-data/program-equipment-view.tsx
+++ b/src/components/master-data/program-equipment-view.tsx
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { MasterDataView } from "@/components/master-data/master-data-view";
+import { useMasterData } from "@/lib/master-data/use-master-data";
+
+/** One program's required equipment items, on the same CRUD list every category uses (US-5). */
+export function ProgramEquipmentView({ programId }: { programId: string }) {
+  const { items: programs } = useMasterData("programs");
+  const program = programs.find((candidate) => candidate.id === programId) ?? null;
+
+  return (
+    <MasterDataView
+      category="required-equipment"
+      parentId={programId}
+      title={`Benötigte Ausrüstung – ${program?.name ?? "Programm"}`}
+    >
+      <Link
+        href="/app/master-data/programs"
+        className="text-muted-foreground hover:text-foreground flex w-fit items-center gap-1 text-sm transition-colors"
+      >
+        <ArrowLeft aria-hidden className="size-4" />
+        Alle Programme
+      </Link>
+    </MasterDataView>
+  );
+}

--- a/src/components/master-data/program-equipment-view.tsx
+++ b/src/components/master-data/program-equipment-view.tsx
@@ -7,19 +7,52 @@
 
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
-import { MasterDataView } from "@/components/master-data/master-data-view";
-import { useMasterData } from "@/lib/master-data/use-master-data";
+import { CrudList, type CrudItem } from "@/components/master-data/crud-list";
+import { apiRequest } from "@/lib/api/client";
+import { EQUIPMENT_LABELS } from "@/lib/master-data/categories";
+import { useProgram, useUsageReport } from "@/lib/master-data/use-master-data";
 
-/** One program's required equipment items, on the same CRUD list every category uses (US-5). */
+/**
+ * A program's required equipment on the same CRUD list every category uses (US-5). The entries
+ * live in a field on the program, so every change rewrites the whole list — which is what makes
+ * adding, renaming and removing one atomic, and uniqueness checkable without a query.
+ */
 export function ProgramEquipmentView({ programId }: { programId: string }) {
-  const { items: programs } = useMasterData("programs");
-  const program = programs.find((candidate) => candidate.id === programId) ?? null;
+  const { program, loading, error } = useProgram(programId);
+  const report = useUsageReport("programs");
+
+  const equipment = program?.requiredEquipment ?? [];
+  // An entry has no id of its own, so its name is what identifies it within the program.
+  const items: CrudItem[] = equipment.map((name) => ({ id: name, name }));
+  const blockedIds = new Set(report.blockedEquipment[programId] ?? []);
+
+  async function save(names: string[]) {
+    await apiRequest(`/api/master-data/programs/${programId}`, {
+      method: "PATCH",
+      body: { requiredEquipment: names },
+    });
+  }
 
   return (
-    <MasterDataView
-      category="required-equipment"
-      parentId={programId}
-      title={`Benötigte Ausrüstung – ${program?.name ?? "Programm"}`}
+    <CrudList
+      labels={EQUIPMENT_LABELS}
+      title={`${EQUIPMENT_LABELS.title} – ${program?.name ?? "Programm"}`}
+      items={items}
+      loading={loading}
+      error={error}
+      blockedIds={blockedIds}
+      onSubmit={(name, item) =>
+        save(
+          item === null ? [...equipment, name] : equipment.map((e) => (e === item.id ? name : e)),
+        )
+      }
+      onDelete={(item) => save(equipment.filter((entry) => entry !== item.id))}
+      deleteNote={(item) => (
+        <>
+          <strong>{item.name}</strong> wird aus der Ausrüstungsliste dieses Programms entfernt.
+          Bereits gespeicherte Schülerdaten bleiben unverändert.
+        </>
+      )}
     >
       <Link
         href="/app/master-data/programs"
@@ -28,6 +61,6 @@ export function ProgramEquipmentView({ programId }: { programId: string }) {
         <ArrowLeft aria-hidden className="size-4" />
         Alle Programme
       </Link>
-    </MasterDataView>
+    </CrudList>
   );
 }

--- a/src/components/master-data/programs-view.test.tsx
+++ b/src/components/master-data/programs-view.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const useMasterData = vi.fn();
+const useBlockedItemIds = vi.fn();
+
+vi.mock("@/lib/master-data/use-master-data", () => ({
+  useMasterData: (...args: unknown[]) => useMasterData(...args),
+  useBlockedItemIds: (...args: unknown[]) => useBlockedItemIds(...args),
+}));
+
+const { ProgramsView } = await import("./programs-view");
+const { ProgramEquipmentView } = await import("./program-equipment-view");
+
+const programs = [
+  { id: "ski", name: "Ski" },
+  { id: "alt", name: "Alternativ" },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useMasterData.mockReturnValue({ items: programs, loading: false, error: null });
+  useBlockedItemIds.mockReturnValue(new Set<string>());
+});
+
+describe("ProgramsView", () => {
+  it("lists the programs", () => {
+    render(<ProgramsView />);
+
+    expect(screen.getByRole("heading", { name: "Programme" })).toBeInTheDocument();
+    expect(screen.getByText("Ski")).toBeInTheDocument();
+  });
+
+  it("links each program to its own equipment list", () => {
+    render(<ProgramsView />);
+
+    expect(screen.getByRole("link", { name: "Benötigte Ausrüstung für Ski" })).toHaveAttribute(
+      "href",
+      "/app/master-data/programs/ski",
+    );
+  });
+
+  it("keeps the equipment list reachable for a program the in-use guard blocks", () => {
+    useBlockedItemIds.mockReturnValue(new Set(["ski"]));
+    render(<ProgramsView />);
+
+    expect(screen.getByRole("link", { name: "Benötigte Ausrüstung für Ski" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Programm Ski bearbeiten" })).toBeDisabled();
+  });
+});
+
+describe("ProgramEquipmentView", () => {
+  it("scopes the list to the program in the URL", () => {
+    render(<ProgramEquipmentView programId="ski" />);
+
+    expect(useMasterData).toHaveBeenCalledWith("required-equipment", "ski");
+  });
+
+  it("names the program it belongs to", () => {
+    useMasterData.mockImplementation((key: string) =>
+      key === "programs"
+        ? { items: programs, loading: false, error: null }
+        : { items: [{ id: "e1", name: "Helm" }], loading: false, error: null },
+    );
+
+    render(<ProgramEquipmentView programId="ski" />);
+
+    expect(screen.getByRole("heading", { name: /Ski/ })).toBeInTheDocument();
+    expect(screen.getByText("Helm")).toBeInTheDocument();
+  });
+
+  it("offers a way back to the programs list", () => {
+    render(<ProgramEquipmentView programId="ski" />);
+
+    expect(screen.getByRole("link", { name: /alle programme/i })).toHaveAttribute(
+      "href",
+      "/app/master-data/programs",
+    );
+  });
+
+  it("renders a program with no equipment as an empty list rather than an error", () => {
+    useMasterData.mockImplementation((key: string) =>
+      key === "programs"
+        ? { items: programs, loading: false, error: null }
+        : { items: [], loading: false, error: null },
+    );
+
+    render(<ProgramEquipmentView programId="alt" />);
+
+    expect(screen.getByText("Dieses Programm benötigt keine Ausrüstung.")).toBeInTheDocument();
+  });
+});

--- a/src/components/master-data/programs-view.test.tsx
+++ b/src/components/master-data/programs-view.test.tsx
@@ -3,15 +3,19 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IN_USE_HINT } from "@/lib/master-data/categories";
 
 const useMasterData = vi.fn();
-const useBlockedItemIds = vi.fn();
+const useProgram = vi.fn();
+const useUsageReport = vi.fn();
 
 vi.mock("@/lib/master-data/use-master-data", () => ({
   useMasterData: (...args: unknown[]) => useMasterData(...args),
-  useBlockedItemIds: (...args: unknown[]) => useBlockedItemIds(...args),
+  useProgram: (...args: unknown[]) => useProgram(...args),
+  useUsageReport: (...args: unknown[]) => useUsageReport(...args),
 }));
 
 const { ProgramsView } = await import("./programs-view");
@@ -22,11 +26,34 @@ const programs = [
   { id: "alt", name: "Alternativ" },
 ];
 
+const ski = { id: "ski", name: "Ski", requiredEquipment: ["Helm", "Stöcke"] };
+
+function stubFetch() {
+  const fetchMock = vi.fn(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ item: ski }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function bodyOf(fetchMock: ReturnType<typeof stubFetch>) {
+  const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+  return JSON.parse(String(init.body));
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   useMasterData.mockReturnValue({ items: programs, loading: false, error: null });
-  useBlockedItemIds.mockReturnValue(new Set<string>());
+  useProgram.mockReturnValue({ program: ski, loading: false, error: null });
+  useUsageReport.mockReturnValue({ blockedIds: new Set<string>(), blockedEquipment: {} });
 });
+
+afterEach(() => vi.unstubAllGlobals());
 
 describe("ProgramsView", () => {
   it("lists the programs", () => {
@@ -46,7 +73,7 @@ describe("ProgramsView", () => {
   });
 
   it("keeps the equipment list reachable for a program the in-use guard blocks", () => {
-    useBlockedItemIds.mockReturnValue(new Set(["ski"]));
+    useUsageReport.mockReturnValue({ blockedIds: new Set(["ski"]), blockedEquipment: {} });
     render(<ProgramsView />);
 
     expect(screen.getByRole("link", { name: "Benötigte Ausrüstung für Ski" })).toBeInTheDocument();
@@ -55,23 +82,18 @@ describe("ProgramsView", () => {
 });
 
 describe("ProgramEquipmentView", () => {
-  it("scopes the list to the program in the URL", () => {
+  it("reads the program named in the URL", () => {
     render(<ProgramEquipmentView programId="ski" />);
 
-    expect(useMasterData).toHaveBeenCalledWith("required-equipment", "ski");
+    expect(useProgram).toHaveBeenCalledWith("ski");
   });
 
-  it("names the program it belongs to", () => {
-    useMasterData.mockImplementation((key: string) =>
-      key === "programs"
-        ? { items: programs, loading: false, error: null }
-        : { items: [{ id: "e1", name: "Helm" }], loading: false, error: null },
-    );
-
+  it("lists the entries the program carries, and names the program", () => {
     render(<ProgramEquipmentView programId="ski" />);
 
     expect(screen.getByRole("heading", { name: /Ski/ })).toBeInTheDocument();
     expect(screen.getByText("Helm")).toBeInTheDocument();
+    expect(screen.getByText("Stöcke")).toBeInTheDocument();
   });
 
   it("offers a way back to the programs list", () => {
@@ -84,14 +106,89 @@ describe("ProgramEquipmentView", () => {
   });
 
   it("renders a program with no equipment as an empty list rather than an error", () => {
-    useMasterData.mockImplementation((key: string) =>
-      key === "programs"
-        ? { items: programs, loading: false, error: null }
-        : { items: [], loading: false, error: null },
-    );
+    useProgram.mockReturnValue({
+      program: { id: "alt", name: "Alternativ", requiredEquipment: [] },
+      loading: false,
+      error: null,
+    });
 
     render(<ProgramEquipmentView programId="alt" />);
 
     expect(screen.getByText("Dieses Programm benötigt keine Ausrüstung.")).toBeInTheDocument();
+  });
+
+  it("appends a new entry rather than replacing the list", async () => {
+    const fetchMock = stubFetch();
+    render(<ProgramEquipmentView programId="ski" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /neuer ausrüstungsgegenstand/i }));
+    await userEvent.type(screen.getByLabelText("Name"), "Brille");
+    await userEvent.click(screen.getByRole("button", { name: "Anlegen" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("/api/master-data/programs/ski");
+    expect(init.method).toBe("PATCH");
+    expect(bodyOf(fetchMock)).toEqual({ requiredEquipment: ["Helm", "Stöcke", "Brille"] });
+  });
+
+  it("renames an entry in place, keeping the order", async () => {
+    const fetchMock = stubFetch();
+    render(<ProgramEquipmentView programId="ski" />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Ausrüstungsgegenstand Helm bearbeiten" }),
+    );
+    const field = screen.getByLabelText("Name");
+    await userEvent.clear(field);
+    await userEvent.type(field, "Skihelm");
+    await userEvent.click(screen.getByRole("button", { name: "Speichern" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(bodyOf(fetchMock)).toEqual({ requiredEquipment: ["Skihelm", "Stöcke"] });
+  });
+
+  it("removes an entry by rewriting the list without it", async () => {
+    const fetchMock = stubFetch();
+    render(<ProgramEquipmentView programId="ski" />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Ausrüstungsgegenstand Helm löschen" }),
+    );
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Löschen" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(bodyOf(fetchMock)).toEqual({ requiredEquipment: ["Stöcke"] });
+  });
+
+  it("disables an entry a student of an open season still rents", () => {
+    useUsageReport.mockReturnValue({
+      blockedIds: new Set<string>(),
+      blockedEquipment: { ski: ["Helm"] },
+    });
+
+    render(<ProgramEquipmentView programId="ski" />);
+
+    expect(
+      screen.getByRole("button", { name: "Ausrüstungsgegenstand Helm bearbeiten" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Ausrüstungsgegenstand Helm löschen" }),
+    ).toBeDisabled();
+    expect(screen.getAllByText(IN_USE_HINT).length).toBeGreaterThan(0);
+  });
+
+  it("leaves the entries of other programs alone", () => {
+    useUsageReport.mockReturnValue({
+      blockedIds: new Set<string>(),
+      blockedEquipment: { board: ["Helm"] },
+    });
+
+    render(<ProgramEquipmentView programId="ski" />);
+
+    expect(
+      screen.getByRole("button", { name: "Ausrüstungsgegenstand Helm löschen" }),
+    ).toBeEnabled();
   });
 });

--- a/src/components/master-data/programs-view.tsx
+++ b/src/components/master-data/programs-view.tsx
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+import Link from "next/link";
+import { Package } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
+import { MasterDataView } from "@/components/master-data/master-data-view";
+import { cn } from "@/lib/utils";
+
+/**
+ * The programs list, plus the way into each program's own required equipment (US-5). The nested
+ * list stays reachable even while the program itself is locked: its items are matched through
+ * the students' rental selections, so the two are blocked independently.
+ */
+export function ProgramsView() {
+  return (
+    <MasterDataView
+      category="programs"
+      renderRowAction={(program) => (
+        <Tooltip label="Benötigte Ausrüstung">
+          <Link
+            href={`/app/master-data/programs/${program.id}`}
+            aria-label={`Benötigte Ausrüstung für ${program.name}`}
+            className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }))}
+          >
+            <Package aria-hidden className="size-3.5" />
+          </Link>
+        </Tooltip>
+      )}
+    />
+  );
+}

--- a/src/components/seasons/delete-season-dialog.test.tsx
+++ b/src/components/seasons/delete-season-dialog.test.tsx
@@ -24,6 +24,7 @@ const season = {
   isActive: false,
   isArchived: true,
   hasStudentData: true,
+  position: 0,
 };
 
 function renderDialog(overrides: Record<string, unknown> = {}) {

--- a/src/components/seasons/season-form-dialog.test.tsx
+++ b/src/components/seasons/season-form-dialog.test.tsx
@@ -104,6 +104,7 @@ describe("SeasonFormDialog — editing", () => {
     isActive: false,
     isArchived: false,
     hasStudentData: false,
+    position: 0,
   };
 
   it("prefills the current name", () => {
@@ -205,6 +206,7 @@ describe("SeasonFormDialog — duplicate name while editing", () => {
     isActive: false,
     isArchived: false,
     hasStudentData: false,
+    position: 0,
   };
 
   it("reports the clash on the field when renaming onto a taken name", async () => {

--- a/src/components/seasons/season-list.test.tsx
+++ b/src/components/seasons/season-list.test.tsx
@@ -15,6 +15,7 @@ const seasons = [
     isActive: true,
     isArchived: false,
     hasStudentData: true,
+    position: 0,
   },
   {
     id: "s2",
@@ -22,6 +23,7 @@ const seasons = [
     isActive: false,
     isArchived: true,
     hasStudentData: true,
+    position: 0,
   },
   {
     id: "s3",
@@ -29,6 +31,7 @@ const seasons = [
     isActive: false,
     isArchived: false,
     hasStudentData: true,
+    position: 0,
   },
   {
     id: "s4",
@@ -36,6 +39,7 @@ const seasons = [
     isActive: false,
     isArchived: false,
     hasStudentData: false,
+    position: 0,
   },
 ];
 
@@ -45,6 +49,7 @@ function renderList(overrides: Record<string, unknown> = {}) {
     onDelete: vi.fn(),
     onActiveChange: vi.fn(),
     onArchivedChange: vi.fn(),
+    onReorder: vi.fn(),
   };
   render(
     <SeasonList seasons={seasons} loading={false} error={null} {...handlers} {...overrides} />,
@@ -261,6 +266,7 @@ describe("SeasonList — row actions", () => {
           isActive: false,
           isArchived: true,
           hasStudentData: false,
+          position: 0,
         },
       ],
     });

--- a/src/components/seasons/season-list.tsx
+++ b/src/components/seasons/season-list.tsx
@@ -38,7 +38,7 @@ type SeasonListProps = {
   onActiveChange: (season: Season, isActive: boolean) => void;
   onArchivedChange: (season: Season, isArchived: boolean) => void;
   /** Receives the ids of the shown seasons in their new order (see Ordering). */
-  onReorder: (orderedIds: string[]) => void;
+  onReorder: (orderedIds: string[]) => void | Promise<void>;
   busySeasonId?: string | null;
 };
 

--- a/src/components/seasons/season-list.tsx
+++ b/src/components/seasons/season-list.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { SortableList } from "@/components/ui/sortable-list";
 import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { Season } from "@/lib/schemas/season";
@@ -36,6 +37,8 @@ type SeasonListProps = {
   onDelete: (season: Season) => void;
   onActiveChange: (season: Season, isActive: boolean) => void;
   onArchivedChange: (season: Season, isArchived: boolean) => void;
+  /** Receives the ids of the shown seasons in their new order (see Ordering). */
+  onReorder: (orderedIds: string[]) => void;
   busySeasonId?: string | null;
 };
 
@@ -47,6 +50,7 @@ export function SeasonList({
   onDelete,
   onActiveChange,
   onArchivedChange,
+  onReorder,
   busySeasonId = null,
 }: SeasonListProps) {
   if (loading) {
@@ -81,8 +85,11 @@ export function SeasonList({
 
   return (
     <Card className="[--card-spacing:--spacing(0)]">
-      <ul>
-        {seasons.map((season) => {
+      <SortableList
+        items={seasons}
+        onReorder={onReorder}
+        className="[&>li]:border-border [&>li]:border-b [&>li:last-child]:border-b-0"
+        renderItem={(season) => {
           const state = seasonState(season);
           const archiveHintId = `${season.id}-archive-hint`;
           const deleteHintId = `${season.id}-delete-hint`;
@@ -96,10 +103,7 @@ export function SeasonList({
           const busy = busySeasonId === season.id;
 
           return (
-            <li
-              key={season.id}
-              className="border-border flex flex-wrap items-center gap-x-4 gap-y-2 border-b px-4 py-3 last:border-b-0"
-            >
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 py-3 pr-4 pl-2">
               <span className="flex-1 text-sm font-medium">{season.name}</span>
 
               <span
@@ -216,10 +220,10 @@ export function SeasonList({
                   </span>
                 ) : null}
               </div>
-            </li>
+            </div>
           );
-        })}
-      </ul>
+        }}
+      />
     </Card>
   );
 }

--- a/src/components/seasons/seasons-view.test.tsx
+++ b/src/components/seasons/seasons-view.test.tsx
@@ -21,6 +21,7 @@ const active = {
   isActive: true,
   isArchived: false,
   hasStudentData: true,
+  position: 0,
 };
 const archived = {
   id: "s2",
@@ -28,6 +29,7 @@ const archived = {
   isActive: false,
   isArchived: true,
   hasStudentData: true,
+  position: 0,
 };
 const inactive = {
   id: "s3",
@@ -35,6 +37,7 @@ const inactive = {
   isActive: false,
   isArchived: false,
   hasStudentData: true,
+  position: 0,
 };
 const noStudentData = {
   id: "s4",
@@ -42,6 +45,7 @@ const noStudentData = {
   isActive: false,
   isArchived: false,
   hasStudentData: false,
+  position: 0,
 };
 
 function stubFetch(implementation: (...args: unknown[]) => unknown) {

--- a/src/components/seasons/seasons-view.tsx
+++ b/src/components/seasons/seasons-view.tsx
@@ -113,7 +113,7 @@ export function SeasonsView() {
             seasons.map((season) => season.id),
             orderedIds,
           );
-          void apiRequest("/api/seasons", { method: "PATCH", body: { order } });
+          return apiRequest("/api/seasons", { method: "PATCH", body: { order } }).then(() => {});
         }}
       />
 

--- a/src/components/seasons/seasons-view.tsx
+++ b/src/components/seasons/seasons-view.tsx
@@ -12,6 +12,7 @@ import { DeleteSeasonDialog } from "@/components/seasons/delete-season-dialog";
 import { SeasonFormDialog } from "@/components/seasons/season-form-dialog";
 import { SeasonList } from "@/components/seasons/season-list";
 import { apiRequest, ApiRequestError } from "@/lib/api/client";
+import { applyVisibleOrder } from "@/lib/schemas/position";
 import type { Season } from "@/lib/schemas/season";
 import { visibleSeasons } from "@/lib/seasons/season-state";
 import { useSeasons } from "@/lib/seasons/use-seasons";
@@ -105,6 +106,15 @@ export function SeasonsView() {
         onDelete={handleDelete}
         onActiveChange={(season, isActive) => patchSeason(season, { isActive })}
         onArchivedChange={(season, isArchived) => patchSeason(season, { isArchived })}
+        onReorder={(orderedIds) => {
+          // The list may be hiding archived seasons, so the visible order is folded back into
+          // the full one rather than sent on its own (see Ordering).
+          const order = applyVisibleOrder(
+            seasons.map((season) => season.id),
+            orderedIds,
+          );
+          void apiRequest("/api/seasons", { method: "PATCH", body: { order } });
+        }}
       />
 
       {dialog.kind === "form" ? (

--- a/src/components/ui/sortable-list.test.tsx
+++ b/src/components/ui/sortable-list.test.tsx
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { stubRowLayout } from "@/test/stub-row-layout";
+import { SortableList } from "./sortable-list";
+
+beforeEach(stubRowLayout);
+afterEach(() => vi.restoreAllMocks());
+
+const items = [
+  { id: "a", name: "Anton" },
+  { id: "b", name: "Berta" },
+  { id: "c", name: "Cesar" },
+];
+
+function renderList(onReorder = vi.fn(), overrides: Record<string, unknown> = {}) {
+  render(
+    <SortableList
+      items={items}
+      onReorder={onReorder}
+      renderItem={(item) => <span>{item.name}</span>}
+      {...overrides}
+    />,
+  );
+  return onReorder;
+}
+
+describe("SortableList", () => {
+  it("renders every item in the given order", () => {
+    renderList();
+
+    const rendered = screen.getAllByRole("listitem").map((row) => row.textContent);
+    expect(rendered.map((text) => text?.replace(/verschieben/, "").trim())).toEqual([
+      "Anton",
+      "Berta",
+      "Cesar",
+    ]);
+  });
+
+  it("gives every item a grip handle, so a drag is never started by accident", () => {
+    renderList();
+
+    expect(screen.getAllByRole("button", { name: /verschieben/ })).toHaveLength(3);
+  });
+
+  it("names the item in each handle, so the control is distinguishable", () => {
+    renderList();
+
+    expect(screen.getByRole("button", { name: "Anton verschieben" })).toBeInTheDocument();
+  });
+
+  it("keeps the handle in the tab order, so ordering is reachable without a mouse", () => {
+    renderList();
+
+    expect(screen.getByRole("button", { name: "Anton verschieben" })).not.toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+  });
+});
+
+describe("SortableList — keyboard reordering", () => {
+  it("moves an item down and reports the new order", async () => {
+    const onReorder = renderList();
+
+    const handle = screen.getByRole("button", { name: "Anton verschieben" });
+    handle.focus();
+    await userEvent.keyboard("{ }");
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("{ }");
+
+    await waitFor(() => expect(onReorder).toHaveBeenCalledWith(["b", "a", "c"]));
+  });
+
+  it("moves an item up and reports the new order", async () => {
+    const onReorder = renderList();
+
+    const handle = screen.getByRole("button", { name: "Cesar verschieben" });
+    handle.focus();
+    await userEvent.keyboard("{ }");
+    await userEvent.keyboard("{ArrowUp}");
+    await userEvent.keyboard("{ }");
+
+    await waitFor(() => expect(onReorder).toHaveBeenCalledWith(["a", "c", "b"]));
+  });
+
+  it("leaves the order alone when the move is cancelled", async () => {
+    const onReorder = renderList();
+
+    const handle = screen.getByRole("button", { name: "Anton verschieben" });
+    handle.focus();
+    await userEvent.keyboard("{ }");
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("{Escape}");
+
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("does not report a move that ends where it started", async () => {
+    const onReorder = renderList();
+
+    const handle = screen.getByRole("button", { name: "Anton verschieben" });
+    handle.focus();
+    await userEvent.keyboard("{ }");
+    await userEvent.keyboard("{ }");
+
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+});
+
+describe("SortableList — when reordering is not offered", () => {
+  it("renders the items without handles", () => {
+    renderList(vi.fn(), { disabled: true });
+
+    expect(screen.queryByRole("button", { name: /verschieben/ })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+});

--- a/src/components/ui/sortable-list.test.tsx
+++ b/src/components/ui/sortable-list.test.tsx
@@ -121,3 +121,95 @@ describe("SortableList — when reordering is not offered", () => {
     expect(screen.getAllByRole("listitem")).toHaveLength(3);
   });
 });
+
+describe("SortableList — showing the result of a move", () => {
+  /** The rendered order, with each row's handle label stripped off. */
+  function shownOrder() {
+    return screen
+      .getAllByRole("listitem")
+      .map((row) => row.textContent?.replace(/\w+ verschieben/, "").trim());
+  }
+
+  async function moveAntonDown() {
+    const handle = screen.getByRole("button", { name: "Anton verschieben" });
+    handle.focus();
+    await userEvent.keyboard("{ }");
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("{ }");
+  }
+
+  function renderWith(onReorder: (ids: string[]) => void | Promise<void>) {
+    const view = render(
+      <SortableList
+        items={items}
+        onReorder={onReorder}
+        renderItem={(item) => <span>{item.name}</span>}
+      />,
+    );
+    return view;
+  }
+
+  // The write goes through a Route Handler, so the subscription only catches up a round trip
+  // later. Waiting for it would show the old order again in between.
+  it("shows the new order at once, without waiting for the data to catch up", async () => {
+    renderWith(vi.fn());
+
+    await moveAntonDown();
+
+    await waitFor(() => expect(shownOrder()).toEqual(["Berta", "Anton", "Cesar"]));
+  });
+
+  it("stays put when the data catches up and agrees", async () => {
+    const { rerender } = renderWith(vi.fn());
+    await moveAntonDown();
+    await waitFor(() => expect(shownOrder()).toEqual(["Berta", "Anton", "Cesar"]));
+
+    rerender(
+      <SortableList
+        items={[items[1], items[0], items[2]]}
+        onReorder={vi.fn()}
+        renderItem={(item) => <span>{item.name}</span>}
+      />,
+    );
+
+    expect(shownOrder()).toEqual(["Berta", "Anton", "Cesar"]);
+  });
+
+  it("goes back to the stored order when the move could not be saved", async () => {
+    renderWith(() => Promise.reject(new Error("offline")));
+
+    await moveAntonDown();
+
+    await waitFor(() => expect(shownOrder()).toEqual(["Anton", "Berta", "Cesar"]));
+  });
+
+  it("keeps an item that arrived during the move visible", async () => {
+    const { rerender } = renderWith(vi.fn());
+    await moveAntonDown();
+
+    rerender(
+      <SortableList
+        items={[...items, { id: "d", name: "Dora" }]}
+        onReorder={vi.fn()}
+        renderItem={(item) => <span>{item.name}</span>}
+      />,
+    );
+
+    expect(shownOrder()).toEqual(["Berta", "Anton", "Cesar", "Dora"]);
+  });
+
+  it("drops an item that disappeared during the move", async () => {
+    const { rerender } = renderWith(vi.fn());
+    await moveAntonDown();
+
+    rerender(
+      <SortableList
+        items={[items[0], items[2]]}
+        onReorder={vi.fn()}
+        renderItem={(item) => <span>{item.name}</span>}
+      />,
+    );
+
+    expect(shownOrder()).toEqual(["Anton", "Cesar"]);
+  });
+});

--- a/src/components/ui/sortable-list.tsx
+++ b/src/components/ui/sortable-list.tsx
@@ -31,8 +31,11 @@ export type SortableItem = { id: string; name: string };
 
 type SortableListProps<T extends SortableItem> = {
   items: T[];
-  /** Receives the ids in their new order; only called when the order actually changed. */
-  onReorder: (orderedIds: string[]) => void;
+  /**
+   * Receives the ids in their new order; only called when the order actually changed. Rejecting
+   * puts the list back the way it was, so a failed save cannot leave a lie on screen.
+   */
+  onReorder: (orderedIds: string[]) => void | Promise<void>;
   renderItem: (item: T) => React.ReactNode;
   /** Hides the handles, for a list that is read-only in its current state. */
   disabled?: boolean;
@@ -54,20 +57,56 @@ export function SortableList<T extends SortableItem>({
   disabled = false,
   className,
 }: SortableListProps<T>) {
+  /**
+   * The order the teacher just dropped, held until the stored data reflects it.
+   *
+   * Without this the list would flick back: the write goes through a Route Handler rather than
+   * the client SDK, so there is no local echo to compensate with, and the subscription only
+   * catches up a round trip later. In between, dropping would visibly undo itself.
+   */
+  const [dropped, setDropped] = React.useState<string[] | null>(null);
+
+  // Once the stored order says the same thing, the local one has nothing left to add. Adjusted
+  // during render rather than in an effect, which would show the list twice to say it once.
+  const storedOrder = items.map((item) => item.id).join("\u0000");
+  if (dropped !== null && dropped.join("\u0000") === storedOrder) setDropped(null);
+
+  const ordered = React.useMemo(() => {
+    if (dropped === null) return items;
+
+    const remaining = new Map(items.map((item) => [item.id, item]));
+    const moved = dropped.flatMap((id) => {
+      const item = remaining.get(id);
+      if (!item) return [];
+      remaining.delete(id);
+      return [item];
+    });
+
+    // Anything added since the drop is kept, so a concurrent create cannot vanish from view.
+    return [...moved, ...remaining.values()];
+  }, [items, dropped]);
+
   const sensors = useSensors(
     // A short distance threshold, so a tap on a handle is not mistaken for the start of a drag.
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
-  function handleDragEnd({ active, over }: DragEndEvent) {
+  async function handleDragEnd({ active, over }: DragEndEvent) {
     if (!over || active.id === over.id) return;
 
-    const from = items.findIndex((item) => item.id === active.id);
-    const to = items.findIndex((item) => item.id === over.id);
+    const from = ordered.findIndex((item) => item.id === active.id);
+    const to = ordered.findIndex((item) => item.id === over.id);
     if (from === -1 || to === -1) return;
 
-    onReorder(arrayMove(items, from, to).map((item) => item.id));
+    const next = arrayMove(ordered, from, to).map((item) => item.id);
+    setDropped(next);
+
+    try {
+      await onReorder(next);
+    } catch {
+      setDropped(null);
+    }
   }
 
   if (disabled) {
@@ -85,11 +124,11 @@ export function SortableList<T extends SortableItem>({
       sensors={sensors}
       collisionDetection={closestCenter}
       modifiers={[restrictToVerticalAxis, restrictToParentElement]}
-      onDragEnd={handleDragEnd}
+      onDragEnd={(event) => void handleDragEnd(event)}
     >
-      <SortableContext items={items} strategy={verticalListSortingStrategy}>
+      <SortableContext items={ordered} strategy={verticalListSortingStrategy}>
         <ul className={className}>
-          {items.map((item) => (
+          {ordered.map((item) => (
             <SortableRow key={item.id} item={item}>
               {renderItem(item)}
             </SortableRow>

--- a/src/components/ui/sortable-list.tsx
+++ b/src/components/ui/sortable-list.tsx
@@ -1,0 +1,126 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+import * as React from "react";
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { restrictToParentElement, restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type SortableItem = { id: string; name: string };
+
+type SortableListProps<T extends SortableItem> = {
+  items: T[];
+  /** Receives the ids in their new order; only called when the order actually changed. */
+  onReorder: (orderedIds: string[]) => void;
+  renderItem: (item: T) => React.ReactNode;
+  /** Hides the handles, for a list that is read-only in its current state. */
+  disabled?: boolean;
+  className?: string;
+};
+
+/**
+ * The application's one drag-and-drop list (see Drag and Drop). Dragging starts from a grip
+ * handle rather than the row, so the rest of the row keeps its own controls, and the handle is
+ * always visible rather than revealed on hover — a hover-only control cannot be reached by touch.
+ *
+ * Pointer sensors rather than native HTML drag-and-drop, which touch devices do not implement;
+ * the keyboard sensor is what keeps ordering usable without a pointer at all.
+ */
+export function SortableList<T extends SortableItem>({
+  items,
+  onReorder,
+  renderItem,
+  disabled = false,
+  className,
+}: SortableListProps<T>) {
+  const sensors = useSensors(
+    // A short distance threshold, so a tap on a handle is not mistaken for the start of a drag.
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleDragEnd({ active, over }: DragEndEvent) {
+    if (!over || active.id === over.id) return;
+
+    const from = items.findIndex((item) => item.id === active.id);
+    const to = items.findIndex((item) => item.id === over.id);
+    if (from === -1 || to === -1) return;
+
+    onReorder(arrayMove(items, from, to).map((item) => item.id));
+  }
+
+  if (disabled) {
+    return (
+      <ul className={className}>
+        {items.map((item) => (
+          <li key={item.id}>{renderItem(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext items={items} strategy={verticalListSortingStrategy}>
+        <ul className={className}>
+          {items.map((item) => (
+            <SortableRow key={item.id} item={item}>
+              {renderItem(item)}
+            </SortableRow>
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+function SortableRow({ item, children }: { item: SortableItem; children: React.ReactNode }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.id,
+  });
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Translate.toString(transform), transition }}
+      className={cn("flex items-center", isDragging && "bg-muted relative z-10 opacity-80")}
+    >
+      <button
+        type="button"
+        aria-label={`${item.name} verschieben`}
+        className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 ml-2 shrink-0 cursor-grab touch-none rounded-md p-1 transition-colors outline-none focus-visible:ring-3 active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical aria-hidden className="size-4" />
+      </button>
+      <div className="min-w-0 flex-1">{children}</div>
+    </li>
+  );
+}

--- a/src/lib/events/event-service.test.ts
+++ b/src/lib/events/event-service.test.ts
@@ -43,7 +43,11 @@ describe("createEvent", () => {
 
     const event = await createEvent({ seasonId: "s1", name: "Montafon" });
 
-    expect(firestore.get("events", event.id)).toEqual({ seasonId: "s1", name: "Montafon" });
+    expect(firestore.get("events", event.id)).toEqual({
+      seasonId: "s1",
+      name: "Montafon",
+      position: 0,
+    });
   });
 
   it("trims the name", async () => {

--- a/src/lib/events/event-service.test.ts
+++ b/src/lib/events/event-service.test.ts
@@ -58,6 +58,20 @@ describe("createEvent", () => {
     expect(event.name).toBe("Lech");
   });
 
+  // Only this season's events decide the position, and only how many of them there are.
+  it("counts the season's existing events rather than downloading them", async () => {
+    seedSeason("s1");
+    seedEvent("e1", "s1", "Montafon");
+    seedEvent("e2", "s1", "Lech");
+    seedEvent("e3", "s2", "Silvretta");
+    firestore.queryDocumentsRead = 0;
+
+    const event = await createEvent({ seasonId: "s1", name: "Damuels" });
+
+    expect(firestore.get("events", event.id)).toMatchObject({ position: 2 });
+    expect(firestore.queryDocumentsRead).toBe(0);
+  });
+
   it("rejects a blank name", async () => {
     seedSeason("s1");
 

--- a/src/lib/events/event-service.ts
+++ b/src/lib/events/event-service.ts
@@ -51,8 +51,12 @@ export async function createEvent(input: { seasonId: string; name: string }): Pr
 
   // A new event goes to the end of its season's order (see Ordering).
   const position = (
-    await adminDb.collection(COLLECTIONS.events).where("seasonId", "==", input.seasonId).get()
-  ).size;
+    await adminDb
+      .collection(COLLECTIONS.events)
+      .where("seasonId", "==", input.seasonId)
+      .count()
+      .get()
+  ).data().count;
 
   // Scoped to the season, so two seasons may both hold a "Montafon".
   return adminDb.runTransaction(async (transaction) => {

--- a/src/lib/events/event-service.ts
+++ b/src/lib/events/event-service.ts
@@ -6,6 +6,7 @@
 import "server-only";
 import { adminDb } from "@/lib/firebase/admin";
 import { commitInChunks, type BatchOperation } from "@/lib/firebase/batch";
+import { reorderCollection } from "@/lib/firebase/reorder";
 import { releaseName, reservationRef, reserveName, scopeOf } from "@/lib/firebase/unique-name";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
@@ -48,6 +49,11 @@ export async function createEvent(input: { seasonId: string; name: string }): Pr
   const name = parseName(input.name);
   await requireOpenSeason(input.seasonId);
 
+  // A new event goes to the end of its season's order (see Ordering).
+  const position = (
+    await adminDb.collection(COLLECTIONS.events).where("seasonId", "==", input.seasonId).get()
+  ).size;
+
   // Scoped to the season, so two seasons may both hold a "Montafon".
   return adminDb.runTransaction(async (transaction) => {
     const reference = adminDb.collection(COLLECTIONS.events).doc();
@@ -57,9 +63,21 @@ export async function createEvent(input: { seasonId: string; name: string }): Pr
       ownerId: reference.id,
     });
 
-    const data = { seasonId: input.seasonId, name };
+    const data = { seasonId: input.seasonId, name, position };
     transaction.set(reference, data);
     return { id: reference.id, ...data };
+  });
+}
+
+/** Ordering is per season, so one season's list can never renumber another's (see Ordering). */
+export async function reorderEvents(
+  seasonId: string,
+  orderedIds: readonly string[],
+): Promise<void> {
+  await reorderCollection({
+    collection: COLLECTIONS.events,
+    orderedIds,
+    scope: { field: "seasonId", value: seasonId },
   });
 }
 

--- a/src/lib/events/use-events.ts
+++ b/src/lib/events/use-events.ts
@@ -6,10 +6,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { collection, orderBy, query, where } from "firebase/firestore";
+import { collection, query, where } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
 import { subscribeWithRecovery } from "@/lib/firebase/live-query";
 import { COLLECTIONS } from "@/lib/schemas/collections";
+import { byPosition } from "@/lib/schemas/position";
 import { eventSchema, type Event } from "@/lib/schemas/season";
 
 /** Real-time read scoped to one season, governed by Security Rules. */
@@ -22,12 +23,10 @@ export function useEvents(seasonId: string) {
     () =>
       subscribeWithRecovery<Event>({
         label: "events",
+        // Sorted here rather than in the query: Firestore's orderBy silently omits documents
+        // that lack the field, which would hide any event stored before ordering existed.
         buildQuery: () =>
-          query(
-            collection(db, COLLECTIONS.events),
-            where("seasonId", "==", seasonId),
-            orderBy("name"),
-          ),
+          query(collection(db, COLLECTIONS.events), where("seasonId", "==", seasonId)),
         parse: (id, data) => {
           const parsed = eventSchema.safeParse({ id, ...data });
           if (!parsed.success) {
@@ -37,7 +36,7 @@ export function useEvents(seasonId: string) {
           return parsed.data;
         },
         onData: (items) => {
-          setEvents(items);
+          setEvents([...items].sort(byPosition));
           setLoading(false);
         },
         onError: (message) => {

--- a/src/lib/firebase/converters.test.ts
+++ b/src/lib/firebase/converters.test.ts
@@ -22,6 +22,7 @@ describe("zodConverter", () => {
       isActive: true,
       isArchived: false,
       hasStudentData: false,
+      position: 0,
     });
 
     expect(written).toEqual({
@@ -29,6 +30,7 @@ describe("zodConverter", () => {
       isActive: true,
       isArchived: false,
       hasStudentData: false,
+      position: 0,
     });
     expect(written).not.toHaveProperty("id");
   });
@@ -40,6 +42,7 @@ describe("zodConverter", () => {
         isActive: true,
         isArchived: false,
         hasStudentData: false,
+        position: 0,
       }),
       {},
     );
@@ -50,6 +53,7 @@ describe("zodConverter", () => {
       isActive: true,
       isArchived: false,
       hasStudentData: false,
+      position: 0,
     });
   });
 

--- a/src/lib/firebase/reorder.test.ts
+++ b/src/lib/firebase/reorder.test.ts
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeFirestore } from "@/test/fake-firestore";
+
+const firestore = new FakeFirestore();
+
+vi.mock("@/lib/firebase/admin", () => ({
+  adminDb: firestore,
+}));
+
+const { reorderCollection } = await import("./reorder");
+const { ServiceError } = await import("@/lib/service-error");
+
+beforeEach(() => firestore.reset());
+
+function seed(collection: string, entries: Record<string, Record<string, unknown>>) {
+  for (const [id, data] of Object.entries(entries)) firestore.seed(collection, id, data);
+}
+
+function positionsOf(collection: string): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(firestore.docs(collection)).map(([id, data]) => [id, data.position]),
+  );
+}
+
+describe("reorderCollection", () => {
+  beforeEach(() =>
+    seed("classOptions", {
+      a: { name: "A", position: 0 },
+      b: { name: "B", position: 1 },
+      c: { name: "C", position: 2 },
+    }),
+  );
+
+  it("writes the requested order as consecutive positions from zero", async () => {
+    await reorderCollection({ collection: "classOptions", orderedIds: ["c", "a", "b"] });
+
+    expect(positionsOf("classOptions")).toEqual({ c: 0, a: 1, b: 2 });
+  });
+
+  it("leaves the names untouched, since ordering changes no stored value", async () => {
+    await reorderCollection({ collection: "classOptions", orderedIds: ["c", "a", "b"] });
+
+    expect(firestore.get("classOptions", "a")).toMatchObject({ name: "A" });
+  });
+
+  it("reports an id that is not in the collection", async () => {
+    await expect(
+      reorderCollection({ collection: "classOptions", orderedIds: ["a", "ghost"] }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("changes nothing when an id is rejected", async () => {
+    await expect(
+      reorderCollection({ collection: "classOptions", orderedIds: ["c", "ghost"] }),
+    ).rejects.toBeInstanceOf(ServiceError);
+
+    expect(positionsOf("classOptions")).toEqual({ a: 0, b: 1, c: 2 });
+  });
+
+  it("rejects a repeated id rather than silently dropping one", async () => {
+    await expect(
+      reorderCollection({ collection: "classOptions", orderedIds: ["a", "a", "b"] }),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  // A teacher adding an item while another reorders must not have it vanish from the list.
+  it("appends an item the caller never saw, keeping it visible", async () => {
+    firestore.seed("classOptions", "d", { name: "D", position: 3 });
+
+    await reorderCollection({ collection: "classOptions", orderedIds: ["c", "b", "a"] });
+
+    expect(positionsOf("classOptions")).toEqual({ c: 0, b: 1, a: 2, d: 3 });
+  });
+
+  it("orders several unseen items among themselves by their previous position", async () => {
+    firestore.seed("classOptions", "e", { name: "E", position: 9 });
+    firestore.seed("classOptions", "d", { name: "D", position: 4 });
+
+    await reorderCollection({ collection: "classOptions", orderedIds: ["a"] });
+
+    expect(positionsOf("classOptions")).toEqual({ a: 0, b: 1, c: 2, d: 3, e: 4 });
+  });
+
+  it("accepts an empty collection without writing anything", async () => {
+    firestore.reset();
+
+    await reorderCollection({ collection: "classOptions", orderedIds: [] });
+
+    expect(firestore.commitCount).toBe(0);
+  });
+});
+
+describe("reorderCollection — scoped to a parent", () => {
+  beforeEach(() =>
+    seed("events", {
+      a: { seasonId: "s1", name: "A", position: 0 },
+      b: { seasonId: "s1", name: "B", position: 1 },
+      x: { seasonId: "s2", name: "X", position: 0 },
+      y: { seasonId: "s2", name: "Y", position: 1 },
+    }),
+  );
+
+  it("renumbers only the items of the scope it was given", async () => {
+    await reorderCollection({
+      collection: "events",
+      orderedIds: ["b", "a"],
+      scope: { field: "seasonId", value: "s1" },
+    });
+
+    expect(positionsOf("events")).toEqual({ b: 0, a: 1, x: 0, y: 1 });
+  });
+
+  it("refuses an id belonging to a different scope", async () => {
+    await expect(
+      reorderCollection({
+        collection: "events",
+        orderedIds: ["a", "x"],
+        scope: { field: "seasonId", value: "s1" },
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});

--- a/src/lib/firebase/reorder.ts
+++ b/src/lib/firebase/reorder.ts
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import "server-only";
+import { adminDb } from "@/lib/firebase/admin";
+import { commitInChunks, type BatchOperation } from "@/lib/firebase/batch";
+import { ErrorCode } from "@/lib/errors";
+import { ServiceError } from "@/lib/service-error";
+
+type Reorder = {
+  collection: string;
+  /** The ids in the order the teacher dropped them into. */
+  orderedIds: readonly string[];
+  /** Restricts renumbering to one parent's items, e.g. the events of a single season. */
+  scope?: { field: string; value: string };
+};
+
+/**
+ * Rewrites an ordered list as consecutive positions from zero (see Ordering).
+ *
+ * Positions are renumbered wholesale rather than patched, so the stored order can never drift
+ * into ties or gaps however the list is edited. Ordering touches no name, so it is deliberately
+ * not subject to the in-use restriction that governs editing and removing.
+ *
+ * Ids the caller did not mention are kept and appended in their previous order: a teacher who
+ * adds an item while another is dragging must not have it disappear from the list.
+ */
+export async function reorderCollection({ collection, orderedIds, scope }: Reorder): Promise<void> {
+  if (new Set(orderedIds).size !== orderedIds.length) {
+    throw new ServiceError(ErrorCode.ValidationError, "Ein Eintrag wurde doppelt übergeben.");
+  }
+
+  const query =
+    scope === undefined
+      ? adminDb.collection(collection)
+      : adminDb.collection(collection).where(scope.field, "==", scope.value);
+  const snapshot = await query.get();
+
+  const known = new Map(snapshot.docs.map((document) => [document.id, document]));
+
+  const missing = orderedIds.find((id) => !known.has(id));
+  if (missing !== undefined) {
+    throw new ServiceError(ErrorCode.NotFound, "Diesen Eintrag gibt es hier nicht.");
+  }
+
+  const rest = snapshot.docs
+    .filter((document) => !orderedIds.includes(document.id))
+    .sort((a, b) => Number(a.data()?.position ?? 0) - Number(b.data()?.position ?? 0))
+    .map((document) => document.id);
+
+  const operations: BatchOperation[] = [...orderedIds, ...rest].map(
+    (id, position) => (batch) => batch.update(known.get(id)!.ref, { position }),
+  );
+
+  await commitInChunks(operations);
+}

--- a/src/lib/master-data/categories.test.ts
+++ b/src/lib/master-data/categories.test.ts
@@ -51,24 +51,16 @@ describe("MASTER_DATA_CATEGORIES", () => {
     });
   });
 
-  it("matches required equipment items through the students' rental selections, not the program", () => {
-    expect(MASTER_DATA_CATEGORIES["required-equipment"].usage).toEqual({ kind: "rentalItem" });
-  });
-
-  it("scopes required equipment items to their program, and nothing else to a parent", () => {
-    const equipment: MasterDataCategory = MASTER_DATA_CATEGORIES["required-equipment"];
-    const classes: MasterDataCategory = MASTER_DATA_CATEGORIES.classes;
-
-    expect(equipment.parentField).toBe("programId");
-    expect(classes.parentField).toBeUndefined();
-  });
-
-  it("names the nested list a program owns, so deleting one can take it along", () => {
+  it("names the field a program keeps its required equipment in, and gives nothing else one", () => {
     const programs: MasterDataCategory = MASTER_DATA_CATEGORIES.programs;
     const classes: MasterDataCategory = MASTER_DATA_CATEGORIES.classes;
 
-    expect(programs.childKey).toBe("required-equipment");
-    expect(classes.childKey).toBeUndefined();
+    expect(programs.equipmentField).toBe("requiredEquipment");
+    expect(classes.equipmentField).toBeUndefined();
+  });
+
+  it("has no category of its own for required equipment, which is a field now", () => {
+    expect(Object.keys(MASTER_DATA_CATEGORIES)).not.toContain("required-equipment");
   });
 
   it("labels every category in German", () => {

--- a/src/lib/master-data/categories.test.ts
+++ b/src/lib/master-data/categories.test.ts
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { describe, expect, it } from "vitest";
+import { COLLECTIONS } from "@/lib/schemas/collections";
+import { MASTER_DATA_SECTIONS } from "@/lib/routes";
+import {
+  MASTER_DATA_CATEGORIES,
+  masterDataCategorySchema,
+  type MasterDataCategory,
+  type MasterDataCategoryKey,
+} from "./categories";
+
+describe("MASTER_DATA_CATEGORIES", () => {
+  it("covers every teacher-maintained section except seasons", () => {
+    const sectionKeys = MASTER_DATA_SECTIONS.map((section) => section.href.split("/").pop()).filter(
+      (key) => key !== "seasons",
+    );
+
+    expect(Object.keys(MASTER_DATA_CATEGORIES)).toEqual(expect.arrayContaining(sectionKeys));
+  });
+
+  it("points every category at a known collection", () => {
+    const known = new Set<string>(Object.values(COLLECTIONS));
+
+    for (const category of Object.values(MASTER_DATA_CATEGORIES)) {
+      expect(known).toContain(category.collection);
+    }
+  });
+
+  it("matches each category against the field student master data snapshots it into", () => {
+    expect(MASTER_DATA_CATEGORIES.classes.usage).toEqual({ kind: "masterData", field: "class" });
+    expect(MASTER_DATA_CATEGORIES.programs.usage).toEqual({ kind: "masterData", field: "program" });
+    expect(MASTER_DATA_CATEGORIES["skill-levels"].usage).toEqual({
+      kind: "masterData",
+      field: "skillLevel",
+    });
+    expect(MASTER_DATA_CATEGORIES["bus-pickup-points"].usage).toEqual({
+      kind: "masterData",
+      field: "busPickupPoint",
+    });
+    expect(MASTER_DATA_CATEGORIES["food-options"].usage).toEqual({
+      kind: "masterData",
+      field: "foodOption",
+    });
+    expect(MASTER_DATA_CATEGORIES["season-pass-options"].usage).toEqual({
+      kind: "masterData",
+      field: "seasonPassOption",
+    });
+  });
+
+  it("matches required equipment items through the students' rental selections, not the program", () => {
+    expect(MASTER_DATA_CATEGORIES["required-equipment"].usage).toEqual({ kind: "rentalItem" });
+  });
+
+  it("scopes required equipment items to their program, and nothing else to a parent", () => {
+    const equipment: MasterDataCategory = MASTER_DATA_CATEGORIES["required-equipment"];
+    const classes: MasterDataCategory = MASTER_DATA_CATEGORIES.classes;
+
+    expect(equipment.parentField).toBe("programId");
+    expect(classes.parentField).toBeUndefined();
+  });
+
+  it("names the nested list a program owns, so deleting one can take it along", () => {
+    const programs: MasterDataCategory = MASTER_DATA_CATEGORIES.programs;
+    const classes: MasterDataCategory = MASTER_DATA_CATEGORIES.classes;
+
+    expect(programs.childKey).toBe("required-equipment");
+    expect(classes.childKey).toBeUndefined();
+  });
+
+  it("labels every category in German", () => {
+    for (const category of Object.values(MASTER_DATA_CATEGORIES)) {
+      expect(category.labels.title).not.toBe("");
+      expect(category.labels.singular).not.toBe("");
+      expect(category.labels.add).toMatch(/^Neue/);
+    }
+  });
+});
+
+describe("masterDataCategorySchema", () => {
+  it("accepts every known key", () => {
+    for (const key of Object.keys(MASTER_DATA_CATEGORIES) as MasterDataCategoryKey[]) {
+      expect(masterDataCategorySchema.safeParse(key).success).toBe(true);
+    }
+  });
+
+  it("rejects an unknown key, so a URL segment cannot name a collection", () => {
+    expect(masterDataCategorySchema.safeParse("users").success).toBe(false);
+    expect(masterDataCategorySchema.safeParse("../users").success).toBe(false);
+  });
+});

--- a/src/lib/master-data/categories.ts
+++ b/src/lib/master-data/categories.ts
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { z } from "zod";
+import { COLLECTIONS } from "@/lib/schemas/collections";
+
+/**
+ * How an item is recognised as still in use (US-5 to US-10). Master data stores plain-text
+ * snapshots rather than references (US-11), so "in use" is a name match, not a join — and the
+ * field to match differs per category. Required equipment items are the odd one out: they are
+ * matched through the students' rental selections, not through the program they belong to.
+ */
+export type MasterDataUsage = { kind: "masterData"; field: string } | { kind: "rentalItem" };
+
+export type MasterDataCategory = {
+  collection: string;
+  usage: MasterDataUsage;
+  /** Set only for a nested list: the field on the item that names its owner. */
+  parentField?: string;
+  /** Set only for a category that owns a nested list, which a delete has to take with it. */
+  childKey?: string;
+  labels: {
+    title: string;
+    singular: string;
+    /** Carries the article, which German needs and a title plus a noun cannot supply. */
+    add: string;
+    /** Shown when the list is empty. */
+    empty: string;
+  };
+};
+
+/**
+ * The six teacher-maintained lists, keyed by the URL segment under /app/master-data. Seasons
+ * are not here: they carry active/archived state of their own and keep their dedicated view.
+ */
+export const MASTER_DATA_CATEGORIES = {
+  programs: {
+    collection: COLLECTIONS.programs,
+    usage: { kind: "masterData", field: "program" },
+    childKey: "required-equipment",
+    labels: {
+      title: "Programme",
+      singular: "Programm",
+      add: "Neues Programm",
+      empty: "Es gibt noch kein Programm.",
+    },
+  },
+  "required-equipment": {
+    collection: COLLECTIONS.requiredEquipmentItems,
+    usage: { kind: "rentalItem" },
+    parentField: "programId",
+    labels: {
+      title: "Benötigte Ausrüstung",
+      singular: "Ausrüstungsgegenstand",
+      add: "Neuer Ausrüstungsgegenstand",
+      empty: "Dieses Programm benötigt keine Ausrüstung.",
+    },
+  },
+  classes: {
+    collection: COLLECTIONS.classOptions,
+    usage: { kind: "masterData", field: "class" },
+    labels: {
+      title: "Klassen",
+      singular: "Klasse",
+      add: "Neue Klasse",
+      empty: "Es gibt noch keine Klasse.",
+    },
+  },
+  "skill-levels": {
+    collection: COLLECTIONS.skillLevels,
+    usage: { kind: "masterData", field: "skillLevel" },
+    labels: {
+      title: "Könnensstufen",
+      singular: "Könnensstufe",
+      add: "Neue Könnensstufe",
+      empty: "Es gibt noch keine Könnensstufe.",
+    },
+  },
+  "bus-pickup-points": {
+    collection: COLLECTIONS.busPickupPoints,
+    usage: { kind: "masterData", field: "busPickupPoint" },
+    labels: {
+      title: "Zustiegsstellen",
+      singular: "Zustiegsstelle",
+      add: "Neue Zustiegsstelle",
+      empty: "Es gibt noch keine Zustiegsstelle.",
+    },
+  },
+  "food-options": {
+    collection: COLLECTIONS.foodOptions,
+    usage: { kind: "masterData", field: "foodOption" },
+    labels: {
+      title: "Verpflegung",
+      singular: "Verpflegungsoption",
+      add: "Neue Verpflegungsoption",
+      empty: "Es gibt noch keine Verpflegungsoption.",
+    },
+  },
+  "season-pass-options": {
+    collection: COLLECTIONS.seasonPassOptions,
+    usage: { kind: "masterData", field: "seasonPassOption" },
+    labels: {
+      title: "Saisonkarten",
+      singular: "Saisonkarte",
+      add: "Neue Saisonkarte",
+      empty: "Es gibt noch keine Saisonkarte.",
+    },
+  },
+} as const satisfies Record<string, MasterDataCategory>;
+
+export type MasterDataCategoryKey = keyof typeof MASTER_DATA_CATEGORIES;
+
+/**
+ * Lives here rather than next to the server-side guard because the list view shows the same
+ * sentence on the controls it disables, and must not pull the Admin SDK in to do so.
+ */
+export const IN_USE_HINT =
+  "Dieser Eintrag wird in einer nicht archivierten Saison noch verwendet. " +
+  "Archiviere diese Saison, um ihn zu bearbeiten oder zu löschen.";
+
+/** Route segments arrive as untrusted strings, so a key is validated before it names a collection. */
+export const masterDataCategorySchema = z.enum(
+  Object.keys(MASTER_DATA_CATEGORIES) as [MasterDataCategoryKey, ...MasterDataCategoryKey[]],
+);
+
+export function categoryOf(key: MasterDataCategoryKey): MasterDataCategory {
+  return MASTER_DATA_CATEGORIES[key];
+}

--- a/src/lib/master-data/categories.ts
+++ b/src/lib/master-data/categories.ts
@@ -9,18 +9,18 @@ import { COLLECTIONS } from "@/lib/schemas/collections";
 /**
  * How an item is recognised as still in use (US-5 to US-10). Master data stores plain-text
  * snapshots rather than references (US-11), so "in use" is a name match, not a join — and the
- * field to match differs per category. Required equipment items are the odd one out: they are
- * matched through the students' rental selections, not through the program they belong to.
+ * field to match differs per category.
  */
-export type MasterDataUsage = { kind: "masterData"; field: string } | { kind: "rentalItem" };
+export type MasterDataUsage = { kind: "masterData"; field: string };
 
 export type MasterDataCategory = {
   collection: string;
   usage: MasterDataUsage;
-  /** Set only for a nested list: the field on the item that names its owner. */
-  parentField?: string;
-  /** Set only for a category that owns a nested list, which a delete has to take with it. */
-  childKey?: string;
+  /**
+   * Set only for a category whose items carry a list of their own. Its entries are matched
+   * against the students' rental selections, not against the field above (US-5).
+   */
+  equipmentField?: string;
   labels: {
     title: string;
     singular: string;
@@ -39,23 +39,12 @@ export const MASTER_DATA_CATEGORIES = {
   programs: {
     collection: COLLECTIONS.programs,
     usage: { kind: "masterData", field: "program" },
-    childKey: "required-equipment",
+    equipmentField: "requiredEquipment",
     labels: {
       title: "Programme",
       singular: "Programm",
       add: "Neues Programm",
       empty: "Es gibt noch kein Programm.",
-    },
-  },
-  "required-equipment": {
-    collection: COLLECTIONS.requiredEquipmentItems,
-    usage: { kind: "rentalItem" },
-    parentField: "programId",
-    labels: {
-      title: "Benötigte Ausrüstung",
-      singular: "Ausrüstungsgegenstand",
-      add: "Neuer Ausrüstungsgegenstand",
-      empty: "Dieses Programm benötigt keine Ausrüstung.",
     },
   },
   classes: {
@@ -119,6 +108,19 @@ export type MasterDataCategoryKey = keyof typeof MASTER_DATA_CATEGORIES;
 export const IN_USE_HINT =
   "Dieser Eintrag wird in einer nicht archivierten Saison noch verwendet. " +
   "Archiviere diese Saison, um ihn zu bearbeiten oder zu löschen.";
+
+/** Deleting a program takes its equipment with it, so a rented item holds the program back too. */
+export const CHILD_IN_USE_HINT =
+  "Ausrüstung dieses Programms wird in einer nicht archivierten Saison noch verwendet. " +
+  "Archiviere diese Saison, um das Programm zu löschen.";
+
+/** Labels for the equipment list a program carries, which is a field rather than a category. */
+export const EQUIPMENT_LABELS = {
+  title: "Benötigte Ausrüstung",
+  singular: "Ausrüstungsgegenstand",
+  add: "Neuer Ausrüstungsgegenstand",
+  empty: "Dieses Programm benötigt keine Ausrüstung.",
+} as const;
 
 /** Route segments arrive as untrusted strings, so a key is validated before it names a collection. */
 export const masterDataCategorySchema = z.enum(

--- a/src/lib/master-data/master-data-service.test.ts
+++ b/src/lib/master-data/master-data-service.test.ts
@@ -1,0 +1,268 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeFirestore } from "@/test/fake-firestore";
+
+const firestore = new FakeFirestore();
+
+vi.mock("@/lib/firebase/admin", () => ({
+  adminDb: firestore,
+}));
+
+const { createMasterDataItem, deleteMasterDataItem, updateMasterDataItem } =
+  await import("./master-data-service");
+const { ServiceError } = await import("@/lib/service-error");
+const { IN_USE_HINT } = await import("./categories");
+
+beforeEach(() => firestore.reset());
+
+/** Mirrors createMasterDataItem: the item plus the reservation that holds its name. */
+function seedItem(
+  collection: string,
+  id: string,
+  name: string,
+  extra: Record<string, unknown> = {},
+) {
+  firestore.seed(collection, id, { name, ...extra });
+  const scope = "programId" in extra ? `${collection}:${String(extra.programId)}` : collection;
+  firestore.seed("reservedNames", `${scope}|${name.trim().toLowerCase()}`, {
+    scope,
+    name,
+    ownerId: id,
+  });
+}
+
+function seedUsedIn(seasonId: string, isArchived: boolean, fields: Record<string, unknown>) {
+  firestore.seed("seasons", seasonId, {
+    name: `Saison ${seasonId}`,
+    isActive: false,
+    isArchived,
+    hasStudentData: true,
+  });
+  firestore.seed("studentMasterData", `r-${seasonId}`, {
+    userId: "u1",
+    seasonId,
+    class: "3AHIT",
+    ...fields,
+  });
+}
+
+describe("createMasterDataItem", () => {
+  it("stores the item under its category's collection", async () => {
+    const item = await createMasterDataItem("classes", { name: "3AHIT" });
+
+    expect(firestore.get("classOptions", item.id)).toEqual({ name: "3AHIT" });
+  });
+
+  it("trims the name", async () => {
+    const item = await createMasterDataItem("skill-levels", { name: "  Anfänger  " });
+
+    expect(item.name).toBe("Anfänger");
+  });
+
+  it("rejects a blank name without storing anything", async () => {
+    await expect(createMasterDataItem("classes", { name: "   " })).rejects.toBeInstanceOf(
+      ServiceError,
+    );
+    expect(firestore.count("classOptions")).toBe(0);
+  });
+
+  it("rejects a name already taken in the same category", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+
+    await expect(createMasterDataItem("classes", { name: " 3ahit " })).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+    expect(firestore.count("classOptions")).toBe(1);
+  });
+
+  it("allows the same name in a different category", async () => {
+    seedItem("classOptions", "c1", "Alternativ");
+
+    const program = await createMasterDataItem("programs", { name: "Alternativ" });
+
+    expect(firestore.get("programs", program.id)).toEqual({ name: "Alternativ" });
+  });
+});
+
+describe("createMasterDataItem — nested lists", () => {
+  beforeEach(() => {
+    seedItem("programs", "ski", "Ski");
+    seedItem("programs", "board", "Snowboard");
+  });
+
+  it("stores the parent id alongside the name", async () => {
+    const item = await createMasterDataItem("required-equipment", {
+      name: "Helm",
+      parentId: "ski",
+    });
+
+    expect(firestore.get("requiredEquipmentItems", item.id)).toEqual({
+      name: "Helm",
+      programId: "ski",
+    });
+  });
+
+  it("keeps names unique only within their program", async () => {
+    await createMasterDataItem("required-equipment", { name: "Helm", parentId: "ski" });
+
+    await expect(
+      createMasterDataItem("required-equipment", { name: "Helm", parentId: "board" }),
+    ).resolves.toMatchObject({ name: "Helm" });
+
+    await expect(
+      createMasterDataItem("required-equipment", { name: "helm", parentId: "ski" }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+  });
+
+  it("refuses to attach an item to a program that does not exist", async () => {
+    await expect(
+      createMasterDataItem("required-equipment", { name: "Helm", parentId: "ghost" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("refuses a nested item with no parent at all", async () => {
+    await expect(
+      createMasterDataItem("required-equipment", { name: "Helm" }),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("ignores a parent id on a flat category", async () => {
+    const item = await createMasterDataItem("classes", { name: "3AHIT", parentId: "ski" });
+
+    expect(firestore.get("classOptions", item.id)).toEqual({ name: "3AHIT" });
+  });
+});
+
+describe("updateMasterDataItem", () => {
+  it("renames an item and frees the old name", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+
+    await updateMasterDataItem("classes", "c1", { name: "3BHIT" });
+
+    expect(firestore.get("classOptions", "c1")).toMatchObject({ name: "3BHIT" });
+    expect(firestore.get("reservedNames", "classOptions|3ahit")).toBeUndefined();
+    expect(firestore.get("reservedNames", "classOptions|3bhit")).toMatchObject({ ownerId: "c1" });
+  });
+
+  it("lets an item keep its own name", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+
+    await expect(updateMasterDataItem("classes", "c1", { name: "3AHIT" })).resolves.toMatchObject({
+      name: "3AHIT",
+    });
+  });
+
+  it("rejects a rename onto a sibling's name", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+    seedItem("classOptions", "c2", "4BHIT");
+
+    await expect(updateMasterDataItem("classes", "c1", { name: "4bhit" })).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+    expect(firestore.get("classOptions", "c1")).toMatchObject({ name: "3AHIT" });
+  });
+
+  it("reports a missing item as not found", async () => {
+    await expect(updateMasterDataItem("classes", "ghost", { name: "X" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("blocks an item still selected in a non-archived season", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+    seedUsedIn("open", false, {});
+
+    await expect(updateMasterDataItem("classes", "c1", { name: "3BHIT" })).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: IN_USE_HINT,
+    });
+    expect(firestore.get("classOptions", "c1")).toMatchObject({ name: "3AHIT" });
+  });
+
+  it("allows an item selected only in archived seasons", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+    seedUsedIn("done", true, {});
+
+    await expect(updateMasterDataItem("classes", "c1", { name: "3BHIT" })).resolves.toMatchObject({
+      name: "3BHIT",
+    });
+  });
+
+  it("blocks a rented equipment item through the rental rows, not through its program", async () => {
+    seedItem("programs", "ski", "Ski");
+    seedItem("requiredEquipmentItems", "e1", "Helm", { programId: "ski" });
+    seedUsedIn("open", false, { program: "Ski" });
+    firestore.seed("equipmentRentalItems", "rent1", {
+      studentMasterDataId: "r-open",
+      itemName: "Helm",
+    });
+
+    await expect(
+      updateMasterDataItem("required-equipment", "e1", { name: "Skihelm" }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+  });
+
+  it("leaves an equipment item alone when only its program is in use", async () => {
+    seedItem("programs", "ski", "Ski");
+    seedItem("requiredEquipmentItems", "e1", "Helm", { programId: "ski" });
+    seedUsedIn("open", false, { program: "Ski" });
+
+    await expect(
+      updateMasterDataItem("required-equipment", "e1", { name: "Skihelm" }),
+    ).resolves.toMatchObject({ name: "Skihelm" });
+  });
+});
+
+describe("deleteMasterDataItem", () => {
+  it("removes the item and frees its name", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+
+    await deleteMasterDataItem("classes", "c1");
+
+    expect(firestore.count("classOptions")).toBe(0);
+    expect(firestore.get("reservedNames", "classOptions|3ahit")).toBeUndefined();
+  });
+
+  it("reports a missing item as not found", async () => {
+    await expect(deleteMasterDataItem("classes", "ghost")).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("blocks an item still selected in a non-archived season", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+    seedUsedIn("open", false, {});
+
+    await expect(deleteMasterDataItem("classes", "c1")).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: IN_USE_HINT,
+    });
+    expect(firestore.count("classOptions")).toBe(1);
+  });
+
+  it("takes a program's required equipment items down with it", async () => {
+    seedItem("programs", "ski", "Ski");
+    seedItem("requiredEquipmentItems", "e1", "Helm", { programId: "ski" });
+    seedItem("requiredEquipmentItems", "e2", "Stöcke", { programId: "ski" });
+    seedItem("requiredEquipmentItems", "e3", "Board", { programId: "board" });
+
+    await deleteMasterDataItem("programs", "ski");
+
+    expect(Object.keys(firestore.docs("requiredEquipmentItems"))).toEqual(["e3"]);
+    expect(firestore.get("reservedNames", "requiredEquipmentItems:ski|helm")).toBeUndefined();
+    expect(firestore.get("reservedNames", "requiredEquipmentItems:board|board")).toBeDefined();
+  });
+
+  it("leaves the snapshots already stored on master data records untouched", async () => {
+    seedItem("programs", "ski", "Ski");
+    seedUsedIn("done", true, { program: "Ski" });
+
+    await deleteMasterDataItem("programs", "ski");
+
+    expect(firestore.get("studentMasterData", "r-done")).toMatchObject({ program: "Ski" });
+  });
+});

--- a/src/lib/master-data/master-data-service.test.ts
+++ b/src/lib/master-data/master-data-service.test.ts
@@ -118,6 +118,18 @@ describe("createMasterDataItem — ordering", () => {
     expect(firestore.get("classOptions", item.id)).toMatchObject({ position: 2 });
   });
 
+  // A class list runs to hundreds of entries, and the position is one number.
+  it("counts the existing items rather than downloading them", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+    seedItem("classOptions", "c2", "4BHIT");
+    firestore.queryDocumentsRead = 0;
+
+    const item = await createMasterDataItem("classes", { name: "5CHIT" });
+
+    expect(firestore.get("classOptions", item.id)).toMatchObject({ position: 2 });
+    expect(firestore.queryDocumentsRead).toBe(0);
+  });
+
   it("counts only its own category", async () => {
     seedItem("classOptions", "c1", "3AHIT");
 

--- a/src/lib/master-data/master-data-service.test.ts
+++ b/src/lib/master-data/master-data-service.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/lib/firebase/admin", () => ({
   adminDb: firestore,
 }));
 
-const { createMasterDataItem, deleteMasterDataItem, updateMasterDataItem } =
+const { createMasterDataItem, deleteMasterDataItem, reorderMasterDataItems, updateMasterDataItem } =
   await import("./master-data-service");
 const { ServiceError } = await import("@/lib/service-error");
 const { IN_USE_HINT } = await import("./categories");
@@ -64,7 +64,7 @@ describe("createMasterDataItem", () => {
   it("stores the item under its category's collection", async () => {
     const item = await createMasterDataItem("classes", { name: "3AHIT" });
 
-    expect(firestore.get("classOptions", item.id)).toEqual({ name: "3AHIT" });
+    expect(firestore.get("classOptions", item.id)).toEqual({ name: "3AHIT", position: 0 });
   });
 
   it("trims the name", async () => {
@@ -96,8 +96,58 @@ describe("createMasterDataItem", () => {
 
     expect(firestore.get("programs", program.id)).toEqual({
       name: "Alternativ",
+      position: 0,
       requiredEquipment: [],
     });
+  });
+});
+
+describe("createMasterDataItem — ordering", () => {
+  it("puts the first item at the top", async () => {
+    const item = await createMasterDataItem("classes", { name: "3AHIT" });
+
+    expect(firestore.get("classOptions", item.id)).toMatchObject({ position: 0 });
+  });
+
+  it("appends a new item to the end of the list", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+    seedItem("classOptions", "c2", "4BHIT");
+
+    const item = await createMasterDataItem("classes", { name: "5CHIT" });
+
+    expect(firestore.get("classOptions", item.id)).toMatchObject({ position: 2 });
+  });
+
+  it("counts only its own category", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+
+    const item = await createMasterDataItem("skill-levels", { name: "Profi" });
+
+    expect(firestore.get("skillLevels", item.id)).toMatchObject({ position: 0 });
+  });
+});
+
+describe("reorderMasterDataItems", () => {
+  it("stores the order the teacher dropped the items into", async () => {
+    seedItem("classOptions", "a", "A", { position: 0 });
+    seedItem("classOptions", "b", "B", { position: 1 });
+
+    await reorderMasterDataItems("classes", ["b", "a"]);
+
+    expect(firestore.get("classOptions", "b")).toMatchObject({ position: 0 });
+    expect(firestore.get("classOptions", "a")).toMatchObject({ position: 1 });
+  });
+
+  it("reorders an item that is in use, since ordering changes no stored value", async () => {
+    seedItem("classOptions", "a", "3AHIT", { position: 0 });
+    seedItem("classOptions", "b", "4BHIT", { position: 1 });
+    seedUsedIn("open", false, {});
+
+    await expect(reorderMasterDataItems("classes", ["b", "a"])).resolves.toBeUndefined();
+  });
+
+  it("rejects an unknown category before it can name a collection", async () => {
+    await expect(reorderMasterDataItems("users" as "classes", ["a"])).rejects.toBeInstanceOf(Error);
   });
 });
 
@@ -110,6 +160,7 @@ describe("createMasterDataItem — required equipment", () => {
 
     expect(firestore.get("programs", program.id)).toEqual({
       name: "Ski",
+      position: 0,
       requiredEquipment: ["Ski", "Helm"],
     });
   });

--- a/src/lib/master-data/master-data-service.test.ts
+++ b/src/lib/master-data/master-data-service.test.ts
@@ -27,12 +27,15 @@ function seedItem(
   extra: Record<string, unknown> = {},
 ) {
   firestore.seed(collection, id, { name, ...extra });
-  const scope = "programId" in extra ? `${collection}:${String(extra.programId)}` : collection;
-  firestore.seed("reservedNames", `${scope}|${name.trim().toLowerCase()}`, {
-    scope,
+  firestore.seed("reservedNames", `${collection}|${name.trim().toLowerCase()}`, {
+    scope: collection,
     name,
     ownerId: id,
   });
+}
+
+function seedProgram(id: string, name: string, requiredEquipment: string[] = []) {
+  seedItem("programs", id, name, { requiredEquipment });
 }
 
 function seedUsedIn(seasonId: string, isArchived: boolean, fields: Record<string, unknown>) {
@@ -47,6 +50,13 @@ function seedUsedIn(seasonId: string, isArchived: boolean, fields: Record<string
     seasonId,
     class: "3AHIT",
     ...fields,
+  });
+}
+
+function seedRental(seasonId: string, itemName: string) {
+  firestore.seed("equipmentRentalItems", `rent-${itemName}`, {
+    studentMasterDataId: `r-${seasonId}`,
+    itemName,
   });
 }
 
@@ -84,56 +94,63 @@ describe("createMasterDataItem", () => {
 
     const program = await createMasterDataItem("programs", { name: "Alternativ" });
 
-    expect(firestore.get("programs", program.id)).toEqual({ name: "Alternativ" });
+    expect(firestore.get("programs", program.id)).toEqual({
+      name: "Alternativ",
+      requiredEquipment: [],
+    });
   });
 });
 
-describe("createMasterDataItem — nested lists", () => {
-  beforeEach(() => {
-    seedItem("programs", "ski", "Ski");
-    seedItem("programs", "board", "Snowboard");
-  });
-
-  it("stores the parent id alongside the name", async () => {
-    const item = await createMasterDataItem("required-equipment", {
-      name: "Helm",
-      parentId: "ski",
+describe("createMasterDataItem — required equipment", () => {
+  it("stores the equipment list on the program itself", async () => {
+    const program = await createMasterDataItem("programs", {
+      name: "Ski",
+      requiredEquipment: ["Ski", "Helm"],
     });
 
-    expect(firestore.get("requiredEquipmentItems", item.id)).toEqual({
-      name: "Helm",
-      programId: "ski",
+    expect(firestore.get("programs", program.id)).toEqual({
+      name: "Ski",
+      requiredEquipment: ["Ski", "Helm"],
     });
   });
 
-  it("keeps names unique only within their program", async () => {
-    await createMasterDataItem("required-equipment", { name: "Helm", parentId: "ski" });
+  it("gives a program with no equipment an empty list rather than no field", async () => {
+    const program = await createMasterDataItem("programs", { name: "Alternativ" });
 
-    await expect(
-      createMasterDataItem("required-equipment", { name: "Helm", parentId: "board" }),
-    ).resolves.toMatchObject({ name: "Helm" });
-
-    await expect(
-      createMasterDataItem("required-equipment", { name: "helm", parentId: "ski" }),
-    ).rejects.toMatchObject({ code: "CONFLICT" });
+    expect(program.requiredEquipment).toEqual([]);
   });
 
-  it("refuses to attach an item to a program that does not exist", async () => {
+  it("rejects a duplicate entry within one program, ignoring case and surrounding space", async () => {
     await expect(
-      createMasterDataItem("required-equipment", { name: "Helm", parentId: "ghost" }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+      createMasterDataItem("programs", { name: "Ski", requiredEquipment: ["Helm", " helm "] }),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    expect(firestore.count("programs")).toBe(0);
   });
 
-  it("refuses a nested item with no parent at all", async () => {
+  it("lets two programs each require the same item", async () => {
+    await createMasterDataItem("programs", { name: "Ski", requiredEquipment: ["Helm"] });
+
     await expect(
-      createMasterDataItem("required-equipment", { name: "Helm" }),
+      createMasterDataItem("programs", { name: "Snowboard", requiredEquipment: ["Helm"] }),
+    ).resolves.toMatchObject({ requiredEquipment: ["Helm"] });
+  });
+
+  it("rejects a blank entry", async () => {
+    await expect(
+      createMasterDataItem("programs", { name: "Ski", requiredEquipment: ["  "] }),
     ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
   });
 
-  it("ignores a parent id on a flat category", async () => {
-    const item = await createMasterDataItem("classes", { name: "3AHIT", parentId: "ski" });
+  it("refuses an equipment list on a category that has none", async () => {
+    await expect(
+      createMasterDataItem("classes", { name: "3AHIT", requiredEquipment: ["Helm"] }),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
 
-    expect(firestore.get("classOptions", item.id)).toEqual({ name: "3AHIT" });
+  it("claims no reservation for an entry, since one document holds every sibling", async () => {
+    await createMasterDataItem("programs", { name: "Ski", requiredEquipment: ["Helm"] });
+
+    expect(Object.keys(firestore.docs("reservedNames"))).toEqual(["programs|ski"]);
   });
 });
 
@@ -191,29 +208,93 @@ describe("updateMasterDataItem", () => {
       name: "3BHIT",
     });
   });
+});
 
-  it("blocks a rented equipment item through the rental rows, not through its program", async () => {
-    seedItem("programs", "ski", "Ski");
-    seedItem("requiredEquipmentItems", "e1", "Helm", { programId: "ski" });
-    seedUsedIn("open", false, { program: "Ski" });
-    firestore.seed("equipmentRentalItems", "rent1", {
-      studentMasterDataId: "r-open",
-      itemName: "Helm",
+describe("updateMasterDataItem — required equipment", () => {
+  it("rewrites the whole list in one step", async () => {
+    seedProgram("ski", "Ski", ["Helm"]);
+
+    await updateMasterDataItem("programs", "ski", { requiredEquipment: ["Helm", "Stöcke"] });
+
+    expect(firestore.get("programs", "ski")).toMatchObject({
+      requiredEquipment: ["Helm", "Stöcke"],
     });
+  });
+
+  it("leaves the program name alone when only the equipment changes", async () => {
+    seedProgram("ski", "Ski", []);
+
+    await updateMasterDataItem("programs", "ski", { requiredEquipment: ["Helm"] });
+
+    expect(firestore.get("programs", "ski")).toMatchObject({ name: "Ski" });
+  });
+
+  it("adds an entry even while the program itself is in use", async () => {
+    seedProgram("ski", "Ski", ["Helm"]);
+    seedUsedIn("open", false, { program: "Ski" });
 
     await expect(
-      updateMasterDataItem("required-equipment", "e1", { name: "Skihelm" }),
+      updateMasterDataItem("programs", "ski", { requiredEquipment: ["Helm", "Stöcke"] }),
+    ).resolves.toMatchObject({ requiredEquipment: ["Helm", "Stöcke"] });
+  });
+
+  it("refuses to remove an entry a student of an open season still rents", async () => {
+    seedProgram("ski", "Ski", ["Helm", "Stöcke"]);
+    seedUsedIn("open", false, { program: "Snowboard" });
+    seedRental("open", "Helm");
+
+    await expect(
+      updateMasterDataItem("programs", "ski", { requiredEquipment: ["Stöcke"] }),
+    ).rejects.toMatchObject({ code: "CONFLICT", message: IN_USE_HINT });
+    expect(firestore.get("programs", "ski")).toMatchObject({
+      requiredEquipment: ["Helm", "Stöcke"],
+    });
+  });
+
+  it("refuses to rename an entry a student of an open season still rents", async () => {
+    seedProgram("ski", "Ski", ["Helm"]);
+    seedUsedIn("open", false, { program: "Ski" });
+    seedRental("open", "Helm");
+
+    await expect(
+      updateMasterDataItem("programs", "ski", { requiredEquipment: ["Skihelm"] }),
     ).rejects.toMatchObject({ code: "CONFLICT" });
   });
 
-  it("leaves an equipment item alone when only its program is in use", async () => {
-    seedItem("programs", "ski", "Ski");
-    seedItem("requiredEquipmentItems", "e1", "Helm", { programId: "ski" });
+  it("treats a case-only change as keeping the entry", async () => {
+    seedProgram("ski", "Ski", ["Helm"]);
     seedUsedIn("open", false, { program: "Ski" });
+    seedRental("open", "Helm");
 
     await expect(
-      updateMasterDataItem("required-equipment", "e1", { name: "Skihelm" }),
-    ).resolves.toMatchObject({ name: "Skihelm" });
+      updateMasterDataItem("programs", "ski", { requiredEquipment: ["HELM"] }),
+    ).resolves.toMatchObject({ requiredEquipment: ["HELM"] });
+  });
+
+  it("removes an entry rented only in archived seasons", async () => {
+    seedProgram("ski", "Ski", ["Helm"]);
+    seedUsedIn("done", true, { program: "Ski" });
+    seedRental("done", "Helm");
+
+    await expect(
+      updateMasterDataItem("programs", "ski", { requiredEquipment: [] }),
+    ).resolves.toMatchObject({ requiredEquipment: [] });
+  });
+
+  it("rejects a duplicate entry", async () => {
+    seedProgram("ski", "Ski", []);
+
+    await expect(
+      updateMasterDataItem("programs", "ski", { requiredEquipment: ["Helm", "helm"] }),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("refuses an equipment list on a category that has none", async () => {
+    seedItem("classOptions", "c1", "3AHIT");
+
+    await expect(
+      updateMasterDataItem("classes", "c1", { requiredEquipment: ["Helm"] }),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
   });
 });
 
@@ -244,21 +325,49 @@ describe("deleteMasterDataItem", () => {
     expect(firestore.count("classOptions")).toBe(1);
   });
 
-  it("takes a program's required equipment items down with it", async () => {
-    seedItem("programs", "ski", "Ski");
-    seedItem("requiredEquipmentItems", "e1", "Helm", { programId: "ski" });
-    seedItem("requiredEquipmentItems", "e2", "Stöcke", { programId: "ski" });
-    seedItem("requiredEquipmentItems", "e3", "Board", { programId: "board" });
+  it("takes a program's equipment list down with it", async () => {
+    seedProgram("ski", "Ski", ["Helm", "Stöcke"]);
 
     await deleteMasterDataItem("programs", "ski");
 
-    expect(Object.keys(firestore.docs("requiredEquipmentItems"))).toEqual(["e3"]);
-    expect(firestore.get("reservedNames", "requiredEquipmentItems:ski|helm")).toBeUndefined();
-    expect(firestore.get("reservedNames", "requiredEquipmentItems:board|board")).toBeDefined();
+    expect(firestore.count("programs")).toBe(0);
+  });
+
+  it("refuses to delete a program whose equipment a student of an open season still rents", async () => {
+    seedProgram("ski", "Ski", ["Helm"]);
+    seedUsedIn("open", false, { program: "Snowboard" });
+    seedRental("open", "Helm");
+
+    await expect(deleteMasterDataItem("programs", "ski")).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: IN_USE_HINT,
+    });
+    expect(firestore.count("programs")).toBe(1);
+  });
+
+  it("deletes a program whose equipment is only rented in archived seasons", async () => {
+    seedProgram("ski", "Ski", ["Helm"]);
+    seedUsedIn("done", true, { program: "Ski" });
+    seedRental("done", "Helm");
+
+    await deleteMasterDataItem("programs", "ski");
+
+    expect(firestore.count("programs")).toBe(0);
+  });
+
+  it("ignores rented equipment another program requires", async () => {
+    seedProgram("ski", "Ski", ["Stöcke"]);
+    seedProgram("board", "Snowboard", ["Helm"]);
+    seedUsedIn("open", false, { program: "Snowboard" });
+    seedRental("open", "Helm");
+
+    await deleteMasterDataItem("programs", "ski");
+
+    expect(Object.keys(firestore.docs("programs"))).toEqual(["board"]);
   });
 
   it("leaves the snapshots already stored on master data records untouched", async () => {
-    seedItem("programs", "ski", "Ski");
+    seedProgram("ski", "Ski", []);
     seedUsedIn("done", true, { program: "Ski" });
 
     await deleteMasterDataItem("programs", "ski");

--- a/src/lib/master-data/master-data-service.ts
+++ b/src/lib/master-data/master-data-service.ts
@@ -5,7 +5,6 @@
  */
 import "server-only";
 import { adminDb } from "@/lib/firebase/admin";
-import { commitInChunks, type BatchOperation } from "@/lib/firebase/batch";
 import {
   normalizeName,
   releaseName,
@@ -15,18 +14,18 @@ import {
 } from "@/lib/firebase/unique-name";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
-import { namedListItemSchema } from "@/lib/schemas/master-data";
+import { namedListItemSchema, requiredEquipmentSchema } from "@/lib/schemas/master-data";
 import {
   categoryOf,
   masterDataCategorySchema,
   type MasterDataCategory,
   type MasterDataCategoryKey,
 } from "./categories";
-import { assertNotInUse } from "./usage-guard";
+import { assertEquipmentNotInUse, assertNotInUse } from "./usage-guard";
 
 const nameSchema = namedListItemSchema.shape.name;
 
-export type MasterDataItem = { id: string; name: string; parentId: string | null };
+export type MasterDataItem = { id: string; name: string; requiredEquipment?: string[] };
 
 function parseName(value: string): string {
   const parsed = nameSchema.safeParse(value);
@@ -39,15 +38,37 @@ function parseName(value: string): string {
   return parsed.data;
 }
 
+/**
+ * Uniqueness within the program needs no reservation: the whole list lives in one document, so
+ * the transaction that writes it already sees every sibling (US-5).
+ */
+function parseEquipment(category: MasterDataCategory, value: readonly string[]): string[] {
+  if (category.equipmentField === undefined) {
+    throw new ServiceError(
+      ErrorCode.ValidationError,
+      "Diese Kategorie führt keine Ausrüstungsliste.",
+    );
+  }
+
+  const parsed = requiredEquipmentSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new ServiceError(
+      ErrorCode.ValidationError,
+      parsed.error.issues[0]?.message ?? "Ungültige Ausrüstungsliste.",
+    );
+  }
+  return parsed.data;
+}
+
 function itemDoc(category: MasterDataCategory, id: string) {
   return adminDb.collection(category.collection).doc(id);
 }
 
-/** Flat lists are unique category-wide; a nested list only within its own parent (US-5). */
-function scopeFor(category: MasterDataCategory, parentId: string | null): string {
-  return category.parentField === undefined
-    ? scopeOf(category.collection)
-    : scopeOf(category.collection, parentId ?? "");
+function equipmentOf(category: MasterDataCategory, data: Record<string, unknown> | undefined) {
+  if (category.equipmentField === undefined) return undefined;
+
+  const stored = data?.[category.equipmentField];
+  return Array.isArray(stored) ? stored.filter((entry) => typeof entry === "string") : [];
 }
 
 function itemFrom(
@@ -60,9 +81,10 @@ function itemFrom(
     throw new ServiceError(ErrorCode.InternalError, "Dieser Eintrag ist beschädigt.");
   }
 
-  const parentId =
-    category.parentField === undefined ? null : String(data?.[category.parentField] ?? "");
-  return { id, name: parsed.data.name, parentId: parentId === "" ? null : parentId };
+  const requiredEquipment = equipmentOf(category, data);
+  return requiredEquipment === undefined
+    ? { id, name: parsed.data.name }
+    : { id, name: parsed.data.name, requiredEquipment };
 }
 
 async function readItem(category: MasterDataCategory, id: string): Promise<MasterDataItem> {
@@ -73,68 +95,75 @@ async function readItem(category: MasterDataCategory, id: string): Promise<Maste
   return itemFrom(category, id, snapshot.data());
 }
 
-async function requireParent(category: MasterDataCategory, parentId: string | undefined) {
-  if (category.parentField === undefined) return null;
-
-  if (!parentId) {
-    throw new ServiceError(ErrorCode.ValidationError, "Es fehlt der übergeordnete Eintrag.");
-  }
-
-  // The only parent a nested list currently has is a program (US-5).
-  const parent = await adminDb.collection(categoryOf("programs").collection).doc(parentId).get();
-  if (!parent.exists) {
-    throw new ServiceError(ErrorCode.NotFound, "Diesen übergeordneten Eintrag gibt es nicht.");
-  }
-  return parentId;
-}
-
 export async function createMasterDataItem(
   key: MasterDataCategoryKey,
-  input: { name: string; parentId?: string },
+  input: { name: string; requiredEquipment?: readonly string[] },
 ): Promise<MasterDataItem> {
   const category = categoryOf(masterDataCategorySchema.parse(key));
   const name = parseName(input.name);
-  const parentId = await requireParent(category, input.parentId);
+  const equipment =
+    category.equipmentField === undefined && input.requiredEquipment === undefined
+      ? undefined
+      : parseEquipment(category, input.requiredEquipment ?? []);
 
   // The reservation is what makes the name unique; it shares the transaction with the record,
   // so a rejected name leaves nothing behind (US-5 to US-10).
   return adminDb.runTransaction(async (transaction) => {
     const reference = adminDb.collection(category.collection).doc();
     await reserveName(transaction, {
-      scope: scopeFor(category, parentId),
+      scope: scopeOf(category.collection),
       name,
       ownerId: reference.id,
     });
 
     const data =
-      category.parentField === undefined
+      category.equipmentField === undefined
         ? { name }
-        : { name, [category.parentField]: parentId as string };
+        : { name, [category.equipmentField]: equipment as string[] };
     transaction.set(reference, data);
 
-    return { id: reference.id, name, parentId };
+    return itemFrom(category, reference.id, data);
   });
 }
+
+export type MasterDataUpdate = { name?: string; requiredEquipment?: readonly string[] };
 
 /**
  * Renaming is gated by the in-use guard: master data records keep a plain-text snapshot of the
  * value they selected (US-11), so a rename would silently orphan every record still pointing at
  * the old text. Archiving the season is what releases the item again (US-5 to US-10).
  *
- * The guard runs ahead of the transaction rather than inside it. It has to scan the master data
- * of every open season, and a transactional query locks the index range it scans — which is what
+ * The equipment list is held to the same rule, one entry at a time: adding is always fine, but
+ * an entry that disappears — removed outright or renamed away — must not be one a student of an
+ * open season still rents. The list is rewritten whole, so the check is a set difference.
+ *
+ * Both guards run ahead of the transaction rather than inside it. They scan the master data of
+ * every open season, and a transactional query locks the index range it scans — which is what
  * made an earlier sibling-query approach to unique names collapse under concurrency.
  */
 export async function updateMasterDataItem(
   key: MasterDataCategoryKey,
   id: string,
-  update: { name: string },
+  update: MasterDataUpdate,
 ): Promise<MasterDataItem> {
   const category = categoryOf(masterDataCategorySchema.parse(key));
-  const name = parseName(update.name);
+  const name = update.name === undefined ? undefined : parseName(update.name);
+  const equipment =
+    update.requiredEquipment === undefined
+      ? undefined
+      : parseEquipment(category, update.requiredEquipment);
 
   const current = await readItem(category, id);
-  await assertNotInUse(category, current.name);
+
+  if (name !== undefined) await assertNotInUse(category, current.name);
+
+  if (equipment !== undefined) {
+    const kept = new Set(equipment.map(normalizeName));
+    const dropped = (current.requiredEquipment ?? []).filter(
+      (entry) => !kept.has(normalizeName(entry)),
+    );
+    await assertEquipmentNotInUse(dropped);
+  }
 
   return adminDb.runTransaction(async (transaction) => {
     const reference = itemDoc(category, id);
@@ -144,52 +173,44 @@ export async function updateMasterDataItem(
     }
 
     const stored = itemFrom(category, id, snapshot.data());
-    const scope = scopeFor(category, stored.parentId);
+    const scope = scopeOf(category.collection);
 
-    // Re-claiming its own name is how a case-only change stays legal: both spellings share one
-    // reservation document, so releasing the old one would drop the claim entirely.
-    await reserveName(transaction, { scope, name, ownerId: id });
-    if (normalizeName(name) !== normalizeName(stored.name)) {
-      releaseName(transaction, { scope, name: stored.name });
+    if (name !== undefined) {
+      // Re-claiming its own name is how a case-only change stays legal: both spellings share one
+      // reservation document, so releasing the old one would drop the claim entirely.
+      await reserveName(transaction, { scope, name, ownerId: id });
+      if (normalizeName(name) !== normalizeName(stored.name)) {
+        releaseName(transaction, { scope, name: stored.name });
+      }
     }
 
-    transaction.update(reference, { name });
-    return { ...stored, name };
+    const next = {
+      ...(name === undefined ? {} : { name }),
+      ...(equipment === undefined ? {} : { [category.equipmentField as string]: equipment }),
+    };
+    transaction.update(reference, next);
+
+    return { ...stored, ...next } as MasterDataItem;
   });
 }
 
 /**
- * Firestore has no cascading delete, so a program's required equipment goes first and the
- * program itself last: a run that fails midway leaves the program in place, so calling this
- * again finishes the job. Master data records keep their snapshots either way (US-11).
+ * A program's required equipment goes with it, since the list lives on the program itself — so
+ * the same restriction applies: an entry a student of an open season still rents cannot be
+ * removed on its own, and deleting the program must not be a way around that. Master data
+ * records keep their snapshots either way (US-11).
  */
 export async function deleteMasterDataItem(key: MasterDataCategoryKey, id: string): Promise<void> {
   const category = categoryOf(masterDataCategorySchema.parse(key));
 
   const item = await readItem(category, id);
   await assertNotInUse(category, item.name);
+  await assertEquipmentNotInUse(item.requiredEquipment ?? []);
 
-  const doomed = [reservationRef(scopeFor(category, item.parentId), item.name)];
-
-  if (category.childKey !== undefined) {
-    const child = categoryOf(category.childKey as MasterDataCategoryKey);
-    const children = await adminDb
-      .collection(child.collection)
-      .where(child.parentField as string, "==", id)
-      .get();
-
-    for (const document of children.docs) {
-      doomed.push(document.ref);
-      const childName = document.data()?.name;
-      // Frees the name as well, otherwise it stays claimed by a record that no longer exists.
-      if (typeof childName === "string") {
-        doomed.push(reservationRef(scopeOf(child.collection, id), childName));
-      }
-    }
-  }
-
-  const operations: BatchOperation[] = doomed.map((target) => (batch) => batch.delete(target));
-  await commitInChunks(operations);
-
-  await itemDoc(category, id).delete();
+  // Frees the name for reuse; otherwise a deleted item would keep blocking it.
+  await adminDb
+    .batch()
+    .delete(reservationRef(scopeOf(category.collection), item.name))
+    .delete(itemDoc(category, id))
+    .commit();
 }

--- a/src/lib/master-data/master-data-service.ts
+++ b/src/lib/master-data/master-data-service.ts
@@ -110,7 +110,7 @@ export async function createMasterDataItem(
   // A new item goes to the end of the teacher's order (see Ordering). Read outside the
   // transaction: two simultaneous creates would tie, which the name tiebreak absorbs and the
   // next reorder renumbers away.
-  const position = (await adminDb.collection(category.collection).get()).size;
+  const position = (await adminDb.collection(category.collection).count().get()).data().count;
 
   // The reservation is what makes the name unique; it shares the transaction with the record,
   // so a rejected name leaves nothing behind (US-5 to US-10).

--- a/src/lib/master-data/master-data-service.ts
+++ b/src/lib/master-data/master-data-service.ts
@@ -5,6 +5,7 @@
  */
 import "server-only";
 import { adminDb } from "@/lib/firebase/admin";
+import { reorderCollection } from "@/lib/firebase/reorder";
 import {
   normalizeName,
   releaseName,
@@ -106,6 +107,11 @@ export async function createMasterDataItem(
       ? undefined
       : parseEquipment(category, input.requiredEquipment ?? []);
 
+  // A new item goes to the end of the teacher's order (see Ordering). Read outside the
+  // transaction: two simultaneous creates would tie, which the name tiebreak absorbs and the
+  // next reorder renumbers away.
+  const position = (await adminDb.collection(category.collection).get()).size;
+
   // The reservation is what makes the name unique; it shares the transaction with the record,
   // so a rejected name leaves nothing behind (US-5 to US-10).
   return adminDb.runTransaction(async (transaction) => {
@@ -118,12 +124,22 @@ export async function createMasterDataItem(
 
     const data =
       category.equipmentField === undefined
-        ? { name }
-        : { name, [category.equipmentField]: equipment as string[] };
+        ? { name, position }
+        : { name, position, [category.equipmentField]: equipment as string[] };
     transaction.set(reference, data);
 
     return itemFrom(category, reference.id, data);
   });
+}
+
+/** Ordering touches no name, so it is deliberately not subject to the in-use guard (see Ordering). */
+export async function reorderMasterDataItems(
+  key: MasterDataCategoryKey,
+  orderedIds: readonly string[],
+): Promise<void> {
+  const category = categoryOf(masterDataCategorySchema.parse(key));
+
+  await reorderCollection({ collection: category.collection, orderedIds });
 }
 
 export type MasterDataUpdate = { name?: string; requiredEquipment?: readonly string[] };

--- a/src/lib/master-data/master-data-service.ts
+++ b/src/lib/master-data/master-data-service.ts
@@ -1,0 +1,195 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import "server-only";
+import { adminDb } from "@/lib/firebase/admin";
+import { commitInChunks, type BatchOperation } from "@/lib/firebase/batch";
+import {
+  normalizeName,
+  releaseName,
+  reservationRef,
+  reserveName,
+  scopeOf,
+} from "@/lib/firebase/unique-name";
+import { ErrorCode } from "@/lib/errors";
+import { ServiceError } from "@/lib/service-error";
+import { namedListItemSchema } from "@/lib/schemas/master-data";
+import {
+  categoryOf,
+  masterDataCategorySchema,
+  type MasterDataCategory,
+  type MasterDataCategoryKey,
+} from "./categories";
+import { assertNotInUse } from "./usage-guard";
+
+const nameSchema = namedListItemSchema.shape.name;
+
+export type MasterDataItem = { id: string; name: string; parentId: string | null };
+
+function parseName(value: string): string {
+  const parsed = nameSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new ServiceError(
+      ErrorCode.ValidationError,
+      parsed.error.issues[0]?.message ?? "Ungültiger Name.",
+    );
+  }
+  return parsed.data;
+}
+
+function itemDoc(category: MasterDataCategory, id: string) {
+  return adminDb.collection(category.collection).doc(id);
+}
+
+/** Flat lists are unique category-wide; a nested list only within its own parent (US-5). */
+function scopeFor(category: MasterDataCategory, parentId: string | null): string {
+  return category.parentField === undefined
+    ? scopeOf(category.collection)
+    : scopeOf(category.collection, parentId ?? "");
+}
+
+function itemFrom(
+  category: MasterDataCategory,
+  id: string,
+  data: Record<string, unknown> | undefined,
+): MasterDataItem {
+  const parsed = namedListItemSchema.safeParse({ id, ...data });
+  if (!parsed.success) {
+    throw new ServiceError(ErrorCode.InternalError, "Dieser Eintrag ist beschädigt.");
+  }
+
+  const parentId =
+    category.parentField === undefined ? null : String(data?.[category.parentField] ?? "");
+  return { id, name: parsed.data.name, parentId: parentId === "" ? null : parentId };
+}
+
+async function readItem(category: MasterDataCategory, id: string): Promise<MasterDataItem> {
+  const snapshot = await itemDoc(category, id).get();
+  if (!snapshot.exists) {
+    throw new ServiceError(ErrorCode.NotFound, "Diesen Eintrag gibt es nicht.");
+  }
+  return itemFrom(category, id, snapshot.data());
+}
+
+async function requireParent(category: MasterDataCategory, parentId: string | undefined) {
+  if (category.parentField === undefined) return null;
+
+  if (!parentId) {
+    throw new ServiceError(ErrorCode.ValidationError, "Es fehlt der übergeordnete Eintrag.");
+  }
+
+  // The only parent a nested list currently has is a program (US-5).
+  const parent = await adminDb.collection(categoryOf("programs").collection).doc(parentId).get();
+  if (!parent.exists) {
+    throw new ServiceError(ErrorCode.NotFound, "Diesen übergeordneten Eintrag gibt es nicht.");
+  }
+  return parentId;
+}
+
+export async function createMasterDataItem(
+  key: MasterDataCategoryKey,
+  input: { name: string; parentId?: string },
+): Promise<MasterDataItem> {
+  const category = categoryOf(masterDataCategorySchema.parse(key));
+  const name = parseName(input.name);
+  const parentId = await requireParent(category, input.parentId);
+
+  // The reservation is what makes the name unique; it shares the transaction with the record,
+  // so a rejected name leaves nothing behind (US-5 to US-10).
+  return adminDb.runTransaction(async (transaction) => {
+    const reference = adminDb.collection(category.collection).doc();
+    await reserveName(transaction, {
+      scope: scopeFor(category, parentId),
+      name,
+      ownerId: reference.id,
+    });
+
+    const data =
+      category.parentField === undefined
+        ? { name }
+        : { name, [category.parentField]: parentId as string };
+    transaction.set(reference, data);
+
+    return { id: reference.id, name, parentId };
+  });
+}
+
+/**
+ * Renaming is gated by the in-use guard: master data records keep a plain-text snapshot of the
+ * value they selected (US-11), so a rename would silently orphan every record still pointing at
+ * the old text. Archiving the season is what releases the item again (US-5 to US-10).
+ *
+ * The guard runs ahead of the transaction rather than inside it. It has to scan the master data
+ * of every open season, and a transactional query locks the index range it scans — which is what
+ * made an earlier sibling-query approach to unique names collapse under concurrency.
+ */
+export async function updateMasterDataItem(
+  key: MasterDataCategoryKey,
+  id: string,
+  update: { name: string },
+): Promise<MasterDataItem> {
+  const category = categoryOf(masterDataCategorySchema.parse(key));
+  const name = parseName(update.name);
+
+  const current = await readItem(category, id);
+  await assertNotInUse(category, current.name);
+
+  return adminDb.runTransaction(async (transaction) => {
+    const reference = itemDoc(category, id);
+    const snapshot = await transaction.get(reference);
+    if (!snapshot.exists) {
+      throw new ServiceError(ErrorCode.NotFound, "Diesen Eintrag gibt es nicht.");
+    }
+
+    const stored = itemFrom(category, id, snapshot.data());
+    const scope = scopeFor(category, stored.parentId);
+
+    // Re-claiming its own name is how a case-only change stays legal: both spellings share one
+    // reservation document, so releasing the old one would drop the claim entirely.
+    await reserveName(transaction, { scope, name, ownerId: id });
+    if (normalizeName(name) !== normalizeName(stored.name)) {
+      releaseName(transaction, { scope, name: stored.name });
+    }
+
+    transaction.update(reference, { name });
+    return { ...stored, name };
+  });
+}
+
+/**
+ * Firestore has no cascading delete, so a program's required equipment goes first and the
+ * program itself last: a run that fails midway leaves the program in place, so calling this
+ * again finishes the job. Master data records keep their snapshots either way (US-11).
+ */
+export async function deleteMasterDataItem(key: MasterDataCategoryKey, id: string): Promise<void> {
+  const category = categoryOf(masterDataCategorySchema.parse(key));
+
+  const item = await readItem(category, id);
+  await assertNotInUse(category, item.name);
+
+  const doomed = [reservationRef(scopeFor(category, item.parentId), item.name)];
+
+  if (category.childKey !== undefined) {
+    const child = categoryOf(category.childKey as MasterDataCategoryKey);
+    const children = await adminDb
+      .collection(child.collection)
+      .where(child.parentField as string, "==", id)
+      .get();
+
+    for (const document of children.docs) {
+      doomed.push(document.ref);
+      const childName = document.data()?.name;
+      // Frees the name as well, otherwise it stays claimed by a record that no longer exists.
+      if (typeof childName === "string") {
+        doomed.push(reservationRef(scopeOf(child.collection, id), childName));
+      }
+    }
+  }
+
+  const operations: BatchOperation[] = doomed.map((target) => (batch) => batch.delete(target));
+  await commitInChunks(operations);
+
+  await itemDoc(category, id).delete();
+}

--- a/src/lib/master-data/seed-defaults.test.ts
+++ b/src/lib/master-data/seed-defaults.test.ts
@@ -49,7 +49,12 @@ describe("seedMasterDataDefaults", () => {
   it("stores the defaults with their German display text", async () => {
     await seedMasterDataDefaults();
 
-    expect(namesOf("skillLevels")).toEqual(["Anfänger", "Beginner", "Fortgeschritten", "Profi"]);
+    expect(namesOf("skillLevels")).toEqual([
+      "Absoluter Anfänger",
+      "Anfänger",
+      "Fortgeschritten",
+      "Profi",
+    ]);
     expect(namesOf("busPickupPoints")).toEqual([
       "Bahnhof Bregenz",
       "Bahnhof Feldkirch",

--- a/src/lib/master-data/seed-defaults.test.ts
+++ b/src/lib/master-data/seed-defaults.test.ts
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeFirestore } from "@/test/fake-firestore";
+
+const firestore = new FakeFirestore();
+
+vi.mock("@/lib/firebase/admin", () => ({
+  adminDb: firestore,
+}));
+
+const { seedMasterDataDefaults } = await import("./seed-defaults");
+
+beforeEach(() => firestore.reset());
+
+function namesOf(collection: string): string[] {
+  return Object.values(firestore.docs(collection))
+    .map((document) => String(document.name))
+    .sort();
+}
+
+function idOfProgram(name: string): string {
+  const entry = Object.entries(firestore.docs("programs")).find(
+    ([, document]) => document.name === name,
+  );
+  if (!entry) throw new Error(`No program named ${name}`);
+  return entry[0];
+}
+
+function equipmentOf(programName: string): string[] {
+  const programId = idOfProgram(programName);
+  return Object.values(firestore.docs("requiredEquipmentItems"))
+    .filter((document) => document.programId === programId)
+    .map((document) => String(document.name))
+    .sort();
+}
+
+describe("seedMasterDataDefaults", () => {
+  it("creates the documented defaults for every pre-populated category", async () => {
+    await seedMasterDataDefaults();
+
+    expect(namesOf("programs")).toEqual(["Alternativ", "Ski", "Snowboard"]);
+    expect(namesOf("skillLevels")).toHaveLength(4);
+    expect(namesOf("busPickupPoints")).toHaveLength(4);
+    expect(namesOf("foodOptions")).toHaveLength(4);
+    expect(namesOf("seasonPassOptions")).toHaveLength(4);
+  });
+
+  it("stores the defaults with their German display text", async () => {
+    await seedMasterDataDefaults();
+
+    expect(namesOf("busPickupPoints")).toContain("HTL Dornbirn");
+    expect(namesOf("seasonPassOptions")).toContain("Silvretta-Montafon");
+    expect(namesOf("foodOptions")).toContain("Vegetarisch");
+  });
+
+  it("leaves classes empty, since that list has no defaults", async () => {
+    await seedMasterDataDefaults();
+
+    expect(firestore.count("classOptions")).toBe(0);
+  });
+
+  it("gives Ski and Snowboard their equipment and Alternativ none", async () => {
+    await seedMasterDataDefaults();
+
+    expect(equipmentOf("Ski")).toEqual(["Helm", "Ski", "Skischuhe", "Stöcke"]);
+    expect(equipmentOf("Snowboard")).toEqual(["Board", "Boots", "Helm"]);
+    expect(equipmentOf("Alternativ")).toEqual([]);
+  });
+
+  it('does not seed "other" as a food option row', async () => {
+    await seedMasterDataDefaults();
+
+    expect(namesOf("foodOptions")).not.toContain("other");
+    expect(namesOf("foodOptions")).not.toContain("Sonstiges");
+  });
+
+  it("claims every seeded name, so a teacher cannot add a duplicate afterwards", async () => {
+    await seedMasterDataDefaults();
+
+    expect(firestore.get("reservedNames", "programs|ski")).toMatchObject({ name: "Ski" });
+    expect(firestore.get("reservedNames", "seasonPassOptions|vielleicht")).toBeDefined();
+  });
+
+  it("is a no-op on the second run", async () => {
+    await seedMasterDataDefaults();
+    const before = firestore.docs("programs");
+
+    await seedMasterDataDefaults();
+
+    expect(firestore.docs("programs")).toEqual(before);
+    expect(namesOf("skillLevels")).toHaveLength(4);
+  });
+
+  it("does not recreate an entry the teacher deleted", async () => {
+    await seedMasterDataDefaults();
+    const doomed = Object.keys(firestore.docs("skillLevels"))[0];
+    firestore.deleteDoc("skillLevels", doomed);
+
+    await seedMasterDataDefaults();
+
+    expect(namesOf("skillLevels")).toHaveLength(3);
+  });
+
+  it("does not overwrite an entry the teacher renamed", async () => {
+    await seedMasterDataDefaults();
+    const target = Object.keys(firestore.docs("busPickupPoints"))[0];
+    firestore.seed("busPickupPoints", target, { name: "Umbenannt" });
+
+    await seedMasterDataDefaults();
+
+    expect(namesOf("busPickupPoints")).toContain("Umbenannt");
+    expect(namesOf("busPickupPoints")).toHaveLength(4);
+  });
+
+  it("tolerates a default a teacher had already added by hand", async () => {
+    firestore.seed("skillLevels", "manual", { name: "Anfänger" });
+    firestore.seed("reservedNames", "skillLevels|anfänger", {
+      scope: "skillLevels",
+      name: "Anfänger",
+      ownerId: "manual",
+    });
+
+    await expect(seedMasterDataDefaults()).resolves.toBeUndefined();
+
+    expect(namesOf("skillLevels").filter((name) => name === "Anfänger")).toHaveLength(1);
+  });
+
+  it("adds a default introduced later without touching the ones already seeded", async () => {
+    await seedMasterDataDefaults();
+    const skiId = idOfProgram("Ski");
+    const doomed = Object.entries(firestore.docs("requiredEquipmentItems")).find(
+      ([, document]) => document.programId === skiId && document.name === "Helm",
+    );
+    firestore.deleteDoc("requiredEquipmentItems", doomed![0]);
+
+    await seedMasterDataDefaults();
+
+    expect(equipmentOf("Ski")).toEqual(["Ski", "Skischuhe", "Stöcke"]);
+  });
+});

--- a/src/lib/master-data/seed-defaults.test.ts
+++ b/src/lib/master-data/seed-defaults.test.ts
@@ -22,20 +22,17 @@ function namesOf(collection: string): string[] {
     .sort();
 }
 
-function idOfProgram(name: string): string {
+function programNamed(name: string): [string, Record<string, unknown>] {
   const entry = Object.entries(firestore.docs("programs")).find(
     ([, document]) => document.name === name,
   );
   if (!entry) throw new Error(`No program named ${name}`);
-  return entry[0];
+  return entry;
 }
 
 function equipmentOf(programName: string): string[] {
-  const programId = idOfProgram(programName);
-  return Object.values(firestore.docs("requiredEquipmentItems"))
-    .filter((document) => document.programId === programId)
-    .map((document) => String(document.name))
-    .sort();
+  const [, program] = programNamed(programName);
+  return [...(program.requiredEquipment as string[])].sort();
 }
 
 describe("seedMasterDataDefaults", () => {
@@ -131,11 +128,11 @@ describe("seedMasterDataDefaults", () => {
 
   it("adds a default introduced later without touching the ones already seeded", async () => {
     await seedMasterDataDefaults();
-    const skiId = idOfProgram("Ski");
-    const doomed = Object.entries(firestore.docs("requiredEquipmentItems")).find(
-      ([, document]) => document.programId === skiId && document.name === "Helm",
-    );
-    firestore.deleteDoc("requiredEquipmentItems", doomed![0]);
+    const [skiId, ski] = programNamed("Ski");
+    firestore.seed("programs", skiId, {
+      ...ski,
+      requiredEquipment: (ski.requiredEquipment as string[]).filter((item) => item !== "Helm"),
+    });
 
     await seedMasterDataDefaults();
 

--- a/src/lib/master-data/seed-defaults.test.ts
+++ b/src/lib/master-data/seed-defaults.test.ts
@@ -22,6 +22,13 @@ function namesOf(collection: string): string[] {
     .sort();
 }
 
+/** The order the teacher sees, which is the order the defaults were seeded in. */
+function orderedNamesOf(collection: string): string[] {
+  return Object.values(firestore.docs(collection))
+    .sort((a, b) => Number(a.position) - Number(b.position))
+    .map((document) => String(document.name));
+}
+
 function programNamed(name: string): [string, Record<string, unknown>] {
   const entry = Object.entries(firestore.docs("programs")).find(
     ([, document]) => document.name === name,
@@ -55,10 +62,10 @@ describe("seedMasterDataDefaults", () => {
       "Fortgeschritten",
       "Profi",
     ]);
-    expect(namesOf("busPickupPoints")).toEqual([
+    expect(orderedNamesOf("busPickupPoints")).toEqual([
+      "HTL Dornbirn",
       "Bahnhof Bregenz",
       "Bahnhof Feldkirch",
-      "HTL Dornbirn",
       "Unterkunft",
     ]);
     expect(namesOf("foodOptions")).toEqual([
@@ -67,7 +74,12 @@ describe("seedMasterDataDefaults", () => {
       "Vegan",
       "Vegetarisch",
     ]);
-    expect(namesOf("seasonPassOptions")).toContain("Silvretta-Montafon");
+    expect(orderedNamesOf("seasonPassOptions")).toEqual([
+      "Keine",
+      "Vielleicht",
+      "Golm-Bielerhöhe (Illwerke)",
+      "Silvretta-Montafon",
+    ]);
   });
 
   it("leaves classes empty, since that list has no defaults", async () => {

--- a/src/lib/master-data/seed-defaults.test.ts
+++ b/src/lib/master-data/seed-defaults.test.ts
@@ -61,8 +61,13 @@ describe("seedMasterDataDefaults", () => {
       "HTL Dornbirn",
       "Unterkunft",
     ]);
+    expect(namesOf("foodOptions")).toEqual([
+      "Alles",
+      "Kein Schweinefleisch",
+      "Vegan",
+      "Vegetarisch",
+    ]);
     expect(namesOf("seasonPassOptions")).toContain("Silvretta-Montafon");
-    expect(namesOf("foodOptions")).toContain("Vegetarisch");
   });
 
   it("leaves classes empty, since that list has no defaults", async () => {

--- a/src/lib/master-data/seed-defaults.test.ts
+++ b/src/lib/master-data/seed-defaults.test.ts
@@ -49,7 +49,13 @@ describe("seedMasterDataDefaults", () => {
   it("stores the defaults with their German display text", async () => {
     await seedMasterDataDefaults();
 
-    expect(namesOf("busPickupPoints")).toContain("HTL Dornbirn");
+    expect(namesOf("skillLevels")).toEqual(["Anfänger", "Beginner", "Fortgeschritten", "Profi"]);
+    expect(namesOf("busPickupPoints")).toEqual([
+      "Bahnhof Bregenz",
+      "Bahnhof Feldkirch",
+      "HTL Dornbirn",
+      "Unterkunft",
+    ]);
     expect(namesOf("seasonPassOptions")).toContain("Silvretta-Montafon");
     expect(namesOf("foodOptions")).toContain("Vegetarisch");
   });

--- a/src/lib/master-data/seed-defaults.ts
+++ b/src/lib/master-data/seed-defaults.ts
@@ -25,13 +25,8 @@ const PROGRAM_DEFAULTS = [
  * from the food options — it is always offered to students and is never a row (US-9).
  */
 const LIST_DEFAULTS: Partial<Record<MasterDataCategoryKey, readonly string[]>> = {
-  "skill-levels": ["Blutiger Anfänger", "Anfänger", "Fortgeschritten", "Könner"],
-  "bus-pickup-points": [
-    "HTL Dornbirn",
-    "Bahnhof Feldkirch",
-    "Bahnhof Bregenz",
-    "Direkt bei der Unterkunft in Tschagguns",
-  ],
+  "skill-levels": ["Beginner", "Anfänger", "Fortgeschritten", "Profi"],
+  "bus-pickup-points": ["HTL Dornbirn", "Bahnhof Feldkirch", "Bahnhof Bregenz", "Unterkunft"],
   "food-options": ["Isst alles", "Vegetarisch", "Vegan", "Kein Schweinefleisch"],
   "season-pass-options": ["Nein", "Vielleicht", "Golm-Bielerhöhe (Illwerke)", "Silvretta-Montafon"],
 };

--- a/src/lib/master-data/seed-defaults.ts
+++ b/src/lib/master-data/seed-defaults.ts
@@ -9,8 +9,9 @@ import { normalizeName } from "@/lib/firebase/unique-name";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
 import { COLLECTIONS } from "@/lib/schemas/collections";
+import { programSchema } from "@/lib/schemas/master-data";
 import { categoryOf, type MasterDataCategoryKey } from "./categories";
-import { createMasterDataItem } from "./master-data-service";
+import { createMasterDataItem, updateMasterDataItem } from "./master-data-service";
 
 /** US-5: Alternativ deliberately requires nothing. */
 const PROGRAM_DEFAULTS = [
@@ -62,22 +63,24 @@ async function alreadySeeded(): Promise<Set<string>> {
 /** A default the teacher happened to type in first is already the desired end state. */
 async function createIgnoringDuplicates(
   key: MasterDataCategoryKey,
-  input: { name: string; parentId?: string },
-): Promise<string | null> {
+  input: { name: string; requiredEquipment?: readonly string[] },
+): Promise<void> {
   try {
-    return (await createMasterDataItem(key, input)).id;
+    await createMasterDataItem(key, input);
   } catch (error) {
-    if (error instanceof ServiceError && error.code === ErrorCode.Conflict) return null;
+    if (error instanceof ServiceError && error.code === ErrorCode.Conflict) return;
     throw error;
   }
 }
 
-async function findProgramByName(name: string): Promise<string | null> {
+async function findProgramByName(name: string) {
   const snapshot = await adminDb
     .collection(categoryOf("programs").collection)
     .where("name", "==", name)
     .get();
-  return snapshot.docs[0]?.id ?? null;
+
+  const found = snapshot.docs[0];
+  return found === undefined ? null : programSchema.parse({ id: found.id, ...found.data() });
 }
 
 /**
@@ -100,26 +103,32 @@ export async function seedMasterDataDefaults(): Promise<void> {
 
   for (const program of PROGRAM_DEFAULTS) {
     const programKey = keyOf("programs", program.name);
-    let programId: string | null = null;
+    const pendingEquipment = program.equipment.filter(
+      (item) => !seeded.has(keyOf("equipment", item, program.name)),
+    );
 
     if (!seeded.has(programKey)) {
-      programId = await createIgnoringDuplicates("programs", { name: program.name });
-      added.push(programKey);
+      await createIgnoringDuplicates("programs", {
+        name: program.name,
+        requiredEquipment: pendingEquipment,
+      });
+      added.push(
+        programKey,
+        ...pendingEquipment.map((item) => keyOf("equipment", item, program.name)),
+      );
+      continue;
     }
 
-    const pendingEquipment = program.equipment.filter(
-      (item) => !seeded.has(keyOf("required-equipment", item, program.name)),
-    );
     if (pendingEquipment.length === 0) continue;
 
-    // The program may predate this run, or the teacher may have removed it since.
-    programId ??= await findProgramByName(program.name);
-    if (programId === null) continue;
+    // The program predates this run, or the teacher has removed it since.
+    const existing = await findProgramByName(program.name);
+    if (existing === null) continue;
 
-    for (const item of pendingEquipment) {
-      await createIgnoringDuplicates("required-equipment", { name: item, parentId: programId });
-      added.push(keyOf("required-equipment", item, program.name));
-    }
+    await updateMasterDataItem("programs", existing.id, {
+      requiredEquipment: [...existing.requiredEquipment, ...pendingEquipment],
+    });
+    added.push(...pendingEquipment.map((item) => keyOf("equipment", item, program.name)));
   }
 
   if (added.length > 0) {

--- a/src/lib/master-data/seed-defaults.ts
+++ b/src/lib/master-data/seed-defaults.ts
@@ -1,0 +1,128 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import "server-only";
+import { adminDb } from "@/lib/firebase/admin";
+import { normalizeName } from "@/lib/firebase/unique-name";
+import { ErrorCode } from "@/lib/errors";
+import { ServiceError } from "@/lib/service-error";
+import { COLLECTIONS } from "@/lib/schemas/collections";
+import { categoryOf, type MasterDataCategoryKey } from "./categories";
+import { createMasterDataItem } from "./master-data-service";
+
+/** US-5: Alternativ deliberately requires nothing. */
+const PROGRAM_DEFAULTS = [
+  { name: "Ski", equipment: ["Ski", "Skischuhe", "Stöcke", "Helm"] },
+  { name: "Snowboard", equipment: ["Board", "Boots", "Helm"] },
+  { name: "Alternativ", equipment: [] },
+] as const;
+
+/**
+ * Classes are absent on purpose: US-6 starts that list empty. "Sonstiges" is likewise absent
+ * from the food options — it is always offered to students and is never a row (US-9).
+ */
+const LIST_DEFAULTS: Partial<Record<MasterDataCategoryKey, readonly string[]>> = {
+  "skill-levels": ["Blutiger Anfänger", "Anfänger", "Fortgeschritten", "Könner"],
+  "bus-pickup-points": [
+    "HTL Dornbirn",
+    "Bahnhof Feldkirch",
+    "Bahnhof Bregenz",
+    "Direkt bei der Unterkunft in Tschagguns",
+  ],
+  "food-options": ["Isst alles", "Vegetarisch", "Vegan", "Kein Schweinefleisch"],
+  "season-pass-options": ["Nein", "Vielleicht", "Golm-Bielerhöhe (Illwerke)", "Silvretta-Montafon"],
+};
+
+const MARKER_ID = "masterDataDefaults";
+
+function markerRef() {
+  return adminDb.collection(COLLECTIONS.seedState).doc(MARKER_ID);
+}
+
+function keyOf(category: string, name: string, parent?: string): string {
+  return parent === undefined
+    ? `${category}|${normalizeName(name)}`
+    : `${category}:${normalizeName(parent)}|${normalizeName(name)}`;
+}
+
+/**
+ * A default is created at most once, ever. What makes that hold is the marker: it records the
+ * defaults already dealt with, so a list the teacher has since emptied stays empty and a renamed
+ * entry keeps its new name. Recording per default rather than per category also means a default
+ * added in a later release still lands, without disturbing the ones already there.
+ */
+async function alreadySeeded(): Promise<Set<string>> {
+  const marker = await markerRef().get();
+  const stored = marker.data()?.seededKeys;
+  return new Set(Array.isArray(stored) ? stored.filter((key) => typeof key === "string") : []);
+}
+
+/** A default the teacher happened to type in first is already the desired end state. */
+async function createIgnoringDuplicates(
+  key: MasterDataCategoryKey,
+  input: { name: string; parentId?: string },
+): Promise<string | null> {
+  try {
+    return (await createMasterDataItem(key, input)).id;
+  } catch (error) {
+    if (error instanceof ServiceError && error.code === ErrorCode.Conflict) return null;
+    throw error;
+  }
+}
+
+async function findProgramByName(name: string): Promise<string | null> {
+  const snapshot = await adminDb
+    .collection(categoryOf("programs").collection)
+    .where("name", "==", name)
+    .get();
+  return snapshot.docs[0]?.id ?? null;
+}
+
+/**
+ * Brings a fresh environment up with the defaults US-5 and US-7 to US-10 call for. Server-side
+ * only, and safe to call on every request: once every key is recorded it costs a single read.
+ */
+export async function seedMasterDataDefaults(): Promise<void> {
+  const seeded = await alreadySeeded();
+  const added: string[] = [];
+
+  for (const [category, names] of Object.entries(LIST_DEFAULTS)) {
+    for (const name of names) {
+      const key = keyOf(category, name);
+      if (seeded.has(key)) continue;
+
+      await createIgnoringDuplicates(category as MasterDataCategoryKey, { name });
+      added.push(key);
+    }
+  }
+
+  for (const program of PROGRAM_DEFAULTS) {
+    const programKey = keyOf("programs", program.name);
+    let programId: string | null = null;
+
+    if (!seeded.has(programKey)) {
+      programId = await createIgnoringDuplicates("programs", { name: program.name });
+      added.push(programKey);
+    }
+
+    const pendingEquipment = program.equipment.filter(
+      (item) => !seeded.has(keyOf("required-equipment", item, program.name)),
+    );
+    if (pendingEquipment.length === 0) continue;
+
+    // The program may predate this run, or the teacher may have removed it since.
+    programId ??= await findProgramByName(program.name);
+    if (programId === null) continue;
+
+    for (const item of pendingEquipment) {
+      await createIgnoringDuplicates("required-equipment", { name: item, parentId: programId });
+      added.push(keyOf("required-equipment", item, program.name));
+    }
+  }
+
+  if (added.length > 0) {
+    await markerRef().set({ seededKeys: [...seeded, ...added] });
+  }
+}

--- a/src/lib/master-data/seed-defaults.ts
+++ b/src/lib/master-data/seed-defaults.ts
@@ -26,9 +26,14 @@ const PROGRAM_DEFAULTS = [
  */
 const LIST_DEFAULTS: Partial<Record<MasterDataCategoryKey, readonly string[]>> = {
   "skill-levels": ["Absoluter Anfänger", "Anfänger", "Fortgeschritten", "Profi"],
-  "bus-pickup-points": ["HTL Dornbirn", "Bahnhof Feldkirch", "Bahnhof Bregenz", "Unterkunft"],
+  "bus-pickup-points": ["HTL Dornbirn", "Bahnhof Bregenz", "Bahnhof Feldkirch", "Unterkunft"],
   "food-options": ["Alles", "Vegetarisch", "Vegan", "Kein Schweinefleisch"],
-  "season-pass-options": ["Nein", "Vielleicht", "Golm-Bielerhöhe (Illwerke)", "Silvretta-Montafon"],
+  "season-pass-options": [
+    "Keine",
+    "Vielleicht",
+    "Golm-Bielerhöhe (Illwerke)",
+    "Silvretta-Montafon",
+  ],
 };
 
 const MARKER_ID = "masterDataDefaults";

--- a/src/lib/master-data/seed-defaults.ts
+++ b/src/lib/master-data/seed-defaults.ts
@@ -27,7 +27,7 @@ const PROGRAM_DEFAULTS = [
 const LIST_DEFAULTS: Partial<Record<MasterDataCategoryKey, readonly string[]>> = {
   "skill-levels": ["Absoluter Anfänger", "Anfänger", "Fortgeschritten", "Profi"],
   "bus-pickup-points": ["HTL Dornbirn", "Bahnhof Feldkirch", "Bahnhof Bregenz", "Unterkunft"],
-  "food-options": ["Isst alles", "Vegetarisch", "Vegan", "Kein Schweinefleisch"],
+  "food-options": ["Alles", "Vegetarisch", "Vegan", "Kein Schweinefleisch"],
   "season-pass-options": ["Nein", "Vielleicht", "Golm-Bielerhöhe (Illwerke)", "Silvretta-Montafon"],
 };
 

--- a/src/lib/master-data/seed-defaults.ts
+++ b/src/lib/master-data/seed-defaults.ts
@@ -25,7 +25,7 @@ const PROGRAM_DEFAULTS = [
  * from the food options — it is always offered to students and is never a row (US-9).
  */
 const LIST_DEFAULTS: Partial<Record<MasterDataCategoryKey, readonly string[]>> = {
-  "skill-levels": ["Beginner", "Anfänger", "Fortgeschritten", "Profi"],
+  "skill-levels": ["Absoluter Anfänger", "Anfänger", "Fortgeschritten", "Profi"],
   "bus-pickup-points": ["HTL Dornbirn", "Bahnhof Feldkirch", "Bahnhof Bregenz", "Unterkunft"],
   "food-options": ["Isst alles", "Vegetarisch", "Vegan", "Kein Schweinefleisch"],
   "season-pass-options": ["Nein", "Vielleicht", "Golm-Bielerhöhe (Illwerke)", "Silvretta-Montafon"],

--- a/src/lib/master-data/usage-guard.test.ts
+++ b/src/lib/master-data/usage-guard.test.ts
@@ -1,0 +1,163 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeFirestore } from "@/test/fake-firestore";
+import { IN_USE_HINT, MASTER_DATA_CATEGORIES } from "./categories";
+
+const firestore = new FakeFirestore();
+
+vi.mock("@/lib/firebase/admin", () => ({
+  adminDb: firestore,
+}));
+
+const { assertNotInUse, blockedItemIds, namesInUse } = await import("./usage-guard");
+const { ServiceError } = await import("@/lib/service-error");
+
+beforeEach(() => firestore.reset());
+
+function seedSeason(id: string, isArchived: boolean) {
+  firestore.seed("seasons", id, {
+    name: `Saison ${id}`,
+    isActive: false,
+    isArchived,
+    hasStudentData: true,
+  });
+}
+
+function seedRecord(id: string, seasonId: string, fields: Record<string, unknown>) {
+  firestore.seed("studentMasterData", id, { userId: `u-${id}`, seasonId, ...fields });
+}
+
+describe("assertNotInUse — categories matched through a master data field", () => {
+  it("blocks an item selected by a record of a non-archived season", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT" });
+
+    await expect(assertNotInUse(MASTER_DATA_CATEGORIES.classes, "3AHIT")).rejects.toBeInstanceOf(
+      ServiceError,
+    );
+  });
+
+  it("explains that the season has to be archived first", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT" });
+
+    await expect(assertNotInUse(MASTER_DATA_CATEGORIES.classes, "3AHIT")).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: IN_USE_HINT,
+    });
+  });
+
+  it("allows an item used only by records of archived seasons", async () => {
+    seedSeason("done", true);
+    seedRecord("r1", "done", { class: "3AHIT" });
+
+    await expect(assertNotInUse(MASTER_DATA_CATEGORIES.classes, "3AHIT")).resolves.toBeUndefined();
+  });
+
+  it("allows an unused item", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT" });
+
+    await expect(assertNotInUse(MASTER_DATA_CATEGORIES.classes, "4BHIT")).resolves.toBeUndefined();
+  });
+
+  it("compares names the way the rest of the app does, ignoring case and surrounding space", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT" });
+
+    await expect(assertNotInUse(MASTER_DATA_CATEGORIES.classes, " 3ahit ")).rejects.toBeInstanceOf(
+      ServiceError,
+    );
+  });
+
+  it("keeps the categories apart, so a program named like a class is not blocked by it", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "Alternativ", program: "Ski" });
+
+    await expect(
+      assertNotInUse(MASTER_DATA_CATEGORIES.programs, "Alternativ"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("blocks a program through the program field", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT", program: "Ski" });
+
+    await expect(assertNotInUse(MASTER_DATA_CATEGORIES.programs, "Ski")).rejects.toBeInstanceOf(
+      ServiceError,
+    );
+  });
+});
+
+describe("assertNotInUse — required equipment items", () => {
+  const equipment = MASTER_DATA_CATEGORIES["required-equipment"];
+
+  it("blocks an item a student of a non-archived season rented", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT", program: "Ski" });
+    firestore.seed("equipmentRentalItems", "e1", { studentMasterDataId: "r1", itemName: "Helm" });
+
+    await expect(assertNotInUse(equipment, "Helm")).rejects.toBeInstanceOf(ServiceError);
+  });
+
+  it("allows an item only rented by students of archived seasons", async () => {
+    seedSeason("done", true);
+    seedRecord("r1", "done", { class: "3AHIT", program: "Ski" });
+    firestore.seed("equipmentRentalItems", "e1", { studentMasterDataId: "r1", itemName: "Helm" });
+
+    await expect(assertNotInUse(equipment, "Helm")).resolves.toBeUndefined();
+  });
+
+  it("does not match through the program field, only through the rental selections", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT", program: "Ski" });
+
+    await expect(assertNotInUse(equipment, "Ski")).resolves.toBeUndefined();
+  });
+});
+
+describe("namesInUse", () => {
+  it("reports the blocked names so the list can disable their controls", async () => {
+    seedSeason("open", false);
+    seedSeason("done", true);
+    seedRecord("r1", "open", { class: "3AHIT" });
+    seedRecord("r2", "done", { class: "4BHIT" });
+
+    await expect(namesInUse(MASTER_DATA_CATEGORIES.classes)).resolves.toEqual(new Set(["3ahit"]));
+  });
+
+  it("is empty when nothing is in use", async () => {
+    seedSeason("open", false);
+
+    await expect(namesInUse(MASTER_DATA_CATEGORIES.classes)).resolves.toEqual(new Set());
+  });
+
+  it("skips records whose snapshot field was never filled in", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT", skillLevel: null });
+
+    await expect(namesInUse(MASTER_DATA_CATEGORIES["skill-levels"])).resolves.toEqual(new Set());
+  });
+});
+
+describe("blockedItemIds", () => {
+  it("resolves the blocked names onto the items the list renders", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: " 3ahit " });
+    firestore.seed("classOptions", "c1", { name: "3AHIT" });
+    firestore.seed("classOptions", "c2", { name: "4BHIT" });
+
+    await expect(blockedItemIds(MASTER_DATA_CATEGORIES.classes)).resolves.toEqual(["c1"]);
+  });
+
+  it("reads no items at all when nothing is blocked", async () => {
+    seedSeason("open", false);
+    firestore.seed("classOptions", "c1", { name: "3AHIT" });
+
+    await expect(blockedItemIds(MASTER_DATA_CATEGORIES.classes)).resolves.toEqual([]);
+  });
+});

--- a/src/lib/master-data/usage-guard.test.ts
+++ b/src/lib/master-data/usage-guard.test.ts
@@ -13,7 +13,8 @@ vi.mock("@/lib/firebase/admin", () => ({
   adminDb: firestore,
 }));
 
-const { assertNotInUse, blockedItemIds, namesInUse } = await import("./usage-guard");
+const { assertEquipmentNotInUse, assertNotInUse, namesInUse, usageReport } =
+  await import("./usage-guard");
 const { ServiceError } = await import("@/lib/service-error");
 
 beforeEach(() => firestore.reset());
@@ -93,30 +94,43 @@ describe("assertNotInUse — categories matched through a master data field", ()
   });
 });
 
-describe("assertNotInUse — required equipment items", () => {
-  const equipment = MASTER_DATA_CATEGORIES["required-equipment"];
-
-  it("blocks an item a student of a non-archived season rented", async () => {
+describe("assertEquipmentNotInUse", () => {
+  it("blocks an entry a student of a non-archived season rented", async () => {
     seedSeason("open", false);
     seedRecord("r1", "open", { class: "3AHIT", program: "Ski" });
     firestore.seed("equipmentRentalItems", "e1", { studentMasterDataId: "r1", itemName: "Helm" });
 
-    await expect(assertNotInUse(equipment, "Helm")).rejects.toBeInstanceOf(ServiceError);
+    await expect(assertEquipmentNotInUse(["Helm"])).rejects.toBeInstanceOf(ServiceError);
   });
 
-  it("allows an item only rented by students of archived seasons", async () => {
+  it("allows an entry only rented by students of archived seasons", async () => {
     seedSeason("done", true);
     seedRecord("r1", "done", { class: "3AHIT", program: "Ski" });
     firestore.seed("equipmentRentalItems", "e1", { studentMasterDataId: "r1", itemName: "Helm" });
 
-    await expect(assertNotInUse(equipment, "Helm")).resolves.toBeUndefined();
+    await expect(assertEquipmentNotInUse(["Helm"])).resolves.toBeUndefined();
   });
 
   it("does not match through the program field, only through the rental selections", async () => {
     seedSeason("open", false);
     seedRecord("r1", "open", { class: "3AHIT", program: "Ski" });
 
-    await expect(assertNotInUse(equipment, "Ski")).resolves.toBeUndefined();
+    await expect(assertEquipmentNotInUse(["Ski"])).resolves.toBeUndefined();
+  });
+
+  it("rejects as soon as any one of the names is rented", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT", program: "Ski" });
+    firestore.seed("equipmentRentalItems", "e1", { studentMasterDataId: "r1", itemName: "Helm" });
+
+    await expect(assertEquipmentNotInUse(["Stöcke", " helm "])).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: IN_USE_HINT,
+    });
+  });
+
+  it("reads nothing when there is nothing to check", async () => {
+    await expect(assertEquipmentNotInUse([])).resolves.toBeUndefined();
   });
 });
 
@@ -144,20 +158,94 @@ describe("namesInUse", () => {
   });
 });
 
-describe("blockedItemIds", () => {
+describe("usageReport", () => {
   it("resolves the blocked names onto the items the list renders", async () => {
     seedSeason("open", false);
     seedRecord("r1", "open", { class: " 3ahit " });
     firestore.seed("classOptions", "c1", { name: "3AHIT" });
     firestore.seed("classOptions", "c2", { name: "4BHIT" });
 
-    await expect(blockedItemIds(MASTER_DATA_CATEGORIES.classes)).resolves.toEqual(["c1"]);
+    await expect(usageReport(MASTER_DATA_CATEGORIES.classes)).resolves.toEqual({
+      blockedIds: ["c1"],
+      blockedEquipment: {},
+    });
   });
 
-  it("reads no items at all when nothing is blocked", async () => {
+  it("blocks nothing when nothing is in use", async () => {
     seedSeason("open", false);
     firestore.seed("classOptions", "c1", { name: "3AHIT" });
 
-    await expect(blockedItemIds(MASTER_DATA_CATEGORIES.classes)).resolves.toEqual([]);
+    await expect(usageReport(MASTER_DATA_CATEGORIES.classes)).resolves.toEqual({
+      blockedIds: [],
+      blockedEquipment: {},
+    });
+  });
+
+  it("names the rented entries of a program, spelled the way the program stores them", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT", program: "Snowboard" });
+    firestore.seed("programs", "ski", { name: "Ski", requiredEquipment: ["Helm", "Stöcke"] });
+    firestore.seed("equipmentRentalItems", "rent1", {
+      studentMasterDataId: "r1",
+      itemName: " helm ",
+    });
+
+    // Renaming the program is still fine — only removing the entry along with it is not.
+    await expect(usageReport(MASTER_DATA_CATEGORIES.programs)).resolves.toEqual({
+      blockedIds: [],
+      blockedEquipment: { ski: ["Helm"] },
+    });
+  });
+
+  it("blocks a program outright once it is itself selected", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT", program: "Ski" });
+    firestore.seed("programs", "ski", { name: "Ski", requiredEquipment: [] });
+
+    await expect(usageReport(MASTER_DATA_CATEGORIES.programs)).resolves.toEqual({
+      blockedIds: ["ski"],
+      blockedEquipment: {},
+    });
+  });
+
+  it("leaves a program whose equipment is only rented in archived seasons alone", async () => {
+    seedSeason("done", true);
+    seedRecord("r1", "done", { class: "3AHIT", program: "Ski" });
+    firestore.seed("programs", "ski", { name: "Ski", requiredEquipment: ["Helm"] });
+    firestore.seed("equipmentRentalItems", "rent1", {
+      studentMasterDataId: "r1",
+      itemName: "Helm",
+    });
+
+    await expect(usageReport(MASTER_DATA_CATEGORIES.programs)).resolves.toEqual({
+      blockedIds: [],
+      blockedEquipment: {},
+    });
+  });
+
+  it("does not hold one program back for another program's rented equipment", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT", program: "Snowboard" });
+    firestore.seed("programs", "ski", { name: "Ski", requiredEquipment: ["Stöcke"] });
+    firestore.seed("programs", "board", { name: "Snowboard", requiredEquipment: ["Helm"] });
+    firestore.seed("equipmentRentalItems", "rent1", {
+      studentMasterDataId: "r1",
+      itemName: "Helm",
+    });
+
+    const report = await usageReport(MASTER_DATA_CATEGORIES.programs);
+
+    expect(report.blockedEquipment).toEqual({ board: ["Helm"] });
+  });
+
+  it("treats a program stored before the field existed as requiring nothing", async () => {
+    seedSeason("open", false);
+    seedRecord("r1", "open", { class: "3AHIT", program: "Snowboard" });
+    firestore.seed("programs", "ski", { name: "Ski" });
+
+    await expect(usageReport(MASTER_DATA_CATEGORIES.programs)).resolves.toEqual({
+      blockedIds: [],
+      blockedEquipment: {},
+    });
   });
 });

--- a/src/lib/master-data/usage-guard.ts
+++ b/src/lib/master-data/usage-guard.ts
@@ -31,6 +31,12 @@ async function openRecords() {
   return perSeason.flatMap((snapshot) => snapshot.docs);
 }
 
+function normalizedNames(values: unknown[]): string[] {
+  return values.flatMap((value) =>
+    typeof value === "string" && value.trim() !== "" ? [normalizeName(value)] : [],
+  );
+}
+
 /**
  * The names an editing teacher may not touch, normalized for comparison.
  *
@@ -40,19 +46,18 @@ async function openRecords() {
  */
 export async function namesInUse(category: MasterDataCategory): Promise<Set<string>> {
   const records = await openRecords();
+  const field = category.usage.field;
 
-  if (category.usage.kind === "masterData") {
-    const field = category.usage.field;
-    return new Set(
-      records.flatMap((record) => {
-        const value = record.data()?.[field];
-        return typeof value === "string" && value.trim() !== "" ? [normalizeName(value)] : [];
-      }),
-    );
-  }
+  return new Set(normalizedNames(records.map((record) => record.data()?.[field])));
+}
 
-  // Required equipment is chosen per student, so it is the rental rows that mark an item as
-  // used — never the program the item belongs to (US-5).
+/**
+ * Required equipment is chosen per student, so it is the rental rows that mark an entry as used
+ * — never the program that requires it (US-5).
+ */
+export async function equipmentNamesInUse(): Promise<Set<string>> {
+  const records = await openRecords();
+
   const rentals = await Promise.all(
     records.map((record) =>
       adminDb
@@ -64,10 +69,7 @@ export async function namesInUse(category: MasterDataCategory): Promise<Set<stri
 
   return new Set(
     rentals.flatMap((snapshot) =>
-      snapshot.docs.flatMap((rental) => {
-        const value = rental.data()?.itemName;
-        return typeof value === "string" && value.trim() !== "" ? [normalizeName(value)] : [];
-      }),
+      normalizedNames(snapshot.docs.map((rental) => rental.data()?.itemName)),
     ),
   );
 }
@@ -83,20 +85,61 @@ export async function assertNotInUse(category: MasterDataCategory, name: string)
   }
 }
 
+/** Rejects as soon as one of `names` is still rented by a student of an open season (US-5). */
+export async function assertEquipmentNotInUse(names: readonly string[]): Promise<void> {
+  if (names.length === 0) return;
+
+  const blocked = await equipmentNamesInUse();
+  if (names.some((name) => blocked.has(normalizeName(name)))) {
+    throw new ServiceError(ErrorCode.Conflict, IN_USE_HINT);
+  }
+}
+
+export type MasterDataUsageReport = {
+  /** In use itself, so it can be neither edited nor deleted. */
+  blockedIds: string[];
+  /**
+   * Per item id, the entries of its own equipment list a student of an open season still rents,
+   * spelled exactly as the item stores them. An item with entries here cannot be deleted, since
+   * deleting it would take them along — but it can still be renamed (US-5).
+   */
+  blockedEquipment: Record<string, string[]>;
+};
+
 /**
  * The same answer keyed by document id, which is what the list view needs. Resolving the names
  * here rather than in the browser keeps one definition of "the same name" — the client would
  * otherwise have to re-implement the comparison, and drift the moment either side changed.
  */
-export async function blockedItemIds(category: MasterDataCategory): Promise<string[]> {
+export async function usageReport(category: MasterDataCategory): Promise<MasterDataUsageReport> {
   const blocked = await namesInUse(category);
-  if (blocked.size === 0) return [];
+  const equipmentField = category.equipmentField;
+  const needsItems = blocked.size > 0 || equipmentField !== undefined;
 
-  const items = await adminDb.collection(category.collection).get();
-  return items.docs
+  const items = needsItems ? (await adminDb.collection(category.collection).get()).docs : [];
+  const blockedIds = items
     .filter((item) => {
       const name = item.data()?.name;
       return typeof name === "string" && blocked.has(normalizeName(name));
     })
     .map((item) => item.id);
+
+  if (equipmentField === undefined) {
+    return { blockedIds, blockedEquipment: {} };
+  }
+
+  const blockedEquipmentNames = await equipmentNamesInUse();
+  const blockedEquipment: Record<string, string[]> = {};
+
+  for (const item of items) {
+    const equipment = item.data()?.[equipmentField];
+    if (!Array.isArray(equipment)) continue;
+
+    const rented = equipment.filter(
+      (entry) => typeof entry === "string" && blockedEquipmentNames.has(normalizeName(entry)),
+    );
+    if (rented.length > 0) blockedEquipment[item.id] = rented;
+  }
+
+  return { blockedIds, blockedEquipment };
 }

--- a/src/lib/master-data/usage-guard.ts
+++ b/src/lib/master-data/usage-guard.ts
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import "server-only";
+import { adminDb } from "@/lib/firebase/admin";
+import { normalizeName } from "@/lib/firebase/unique-name";
+import { ErrorCode } from "@/lib/errors";
+import { ServiceError } from "@/lib/service-error";
+import { COLLECTIONS } from "@/lib/schemas/collections";
+import { IN_USE_HINT, type MasterDataCategory } from "./categories";
+
+/**
+ * Master data records of seasons that are still open. Archiving is what signs a season's data
+ * off (US-4), so it is the season's flag — never a flag on the record — that decides whether the
+ * values it snapshotted are still binding (US-5 to US-10).
+ */
+async function openRecords() {
+  const seasons = await adminDb
+    .collection(COLLECTIONS.seasons)
+    .where("isArchived", "==", false)
+    .get();
+
+  const perSeason = await Promise.all(
+    seasons.docs.map((season) =>
+      adminDb.collection(COLLECTIONS.studentMasterData).where("seasonId", "==", season.id).get(),
+    ),
+  );
+
+  return perSeason.flatMap((snapshot) => snapshot.docs);
+}
+
+/**
+ * The names an editing teacher may not touch, normalized for comparison.
+ *
+ * The lists store names, and so do the records that select from them — master data keeps a
+ * plain-text snapshot rather than a reference (US-11), which is exactly why this is a name
+ * match and not a join.
+ */
+export async function namesInUse(category: MasterDataCategory): Promise<Set<string>> {
+  const records = await openRecords();
+
+  if (category.usage.kind === "masterData") {
+    const field = category.usage.field;
+    return new Set(
+      records.flatMap((record) => {
+        const value = record.data()?.[field];
+        return typeof value === "string" && value.trim() !== "" ? [normalizeName(value)] : [];
+      }),
+    );
+  }
+
+  // Required equipment is chosen per student, so it is the rental rows that mark an item as
+  // used — never the program the item belongs to (US-5).
+  const rentals = await Promise.all(
+    records.map((record) =>
+      adminDb
+        .collection(COLLECTIONS.equipmentRentalItems)
+        .where("studentMasterDataId", "==", record.id)
+        .get(),
+    ),
+  );
+
+  return new Set(
+    rentals.flatMap((snapshot) =>
+      snapshot.docs.flatMap((rental) => {
+        const value = rental.data()?.itemName;
+        return typeof value === "string" && value.trim() !== "" ? [normalizeName(value)] : [];
+      }),
+    ),
+  );
+}
+
+/**
+ * The server-side half of the in-use restriction. The list also disables the controls, but that
+ * is a convenience: a client that skips the UI still has to come through here.
+ */
+export async function assertNotInUse(category: MasterDataCategory, name: string): Promise<void> {
+  const blocked = await namesInUse(category);
+  if (blocked.has(normalizeName(name))) {
+    throw new ServiceError(ErrorCode.Conflict, IN_USE_HINT);
+  }
+}
+
+/**
+ * The same answer keyed by document id, which is what the list view needs. Resolving the names
+ * here rather than in the browser keeps one definition of "the same name" — the client would
+ * otherwise have to re-implement the comparison, and drift the moment either side changed.
+ */
+export async function blockedItemIds(category: MasterDataCategory): Promise<string[]> {
+  const blocked = await namesInUse(category);
+  if (blocked.size === 0) return [];
+
+  const items = await adminDb.collection(category.collection).get();
+  return items.docs
+    .filter((item) => {
+      const name = item.data()?.name;
+      return typeof name === "string" && blocked.has(normalizeName(name));
+    })
+    .map((item) => item.id);
+}

--- a/src/lib/master-data/use-master-data.test.ts
+++ b/src/lib/master-data/use-master-data.test.ts
@@ -15,16 +15,17 @@ const where = vi.fn((field: string, _op: string, value: unknown) => `where:${fie
 
 vi.mock("firebase/firestore", () => ({
   collection: (...args: unknown[]) => collection(args[0], args[1] as string),
+  doc: vi.fn(),
+  onSnapshot,
   query: vi.fn((...args: unknown[]) => args),
   orderBy: vi.fn((field: string) => `order-by:${field}`),
   where: (...args: unknown[]) => where(args[0] as string, args[1] as string, args[2]),
-  onSnapshot,
 }));
 
 vi.mock("firebase/auth", () => ({ onAuthStateChanged }));
 vi.mock("@/lib/firebase/client", () => ({ auth: {}, db: {} }));
 
-const { useBlockedItemIds, useMasterData } = await import("@/lib/master-data/use-master-data");
+const { useMasterData, useUsageReport } = await import("@/lib/master-data/use-master-data");
 
 function docOf(id: string, data: unknown) {
   return { id, data: () => data };
@@ -83,23 +84,18 @@ describe("useMasterData", () => {
     expect(result.current.items).toEqual([{ id: "c2", name: "4BHIT" }]);
   });
 
-  it("scopes a nested list to its parent", () => {
-    renderHook(() => useMasterData("required-equipment", "ski"));
-    signIn();
-
-    expect(where).toHaveBeenCalledWith("programId", "==", "ski");
-  });
-
-  it("does not filter a flat list by a parent", () => {
-    renderHook(() => useMasterData("classes"));
+  it("scopes nothing by a parent, since no category has one any more", () => {
+    renderHook(() => useMasterData("programs"));
     signIn();
 
     expect(where).not.toHaveBeenCalled();
   });
 });
 
-describe("useBlockedItemIds", () => {
+describe("useUsageReport", () => {
   afterEach(() => vi.unstubAllGlobals());
+
+  const nothingBlocked = { blockedIds: new Set(), blockedEquipment: {} };
 
   function stubFetch(implementation: (...args: unknown[]) => unknown) {
     const fetchMock = vi.fn(implementation);
@@ -107,50 +103,51 @@ describe("useBlockedItemIds", () => {
     return fetchMock;
   }
 
-  it("asks the handler for the category it was given", async () => {
-    const fetchMock = stubFetch(() =>
+  function respond(body: unknown) {
+    return () =>
       Promise.resolve(
-        new Response(JSON.stringify({ blockedIds: [] }), {
+        new Response(JSON.stringify(body), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
-      ),
-    );
+      );
+  }
 
-    renderHook(() => useBlockedItemIds("food-options"));
+  it("asks the handler for the category it was given", async () => {
+    const fetchMock = stubFetch(respond({ blockedIds: [], blockedEquipment: {} }));
+
+    renderHook(() => useUsageReport("food-options"));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/master-data/food-options"));
   });
 
-  it("returns the blocked ids", async () => {
-    stubFetch(() =>
-      Promise.resolve(
-        new Response(JSON.stringify({ blockedIds: ["c1", "c2"] }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      ),
+  it("keeps what is in use apart from the entries an item's own list holds", async () => {
+    stubFetch(respond({ blockedIds: ["p1"], blockedEquipment: { p2: ["Helm"] } }));
+
+    const { result } = renderHook(() => useUsageReport("programs"));
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        blockedIds: new Set(["p1"]),
+        blockedEquipment: { p2: ["Helm"] },
+      }),
     );
-
-    const { result } = renderHook(() => useBlockedItemIds("classes"));
-
-    await waitFor(() => expect(result.current).toEqual(new Set(["c1", "c2"])));
   });
 
   it("blocks nothing when the handler refuses, since the server re-checks every write", async () => {
     stubFetch(() => Promise.resolve(new Response(null, { status: 403 })));
 
-    const { result } = renderHook(() => useBlockedItemIds("classes"));
+    const { result } = renderHook(() => useUsageReport("classes"));
 
-    await waitFor(() => expect(result.current).toEqual(new Set()));
+    await waitFor(() => expect(result.current).toEqual(nothingBlocked));
   });
 
   it("survives a failed request", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     stubFetch(() => Promise.reject(new Error("offline")));
 
-    const { result } = renderHook(() => useBlockedItemIds("classes"));
+    const { result } = renderHook(() => useUsageReport("classes"));
 
-    await waitFor(() => expect(result.current).toEqual(new Set()));
+    await waitFor(() => expect(result.current).toEqual(nothingBlocked));
   });
 });

--- a/src/lib/master-data/use-master-data.test.ts
+++ b/src/lib/master-data/use-master-data.test.ts
@@ -67,10 +67,34 @@ describe("useMasterData", () => {
     const { result } = renderHook(() => useMasterData("classes"));
     signIn();
 
-    emit([docOf("c1", { name: "3AHIT" })]);
+    emit([docOf("c1", { name: "3AHIT", position: 0 })]);
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.items).toEqual([{ id: "c1", name: "3AHIT" }]);
+    expect(result.current.items).toEqual([{ id: "c1", name: "3AHIT", position: 0 }]);
+  });
+
+  it("shows the items in the order the teacher set, not alphabetically", async () => {
+    const { result } = renderHook(() => useMasterData("classes"));
+    signIn();
+
+    emit([
+      docOf("a", { name: "Anton", position: 2 }),
+      docOf("z", { name: "Zoe", position: 0 }),
+      docOf("m", { name: "Mia", position: 1 }),
+    ]);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items.map((item) => item.id)).toEqual(["z", "m", "a"]);
+  });
+
+  it("keeps an item stored before ordering existed visible, at the end", async () => {
+    const { result } = renderHook(() => useMasterData("classes"));
+    signIn();
+
+    emit([docOf("old", { name: "Anton" }), docOf("new", { name: "Zoe", position: 0 })]);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items.map((item) => item.id)).toEqual(["new", "old"]);
   });
 
   it("drops a malformed document instead of failing the whole list", async () => {
@@ -78,10 +102,10 @@ describe("useMasterData", () => {
     const { result } = renderHook(() => useMasterData("classes"));
     signIn();
 
-    emit([docOf("c1", { name: "   " }), docOf("c2", { name: "4BHIT" })]);
+    emit([docOf("c1", { name: "   " }), docOf("c2", { name: "4BHIT", position: 0 })]);
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.items).toEqual([{ id: "c2", name: "4BHIT" }]);
+    expect(result.current.items).toEqual([{ id: "c2", name: "4BHIT", position: 0 }]);
   });
 
   it("scopes nothing by a parent, since no category has one any more", () => {

--- a/src/lib/master-data/use-master-data.test.ts
+++ b/src/lib/master-data/use-master-data.test.ts
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type SnapshotHandler = (snapshot: { docs: { id: string; data: () => unknown }[] }) => void;
+
+const onSnapshot = vi.fn();
+const onAuthStateChanged = vi.fn();
+const collection = vi.fn((_db: unknown, path: string) => path);
+const where = vi.fn((field: string, _op: string, value: unknown) => `where:${field}=${value}`);
+
+vi.mock("firebase/firestore", () => ({
+  collection: (...args: unknown[]) => collection(args[0], args[1] as string),
+  query: vi.fn((...args: unknown[]) => args),
+  orderBy: vi.fn((field: string) => `order-by:${field}`),
+  where: (...args: unknown[]) => where(args[0] as string, args[1] as string, args[2]),
+  onSnapshot,
+}));
+
+vi.mock("firebase/auth", () => ({ onAuthStateChanged }));
+vi.mock("@/lib/firebase/client", () => ({ auth: {}, db: {} }));
+
+const { useBlockedItemIds, useMasterData } = await import("@/lib/master-data/use-master-data");
+
+function docOf(id: string, data: unknown) {
+  return { id, data: () => data };
+}
+
+/** The subscription waits for Firebase Auth, so tests have to announce a signed-in user first. */
+function signIn() {
+  act(() =>
+    (onAuthStateChanged.mock.calls.at(-1)![1] as (user: unknown) => void)({ uid: "uid-1" }),
+  );
+}
+
+function emit(docs: { id: string; data: () => unknown }[]) {
+  act(() => (onSnapshot.mock.calls.at(-1)![1] as SnapshotHandler)({ docs }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  onSnapshot.mockReturnValue(() => {});
+  onAuthStateChanged.mockReturnValue(() => {});
+});
+
+describe("useMasterData", () => {
+  it("starts in the loading state", () => {
+    const { result } = renderHook(() => useMasterData("classes"));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.items).toEqual([]);
+  });
+
+  it("reads the collection its category names", () => {
+    renderHook(() => useMasterData("skill-levels"));
+    signIn();
+
+    expect(collection).toHaveBeenCalledWith(expect.anything(), "skillLevels");
+  });
+
+  it("returns the items from the snapshot", async () => {
+    const { result } = renderHook(() => useMasterData("classes"));
+    signIn();
+
+    emit([docOf("c1", { name: "3AHIT" })]);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toEqual([{ id: "c1", name: "3AHIT" }]);
+  });
+
+  it("drops a malformed document instead of failing the whole list", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => useMasterData("classes"));
+    signIn();
+
+    emit([docOf("c1", { name: "   " }), docOf("c2", { name: "4BHIT" })]);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toEqual([{ id: "c2", name: "4BHIT" }]);
+  });
+
+  it("scopes a nested list to its parent", () => {
+    renderHook(() => useMasterData("required-equipment", "ski"));
+    signIn();
+
+    expect(where).toHaveBeenCalledWith("programId", "==", "ski");
+  });
+
+  it("does not filter a flat list by a parent", () => {
+    renderHook(() => useMasterData("classes"));
+    signIn();
+
+    expect(where).not.toHaveBeenCalled();
+  });
+});
+
+describe("useBlockedItemIds", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function stubFetch(implementation: (...args: unknown[]) => unknown) {
+    const fetchMock = vi.fn(implementation);
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("asks the handler for the category it was given", async () => {
+    const fetchMock = stubFetch(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ blockedIds: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    renderHook(() => useBlockedItemIds("food-options"));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/master-data/food-options"));
+  });
+
+  it("returns the blocked ids", async () => {
+    stubFetch(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ blockedIds: ["c1", "c2"] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useBlockedItemIds("classes"));
+
+    await waitFor(() => expect(result.current).toEqual(new Set(["c1", "c2"])));
+  });
+
+  it("blocks nothing when the handler refuses, since the server re-checks every write", async () => {
+    stubFetch(() => Promise.resolve(new Response(null, { status: 403 })));
+
+    const { result } = renderHook(() => useBlockedItemIds("classes"));
+
+    await waitFor(() => expect(result.current).toEqual(new Set()));
+  });
+
+  it("survives a failed request", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    stubFetch(() => Promise.reject(new Error("offline")));
+
+    const { result } = renderHook(() => useBlockedItemIds("classes"));
+
+    await waitFor(() => expect(result.current).toEqual(new Set()));
+  });
+});

--- a/src/lib/master-data/use-master-data.ts
+++ b/src/lib/master-data/use-master-data.ts
@@ -6,14 +6,19 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { collection, orderBy, query, where } from "firebase/firestore";
+import { collection, doc, onSnapshot, orderBy, query } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
 import { subscribeWithRecovery } from "@/lib/firebase/live-query";
-import { namedListItemSchema, type NamedListItem } from "@/lib/schemas/master-data";
+import {
+  namedListItemSchema,
+  programSchema,
+  type NamedListItem,
+  type Program,
+} from "@/lib/schemas/master-data";
 import { categoryOf, type MasterDataCategoryKey } from "./categories";
 
 /** Real-time read straight from the client SDK, governed by Security Rules. */
-export function useMasterData(key: MasterDataCategoryKey, parentId?: string) {
+export function useMasterData(key: MasterDataCategoryKey) {
   const [items, setItems] = useState<NamedListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -23,12 +28,7 @@ export function useMasterData(key: MasterDataCategoryKey, parentId?: string) {
 
     return subscribeWithRecovery<NamedListItem>({
       label: category.collection,
-      buildQuery: () => {
-        const items = collection(db, category.collection);
-        return category.parentField === undefined
-          ? query(items, orderBy("name"))
-          : query(items, where(category.parentField, "==", parentId ?? ""), orderBy("name"));
-      },
+      buildQuery: () => query(collection(db, category.collection), orderBy("name")),
       parse: (id, data) => {
         const parsed = namedListItemSchema.safeParse({ id, ...data });
         if (!parsed.success) {
@@ -46,19 +46,59 @@ export function useMasterData(key: MasterDataCategoryKey, parentId?: string) {
         if (message !== null) setLoading(false);
       },
     });
-  }, [key, parentId]);
+  }, [key]);
 
   return { items, loading, error };
 }
 
+/** One program, including the equipment list it carries (US-5). */
+export function useProgram(programId: string) {
+  const [program, setProgram] = useState<Program | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const category = categoryOf("programs");
+
+    return onSnapshot(
+      doc(db, category.collection, programId),
+      (snapshot) => {
+        const parsed = programSchema.safeParse({ id: snapshot.id, ...snapshot.data() });
+        if (!snapshot.exists() || !parsed.success) {
+          setProgram(null);
+        } else {
+          setProgram(parsed.data);
+        }
+        setLoading(false);
+        setError(null);
+      },
+      (caught) => {
+        console.error(`Failed to read program ${programId}:`, caught);
+        setError(caught.message);
+        setLoading(false);
+      },
+    );
+  }, [programId]);
+
+  return { program, loading, error };
+}
+
+export type UsageReport = {
+  blockedIds: Set<string>;
+  /** Per item id, the entries of its equipment list a student still rents, spelled as stored. */
+  blockedEquipment: Record<string, string[]>;
+};
+
+const NOTHING_BLOCKED: UsageReport = { blockedIds: new Set(), blockedEquipment: {} };
+
 /**
- * The items the in-use guard blocks (US-5 to US-10). The answer is derived from student master
- * data, which no client may read (see firestore.rules), so it comes from a teacher-guarded
- * handler rather than a subscription. Fetching once is enough: it only moves when a student
- * edits their master data, which cannot happen from this view.
+ * What the in-use guard blocks (US-5 to US-10). The answer is derived from student master data,
+ * which no client may read (see firestore.rules), so it comes from a teacher-guarded handler
+ * rather than a subscription. Fetching once is enough: it only moves when a student edits their
+ * master data, which cannot happen from this view.
  */
-export function useBlockedItemIds(key: MasterDataCategoryKey) {
-  const [blockedIds, setBlockedIds] = useState<Set<string>>(new Set());
+export function useUsageReport(key: MasterDataCategoryKey): UsageReport {
+  const [report, setReport] = useState<UsageReport>(NOTHING_BLOCKED);
 
   useEffect(() => {
     let active = true;
@@ -69,7 +109,15 @@ export function useBlockedItemIds(key: MasterDataCategoryKey) {
         if (!response.ok) return;
 
         const body = await response.json();
-        if (active && Array.isArray(body?.blockedIds)) setBlockedIds(new Set(body.blockedIds));
+        if (!active) return;
+
+        setReport({
+          blockedIds: new Set(Array.isArray(body?.blockedIds) ? body.blockedIds : []),
+          blockedEquipment:
+            body?.blockedEquipment && typeof body.blockedEquipment === "object"
+              ? body.blockedEquipment
+              : {},
+        });
       } catch (error) {
         // A missing answer only costs the disabled state; the server re-checks on every write.
         console.error(`Failed to read ${key} usage:`, error);
@@ -82,5 +130,5 @@ export function useBlockedItemIds(key: MasterDataCategoryKey) {
     };
   }, [key]);
 
-  return blockedIds;
+  return report;
 }

--- a/src/lib/master-data/use-master-data.ts
+++ b/src/lib/master-data/use-master-data.ts
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import { collection, orderBy, query, where } from "firebase/firestore";
+import { db } from "@/lib/firebase/client";
+import { subscribeWithRecovery } from "@/lib/firebase/live-query";
+import { namedListItemSchema, type NamedListItem } from "@/lib/schemas/master-data";
+import { categoryOf, type MasterDataCategoryKey } from "./categories";
+
+/** Real-time read straight from the client SDK, governed by Security Rules. */
+export function useMasterData(key: MasterDataCategoryKey, parentId?: string) {
+  const [items, setItems] = useState<NamedListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const category = categoryOf(key);
+
+    return subscribeWithRecovery<NamedListItem>({
+      label: category.collection,
+      buildQuery: () => {
+        const items = collection(db, category.collection);
+        return category.parentField === undefined
+          ? query(items, orderBy("name"))
+          : query(items, where(category.parentField, "==", parentId ?? ""), orderBy("name"));
+      },
+      parse: (id, data) => {
+        const parsed = namedListItemSchema.safeParse({ id, ...data });
+        if (!parsed.success) {
+          console.error(`${category.collection}/${id} does not match the schema`, parsed.error);
+          return null;
+        }
+        return parsed.data;
+      },
+      onData: (received) => {
+        setItems(received);
+        setLoading(false);
+      },
+      onError: (message) => {
+        setError(message);
+        if (message !== null) setLoading(false);
+      },
+    });
+  }, [key, parentId]);
+
+  return { items, loading, error };
+}
+
+/**
+ * The items the in-use guard blocks (US-5 to US-10). The answer is derived from student master
+ * data, which no client may read (see firestore.rules), so it comes from a teacher-guarded
+ * handler rather than a subscription. Fetching once is enough: it only moves when a student
+ * edits their master data, which cannot happen from this view.
+ */
+export function useBlockedItemIds(key: MasterDataCategoryKey) {
+  const [blockedIds, setBlockedIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        const response = await fetch(`/api/master-data/${key}`);
+        if (!response.ok) return;
+
+        const body = await response.json();
+        if (active && Array.isArray(body?.blockedIds)) setBlockedIds(new Set(body.blockedIds));
+      } catch (error) {
+        // A missing answer only costs the disabled state; the server re-checks on every write.
+        console.error(`Failed to read ${key} usage:`, error);
+      }
+    }
+
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [key]);
+
+  return blockedIds;
+}

--- a/src/lib/master-data/use-master-data.ts
+++ b/src/lib/master-data/use-master-data.ts
@@ -6,9 +6,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { collection, doc, onSnapshot, orderBy, query } from "firebase/firestore";
+import { collection, doc, onSnapshot, query } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
 import { subscribeWithRecovery } from "@/lib/firebase/live-query";
+import { byPosition } from "@/lib/schemas/position";
 import {
   namedListItemSchema,
   programSchema,
@@ -28,7 +29,9 @@ export function useMasterData(key: MasterDataCategoryKey) {
 
     return subscribeWithRecovery<NamedListItem>({
       label: category.collection,
-      buildQuery: () => query(collection(db, category.collection), orderBy("name")),
+      // Sorted here rather than in the query: Firestore's orderBy silently omits documents that
+      // lack the field, which would hide any item stored before ordering existed.
+      buildQuery: () => query(collection(db, category.collection)),
       parse: (id, data) => {
         const parsed = namedListItemSchema.safeParse({ id, ...data });
         if (!parsed.success) {
@@ -38,7 +41,7 @@ export function useMasterData(key: MasterDataCategoryKey) {
         return parsed.data;
       },
       onData: (received) => {
-        setItems(received);
+        setItems([...received].sort(byPosition));
         setLoading(false);
       },
       onError: (message) => {

--- a/src/lib/schemas/collections.test.ts
+++ b/src/lib/schemas/collections.test.ts
@@ -27,6 +27,9 @@ describe("COLLECTIONS", () => {
         // Not an entity of its own: one document per claimed name, which is how uniqueness
         // is enforced (US-4 to US-10). See lib/firebase/unique-name.ts.
         "reservedNames",
+        // Likewise bookkeeping: which defaults have already been seeded, so one a teacher
+        // deleted is never brought back (US-5, US-7 to US-10).
+        "seedState",
       ].sort(),
     );
   });

--- a/src/lib/schemas/collections.test.ts
+++ b/src/lib/schemas/collections.test.ts
@@ -14,7 +14,6 @@ describe("COLLECTIONS", () => {
         "seasons",
         "events",
         "programs",
-        "requiredEquipmentItems",
         "classOptions",
         "skillLevels",
         "busPickupPoints",

--- a/src/lib/schemas/collections.ts
+++ b/src/lib/schemas/collections.ts
@@ -9,7 +9,6 @@ export const COLLECTIONS = {
   seasons: "seasons",
   events: "events",
   programs: "programs",
-  requiredEquipmentItems: "requiredEquipmentItems",
   classOptions: "classOptions",
   skillLevels: "skillLevels",
   busPickupPoints: "busPickupPoints",

--- a/src/lib/schemas/collections.ts
+++ b/src/lib/schemas/collections.ts
@@ -21,6 +21,8 @@ export const COLLECTIONS = {
   savedReportFilters: "savedReportFilters",
   /** Name reservations: the document id is the name, which is how uniqueness is enforced. */
   reservedNames: "reservedNames",
+  /** Which defaults have already been seeded, so a deleted one is never resurrected. */
+  seedState: "seedState",
 } as const;
 
 export type CollectionName = (typeof COLLECTIONS)[keyof typeof COLLECTIONS];

--- a/src/lib/schemas/master-data.test.ts
+++ b/src/lib/schemas/master-data.test.ts
@@ -11,7 +11,7 @@ import {
   FOOD_OPTION_OTHER_LABEL,
   foodOptionSchema,
   programSchema,
-  requiredEquipmentItemSchema,
+  requiredEquipmentSchema,
   seasonPassOptionSchema,
   skillLevelSchema,
 } from "@/lib/schemas/master-data";
@@ -22,7 +22,6 @@ const NAMED_LIST_SCHEMAS = [
   ["busPickupPoint", busPickupPointSchema],
   ["foodOption", foodOptionSchema],
   ["seasonPassOption", seasonPassOptionSchema],
-  ["program", programSchema],
 ] as const;
 
 describe.each(NAMED_LIST_SCHEMAS)("%s schema", (_name, schema) => {
@@ -39,17 +38,47 @@ describe.each(NAMED_LIST_SCHEMAS)("%s schema", (_name, schema) => {
   });
 });
 
-describe("requiredEquipmentItemSchema", () => {
-  const validItem = { id: "equip-1", programId: "program-1", name: "Skischuhe" };
-
-  it("parses a valid required equipment item", () => {
-    expect(requiredEquipmentItemSchema.parse(validItem)).toEqual(validItem);
+describe("requiredEquipmentSchema", () => {
+  it("accepts a list of names", () => {
+    expect(requiredEquipmentSchema.parse(["Ski", "Helm"])).toEqual(["Ski", "Helm"]);
   });
 
-  it("belongs to a program via a genuine foreign key", () => {
-    expect(requiredEquipmentItemSchema.safeParse({ ...validItem, programId: "" }).success).toBe(
-      false,
-    );
+  it("accepts an empty list, which is what Alternativ needs", () => {
+    expect(requiredEquipmentSchema.parse([])).toEqual([]);
+  });
+
+  it("trims each name", () => {
+    expect(requiredEquipmentSchema.parse(["  Helm  "])).toEqual(["Helm"]);
+  });
+
+  it("rejects a blank entry", () => {
+    expect(requiredEquipmentSchema.safeParse(["Helm", "   "]).success).toBe(false);
+  });
+
+  it("rejects a duplicate within the same program, ignoring case and surrounding space", () => {
+    expect(requiredEquipmentSchema.safeParse(["Helm", " helm "]).success).toBe(false);
+  });
+});
+
+describe("programSchema", () => {
+  it("carries its required equipment rather than pointing at records of its own", () => {
+    expect(programSchema.parse({ id: "p1", name: "Ski", requiredEquipment: ["Helm"] })).toEqual({
+      id: "p1",
+      name: "Ski",
+      requiredEquipment: ["Helm"],
+    });
+  });
+
+  it("treats a program stored before the field existed as requiring nothing", () => {
+    expect(programSchema.parse({ id: "p1", name: "Alternativ" })).toEqual({
+      id: "p1",
+      name: "Alternativ",
+      requiredEquipment: [],
+    });
+  });
+
+  it("requires a non-empty name", () => {
+    expect(programSchema.safeParse({ id: "p1", name: "  " }).success).toBe(false);
   });
 });
 

--- a/src/lib/schemas/master-data.test.ts
+++ b/src/lib/schemas/master-data.test.ts
@@ -8,6 +8,7 @@ import {
   busPickupPointSchema,
   classOptionSchema,
   FOOD_OPTION_OTHER,
+  FOOD_OPTION_OTHER_LABEL,
   foodOptionSchema,
   programSchema,
   requiredEquipmentItemSchema,
@@ -55,5 +56,10 @@ describe("requiredEquipmentItemSchema", () => {
 describe("FOOD_OPTION_OTHER", () => {
   it("is a stable sentinel rather than teacher-editable display text", () => {
     expect(FOOD_OPTION_OTHER).toBe("other");
+  });
+
+  it("is shown to the user under a German label, which is not the stored value", () => {
+    expect(FOOD_OPTION_OTHER_LABEL).toBe("Sonstiges");
+    expect(FOOD_OPTION_OTHER_LABEL).not.toBe(FOOD_OPTION_OTHER);
   });
 });

--- a/src/lib/schemas/master-data.test.ts
+++ b/src/lib/schemas/master-data.test.ts
@@ -25,8 +25,16 @@ const NAMED_LIST_SCHEMAS = [
 ] as const;
 
 describe.each(NAMED_LIST_SCHEMAS)("%s schema", (_name, schema) => {
-  it("parses an item with an id and a name", () => {
-    expect(schema.parse({ id: "item-1", name: "Ski" })).toEqual({ id: "item-1", name: "Ski" });
+  it("parses an item with an id, a name and its place in the order", () => {
+    expect(schema.parse({ id: "item-1", name: "Ski", position: 2 })).toEqual({
+      id: "item-1",
+      name: "Ski",
+      position: 2,
+    });
+  });
+
+  it("sorts an item stored before ordering existed to the end, not the top", () => {
+    expect(schema.parse({ id: "item-1", name: "Ski" }).position).toBe(Number.MAX_SAFE_INTEGER);
   });
 
   it("requires a non-empty name", () => {
@@ -62,17 +70,21 @@ describe("requiredEquipmentSchema", () => {
 
 describe("programSchema", () => {
   it("carries its required equipment rather than pointing at records of its own", () => {
-    expect(programSchema.parse({ id: "p1", name: "Ski", requiredEquipment: ["Helm"] })).toEqual({
+    expect(
+      programSchema.parse({ id: "p1", name: "Ski", position: 0, requiredEquipment: ["Helm"] }),
+    ).toEqual({
       id: "p1",
       name: "Ski",
+      position: 0,
       requiredEquipment: ["Helm"],
     });
   });
 
   it("treats a program stored before the field existed as requiring nothing", () => {
-    expect(programSchema.parse({ id: "p1", name: "Alternativ" })).toEqual({
+    expect(programSchema.parse({ id: "p1", name: "Alternativ", position: 0 })).toEqual({
       id: "p1",
       name: "Alternativ",
+      position: 0,
       requiredEquipment: [],
     });
   });

--- a/src/lib/schemas/master-data.ts
+++ b/src/lib/schemas/master-data.ts
@@ -18,14 +18,25 @@ export const skillLevelSchema = namedListItemSchema;
 export const busPickupPointSchema = namedListItemSchema;
 export const foodOptionSchema = namedListItemSchema;
 export const seasonPassOptionSchema = namedListItemSchema;
-export const programSchema = namedListItemSchema;
 
-export const requiredEquipmentItemSchema = z.object({
-  id: documentIdSchema,
-  programId: documentIdSchema,
-  name: requiredText(120),
+/**
+ * Required equipment lives on the program rather than in records of its own (US-5): an item has
+ * no identity outside the program that requires it, and nothing references one. Holding the list
+ * in a single field is also what makes uniqueness checkable without a query — the whole list is
+ * right there, and rewriting it is one atomic change.
+ */
+export const requiredEquipmentSchema = z
+  .array(requiredText(120))
+  .max(50, "Höchstens 50 Einträge.")
+  .refine((names) => {
+    const normalized = names.map((name) => name.trim().toLocaleLowerCase("de-AT"));
+    return new Set(normalized).size === normalized.length;
+  }, "Jeder Ausrüstungsgegenstand darf nur einmal vorkommen.");
+
+export const programSchema = namedListItemSchema.extend({
+  requiredEquipment: requiredEquipmentSchema.default([]),
 });
-export type RequiredEquipmentItem = z.infer<typeof requiredEquipmentItemSchema>;
+export type Program = z.infer<typeof programSchema>;
 
 /** Always offered to students and not editable by teachers, so it is never a foodOptions row (US-9). */
 export const FOOD_OPTION_OTHER = "other";

--- a/src/lib/schemas/master-data.ts
+++ b/src/lib/schemas/master-data.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { documentIdSchema, requiredText } from "./common";
 
 /** Every teacher-maintained list (US-5 to US-10) shares this shape. */
-const namedListItemSchema = z.object({
+export const namedListItemSchema = z.object({
   id: documentIdSchema,
   name: requiredText(120),
 });
@@ -29,3 +29,6 @@ export type RequiredEquipmentItem = z.infer<typeof requiredEquipmentItemSchema>;
 
 /** Always offered to students and not editable by teachers, so it is never a foodOptions row (US-9). */
 export const FOOD_OPTION_OTHER = "other";
+
+/** What that sentinel is called in the UI — kept apart so display text never becomes the value. */
+export const FOOD_OPTION_OTHER_LABEL = "Sonstiges";

--- a/src/lib/schemas/master-data.ts
+++ b/src/lib/schemas/master-data.ts
@@ -5,11 +5,13 @@
  */
 import { z } from "zod";
 import { documentIdSchema, requiredText } from "./common";
+import { positionSchema } from "./position";
 
 /** Every teacher-maintained list (US-5 to US-10) shares this shape. */
 export const namedListItemSchema = z.object({
   id: documentIdSchema,
   name: requiredText(120),
+  position: positionSchema,
 });
 export type NamedListItem = z.infer<typeof namedListItemSchema>;
 

--- a/src/lib/schemas/order.ts
+++ b/src/lib/schemas/order.ts
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { z } from "zod";
+import { documentIdSchema } from "@/lib/schemas/common";
+
+/** The ids of an ordered list, in the order the teacher dropped them into (see Ordering). */
+export const orderSchema = z.array(documentIdSchema).max(500, "Zu viele Einträge.");

--- a/src/lib/schemas/position.test.ts
+++ b/src/lib/schemas/position.test.ts
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { describe, expect, it } from "vitest";
+import { applyVisibleOrder, byPosition, positionSchema } from "./position";
+
+describe("positionSchema", () => {
+  it("accepts a whole number", () => {
+    expect(positionSchema.parse(3)).toBe(3);
+  });
+
+  it("treats a record stored before ordering existed as unplaced", () => {
+    expect(positionSchema.parse(undefined)).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("rejects a fractional position, so ties cannot be introduced by halving", () => {
+    expect(positionSchema.safeParse(1.5).success).toBe(false);
+  });
+
+  it("rejects a negative position", () => {
+    expect(positionSchema.safeParse(-1).success).toBe(false);
+  });
+});
+
+describe("byPosition", () => {
+  it("orders by position, not by name", () => {
+    const items = [
+      { id: "c", name: "Anton", position: 2 },
+      { id: "a", name: "Zoe", position: 0 },
+      { id: "b", name: "Mia", position: 1 },
+    ];
+
+    expect([...items].sort(byPosition).map((item) => item.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("puts unplaced items last, so a list predating ordering still shows every item", () => {
+    const items = [
+      { id: "old", name: "Anton", position: Number.MAX_SAFE_INTEGER },
+      { id: "new", name: "Zoe", position: 0 },
+    ];
+
+    expect([...items].sort(byPosition).map((item) => item.id)).toEqual(["new", "old"]);
+  });
+
+  it("falls back to the name when positions tie, so the order is never arbitrary", () => {
+    const items = [
+      { id: "b", name: "Zoe", position: 0 },
+      { id: "a", name: "Anton", position: 0 },
+    ];
+
+    expect([...items].sort(byPosition).map((item) => item.id)).toEqual(["a", "b"]);
+  });
+
+  it("compares names the German way, so umlauts sort where a reader expects", () => {
+    const items = [
+      { id: "z", name: "Zell", position: 0 },
+      { id: "o", name: "Öhler", position: 0 },
+      { id: "a", name: "Anton", position: 0 },
+    ];
+
+    expect([...items].sort(byPosition).map((item) => item.id)).toEqual(["a", "o", "z"]);
+  });
+});
+
+describe("applyVisibleOrder", () => {
+  it("returns the new order unchanged when everything is visible", () => {
+    expect(applyVisibleOrder(["a", "b", "c"], ["c", "a", "b"])).toEqual(["c", "a", "b"]);
+  });
+
+  it("leaves a hidden item in its own slot", () => {
+    // "hidden" sits second and stays second; the visible pair swaps around it.
+    expect(applyVisibleOrder(["a", "hidden", "b"], ["b", "a"])).toEqual(["b", "hidden", "a"]);
+  });
+
+  it("keeps several hidden items where they were", () => {
+    expect(applyVisibleOrder(["h1", "a", "h2", "b", "c"], ["c", "b", "a"])).toEqual([
+      "h1",
+      "c",
+      "h2",
+      "b",
+      "a",
+    ]);
+  });
+
+  it("changes nothing when nothing is visible", () => {
+    expect(applyVisibleOrder(["a", "b"], [])).toEqual(["a", "b"]);
+  });
+});

--- a/src/lib/schemas/position.ts
+++ b/src/lib/schemas/position.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { z } from "zod";
+
+/**
+ * Where an item sits in the order its teacher chose (see Ordering). Alphabetical would be a
+ * guess at intent — skill levels are ranked, pickup points follow the bus route.
+ *
+ * A record written before ordering existed has no position at all, and sorts last rather than
+ * first: a missing value must not silently jump an item to the top of someone's list.
+ */
+export const positionSchema = z.number().int().nonnegative().default(Number.MAX_SAFE_INTEGER);
+
+const collator = new Intl.Collator("de-AT");
+
+type Positioned = { name: string; position: number };
+
+/** Ties break by name so the order stays stable rather than following document id. */
+export function byPosition(a: Positioned, b: Positioned): number {
+  return a.position - b.position || collator.compare(a.name, b.name);
+}
+
+/**
+ * Folds an order made on a filtered list back into the full one.
+ *
+ * The season list can hide archived seasons, so a teacher may reorder only part of it. Sending
+ * just the visible ids would push everything hidden to the end; instead the reordered items are
+ * dealt back into the slots the visible items already occupied, leaving the hidden ones where
+ * they were.
+ */
+export function applyVisibleOrder(
+  allIds: readonly string[],
+  visibleOrderedIds: readonly string[],
+): string[] {
+  const visible = new Set(visibleOrderedIds);
+  let next = 0;
+
+  return allIds.map((id) => (visible.has(id) ? visibleOrderedIds[next++] : id));
+}

--- a/src/lib/schemas/season.test.ts
+++ b/src/lib/schemas/season.test.ts
@@ -12,8 +12,9 @@ const validSeason = {
   isActive: true,
   isArchived: false,
   hasStudentData: false,
+  position: 0,
 };
-const validEvent = { id: "event-1", seasonId: "season-1", name: "Montafon" };
+const validEvent = { id: "event-1", seasonId: "season-1", name: "Montafon", position: 0 };
 
 describe("seasonSchema", () => {
   it("parses a valid season", () => {
@@ -30,7 +31,7 @@ describe("seasonSchema", () => {
 
   it("carries no third state field, since the displayed state is derived", () => {
     expect(Object.keys(seasonSchema.shape).sort()).toEqual(
-      ["id", "isActive", "isArchived", "hasStudentData", "name"].sort(),
+      ["id", "isActive", "isArchived", "hasStudentData", "name", "position"].sort(),
     );
   });
 });

--- a/src/lib/schemas/season.ts
+++ b/src/lib/schemas/season.ts
@@ -5,6 +5,7 @@
  */
 import { z } from "zod";
 import { documentIdSchema, requiredText } from "./common";
+import { positionSchema } from "./position";
 
 // The displayed state (active / archived / inactive) is derived from these two flags, never stored.
 export const seasonSchema = z.object({
@@ -15,6 +16,7 @@ export const seasonSchema = z.object({
   // Denormalized from studentMasterData so clients — who cannot read that collection directly
   // (see firestore.rules) — can tell whether archiving/deleting is allowed without a round trip.
   hasStudentData: z.boolean(),
+  position: positionSchema,
 });
 export type Season = z.infer<typeof seasonSchema>;
 
@@ -22,5 +24,6 @@ export const eventSchema = z.object({
   id: documentIdSchema,
   seasonId: documentIdSchema,
   name: requiredText(120),
+  position: positionSchema,
 });
 export type Event = z.infer<typeof eventSchema>;

--- a/src/lib/schemas/student-master-data.test.ts
+++ b/src/lib/schemas/student-master-data.test.ts
@@ -23,7 +23,7 @@ const validRecord = {
   busPickupPoint: "HTL Dornbirn",
   foodOption: "Vegetarisch",
   foodOtherText: null,
-  seasonPassOption: "Nein",
+  seasonPassOption: "Keine",
   dateOfBirth: "2008-05-04",
   gender: "female",
   phoneNumber: "+436601234567",

--- a/src/lib/seasons/season-service.test.ts
+++ b/src/lib/seasons/season-service.test.ts
@@ -24,6 +24,7 @@ function seedSeason(id: string, overrides: Record<string, unknown> = {}) {
     isActive: false,
     isArchived: false,
     hasStudentData: false,
+    position: 0,
     ...overrides,
   };
   firestore.seed("seasons", id, season);
@@ -43,6 +44,7 @@ describe("createSeason", () => {
       isActive: false,
       isArchived: false,
       hasStudentData: false,
+      position: 0,
     });
   });
 
@@ -103,6 +105,7 @@ describe("updateSeason", () => {
       isActive: true,
       isArchived: false,
       hasStudentData: false,
+      position: 0,
     });
   });
 });

--- a/src/lib/seasons/season-service.test.ts
+++ b/src/lib/seasons/season-service.test.ts
@@ -55,6 +55,18 @@ describe("createSeason", () => {
     expect(season.id).toBeTruthy();
   });
 
+  // The position is one number, so it must not cost a download of every season.
+  it("counts the existing seasons rather than downloading them", async () => {
+    seedSeason("s1", { position: 0 });
+    seedSeason("s2", { position: 1 });
+    firestore.queryDocumentsRead = 0;
+
+    const season = await createSeason({ name: "Wintersportwoche 2026" });
+
+    expect(firestore.get("seasons", season.id)).toMatchObject({ position: 2 });
+    expect(firestore.queryDocumentsRead).toBe(0);
+  });
+
   it("trims the name", async () => {
     const season = await createSeason({ name: "  Sommersportwoche  " });
 

--- a/src/lib/seasons/season-service.ts
+++ b/src/lib/seasons/season-service.ts
@@ -34,7 +34,7 @@ export async function createSeason(input: { name: string }): Promise<Season> {
   const name = parseName(input.name);
 
   // A new season goes to the end of the teacher's order (see Ordering).
-  const position = (await adminDb.collection(COLLECTIONS.seasons).get()).size;
+  const position = (await adminDb.collection(COLLECTIONS.seasons).count().get()).data().count;
 
   // The reservation is what makes the name unique; it shares the transaction with the
   // record, so a rejected name leaves nothing behind (US-4).

--- a/src/lib/seasons/season-service.ts
+++ b/src/lib/seasons/season-service.ts
@@ -6,6 +6,7 @@
 import "server-only";
 import { adminDb } from "@/lib/firebase/admin";
 import { commitInChunks, type BatchOperation } from "@/lib/firebase/batch";
+import { reorderCollection } from "@/lib/firebase/reorder";
 import { releaseName, reservationRef, reserveName, scopeOf } from "@/lib/firebase/unique-name";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
@@ -32,6 +33,9 @@ function seasonDoc(id: string) {
 export async function createSeason(input: { name: string }): Promise<Season> {
   const name = parseName(input.name);
 
+  // A new season goes to the end of the teacher's order (see Ordering).
+  const position = (await adminDb.collection(COLLECTIONS.seasons).get()).size;
+
   // The reservation is what makes the name unique; it shares the transaction with the
   // record, so a rejected name leaves nothing behind (US-4).
   return adminDb.runTransaction(async (transaction) => {
@@ -42,10 +46,15 @@ export async function createSeason(input: { name: string }): Promise<Season> {
       ownerId: reference.id,
     });
 
-    const data = { name, isActive: false, isArchived: false, hasStudentData: false };
+    const data = { name, isActive: false, isArchived: false, hasStudentData: false, position };
     transaction.set(reference, data);
     return { id: reference.id, ...data };
   });
+}
+
+/** Ordering touches no name or flag, so it needs none of the guards the other writes carry. */
+export async function reorderSeasons(orderedIds: readonly string[]): Promise<void> {
+  await reorderCollection({ collection: COLLECTIONS.seasons, orderedIds });
 }
 
 export type SeasonUpdate = {
@@ -135,7 +144,14 @@ export async function updateSeason(id: string, update: SeasonUpdate): Promise<Se
       releaseName(transaction, { scope: scopeOf(COLLECTIONS.seasons), name: current.name });
     }
 
-    const next = { name: name ?? current.name, isActive, isArchived, hasStudentData };
+    // `set` replaces the document, so the teacher's ordering has to be carried across.
+    const next = {
+      name: name ?? current.name,
+      isActive,
+      isArchived,
+      hasStudentData,
+      position: current.position,
+    };
     transaction.set(reference, next);
     for (const doc of previouslyActive) transaction.update(doc.ref, { isActive: false });
 

--- a/src/lib/seasons/use-seasons.test.ts
+++ b/src/lib/seasons/use-seasons.test.ts
@@ -33,6 +33,7 @@ const validSeason = {
   isActive: true,
   isArchived: false,
   hasStudentData: false,
+  position: 0,
 };
 
 /** The hook waits for Firebase Auth, so tests have to announce a signed-in user first. */

--- a/src/lib/seasons/use-seasons.ts
+++ b/src/lib/seasons/use-seasons.ts
@@ -6,10 +6,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { collection, orderBy, query } from "firebase/firestore";
+import { collection, query } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
 import { subscribeWithRecovery } from "@/lib/firebase/live-query";
 import { COLLECTIONS } from "@/lib/schemas/collections";
+import { byPosition } from "@/lib/schemas/position";
 import { seasonSchema, type Season } from "@/lib/schemas/season";
 
 /** Real-time read straight from the client SDK, governed by Security Rules. */
@@ -22,7 +23,9 @@ export function useSeasons() {
     () =>
       subscribeWithRecovery<Season>({
         label: "seasons",
-        buildQuery: () => query(collection(db, COLLECTIONS.seasons), orderBy("name", "desc")),
+        // Sorted here rather than in the query: Firestore's orderBy silently omits documents
+        // that lack the field, which would hide any season stored before ordering existed.
+        buildQuery: () => query(collection(db, COLLECTIONS.seasons)),
         parse: (id, data) => {
           const parsed = seasonSchema.safeParse({ id, ...data });
           if (!parsed.success) {
@@ -32,7 +35,7 @@ export function useSeasons() {
           return parsed.data;
         },
         onData: (items) => {
-          setSeasons(items);
+          setSeasons([...items].sort(byPosition));
           setLoading(false);
         },
         onError: (message) => {

--- a/src/test/fake-firestore.ts
+++ b/src/test/fake-firestore.ts
@@ -84,6 +84,14 @@ export class FakeDocumentReference {
 
 type Filter = { field: string; value: unknown };
 
+export class FakeAggregateSnapshot {
+  constructor(private readonly matches: number) {}
+
+  data(): { count: number } {
+    return { count: this.matches };
+  }
+}
+
 export class FakeQuery {
   constructor(
     protected readonly firestore: FakeFirestore,
@@ -106,6 +114,14 @@ export class FakeQuery {
 
   limit(count: number): FakeQuery {
     return new FakeQuery(this.firestore, this.collectionPath, this.filters, count);
+  }
+
+  /** Aggregates server-side, so the documents themselves never cross the wire. */
+  count(): { get(): Promise<FakeAggregateSnapshot> } {
+    return {
+      get: async () =>
+        new FakeAggregateSnapshot(this.firestore.runCount(this.collectionPath, this.filters)),
+    };
   }
 
   async get(): Promise<FakeQuerySnapshot> {
@@ -213,6 +229,9 @@ export class FakeFirestore {
   commitCount = 0;
   batchSizes: number[] = [];
 
+  /** Documents a query actually handed back, so a test can prove a read is not O(collection). */
+  queryDocumentsRead = 0;
+
   /** Runs before each transaction attempt, letting a test simulate a concurrent write. */
   onTransactionAttempt: ((attempt: number) => void) | null = null;
   transactionCount = 0;
@@ -285,14 +304,24 @@ export class FakeFirestore {
     filters: Filter[],
     limitCount: number | null,
   ): FakeQuerySnapshot {
-    const matches = [...this.collectionMap(collectionPath).entries()]
-      .filter(([, data]) => filters.every((filter) => data[filter.field] === filter.value))
-      .map(
-        ([id, data]) =>
-          new FakeDocumentSnapshot(id, data, new FakeDocumentReference(this, collectionPath, id)),
-      );
+    const matches = this.matching(collectionPath, filters).map(
+      ([id, data]) =>
+        new FakeDocumentSnapshot(id, data, new FakeDocumentReference(this, collectionPath, id)),
+    );
 
-    return new FakeQuerySnapshot(limitCount === null ? matches : matches.slice(0, limitCount));
+    const returned = limitCount === null ? matches : matches.slice(0, limitCount);
+    this.queryDocumentsRead += returned.length;
+    return new FakeQuerySnapshot(returned);
+  }
+
+  runCount(collectionPath: string, filters: Filter[]): number {
+    return this.matching(collectionPath, filters).length;
+  }
+
+  private matching(collectionPath: string, filters: Filter[]): [string, DocumentData][] {
+    return [...this.collectionMap(collectionPath).entries()].filter(([, data]) =>
+      filters.every((filter) => data[filter.field] === filter.value),
+    );
   }
 
   seed(collectionPath: string, id: string, data: DocumentData): void {
@@ -316,6 +345,7 @@ export class FakeFirestore {
     this.idCounter = 0;
     this.commitCount = 0;
     this.batchSizes = [];
+    this.queryDocumentsRead = 0;
     this.transactionCount = 0;
     this.onTransactionAttempt = null;
   }

--- a/src/test/stub-row-layout.ts
+++ b/src/test/stub-row-layout.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { vi } from "vitest";
+
+export const ROW_HEIGHT = 40;
+
+function rectOf(top: number, height: number): DOMRect {
+  return {
+    x: 0,
+    y: top,
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 200,
+    width: 200,
+    height,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+/**
+ * Lays list rows out vertically for the duration of a test.
+ *
+ * jsdom reports a zero rect for every element, which leaves drag-and-drop unable to tell one row
+ * from the next — the keyboard sensor then moves an item to the far end instead of one step.
+ * The container has to span every row as well, or the parent-element modifier clamps each move
+ * away before it happens.
+ */
+export function stubRowLayout(): void {
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    const row = this.closest("li");
+    if (!row) return rectOf(0, Math.max(this.querySelectorAll("li").length, 1) * ROW_HEIGHT);
+
+    const siblings = row.parentElement ? [...row.parentElement.children] : [];
+    return rectOf(Math.max(siblings.indexOf(row), 0) * ROW_HEIGHT, ROW_HEIGHT);
+  });
+}

--- a/vitest.rules.config.ts
+++ b/vitest.rules.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["firestore-tests/**/*.test.ts"],
+    // Several tests here deliberately put a burst of transactions in contention, and the
+    // Admin SDK answers that by retrying with backoff — seconds of wall clock is the
+    // behaviour under test, not a hang. Vitest's 5s default left no margin at all.
+    testTimeout: 30_000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Implements milestone 4: the six teacher-maintained master data lists (US-5 to US-10), plus the ordering they turned out to need.

68 files, +4,928 / −103.

## What changed

- **One shared CRUD list.** US-5 to US-10 all ask for the same thing — a list of named items a teacher can add to, rename and remove. The six categories are configuration in one registry rendered by one view, rather than six near-identical implementations.
- **Required equipment lives on its program** as a field, not a collection. It has no identity outside the program and is referenced from nowhere, so a collection cost a foreign key, a scoped name reservation, a composite index, a cascade delete and a second rules entry, and bought nothing.
- **Teacher-defined order**, stored as a `position` per record and changed by dragging. Alphabetical order was a guess the data contradicts: skill levels are ranked, pickup points follow the bus route, and a school groups classes by year. One drag-and-drop mechanism serves the whole application, so the gesture learned here carries over to the assignment transfer lists when US-12 lands.
- **Seeded defaults** for programs, skill levels, pickup points, food options and season pass options, in the school's own German wording.

## Notable decisions

- Writes go through teacher-guarded Route Handlers because the invariants involved need a query, which Security Rules cannot run.
- The in-use guard is what makes a rename safe: master data stores a plain-text snapshot, not a reference, so renaming an item still selected by an open season would orphan every record pointing at the old text. Reordering is deliberately exempt — it changes no stored name.
- Sorting happens in the client, not in the query: Firestore's `orderBy` silently omits documents missing the field, which would have hidden every record written before `position` existed.
- Seeding records each default it has already dealt with, so a default a teacher deleted stays deleted and a renamed one keeps its name.
- Drag-and-drop is pointer-driven rather than native HTML5 DnD, which touch devices do not implement; the grip handle is always visible because hover cannot be triggered by touch; and the keyboard sensor keeps ordering from becoming a mouse-only capability.
- A drop holds its new order optimistically until the stored data agrees, and a rejected save puts it back — the write goes through the Admin SDK, so there is no local echo to compensate with.

Closes #21, #22, #23, #25, #26, #27, #28, #29, #30
