### PR TITLE
Fix the CodeQL escaping finding and scan staging too

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+# Licensed under the MIT License. See LICENSE in the repository root for details.
+#
+
+name: CodeQL
+
+# Replaces the default setup, which only ever scanned the default branch and pull requests
+# into it. With features merging into staging first, that left every feature branch unscanned
+# and the first analysis happening after the code was already deployed to staging.
+on:
+  push:
+    branches: [main, staging]
+  pull_request:
+    branches: [main, staging]
+  schedule:
+    # Keeps finding newly published problems in code that has stopped changing.
+    - cron: "27 3 * * 1"
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # `javascript-typescript` covers both languages in one analysis. `actions` scans the
+        # workflows themselves, which is what catches an expression spliced into a run block.
+        language: [actions, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          # Nothing here is compiled, so CodeQL has no build to observe.
+          build-mode: none
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/src/lib/auth/upn.test.ts
+++ b/src/lib/auth/upn.test.ts
@@ -106,6 +106,9 @@ describe("isSchoolUpn", () => {
     ["an unrelated domain", "jane.doe@gmail.com"],
     ["a lookalike domain", "jane.doe@evil-htldornbirn.at"],
     ["a suffixed domain", "jane.doe@htldornbirn.at.evil.com"],
+    // Left unescaped, the dot in the domain is a wildcard and these would pass.
+    ["a staff domain with the dot substituted", "jane.doe@htldornbirnXat"],
+    ["a student domain with the dot substituted", "jane.doe@studentXhtldornbirn.at"],
     ["a dangling hyphen", "jane-.doe@htldornbirn.at"],
     ["an empty string", ""],
   ])("rejects %s", (_case, upn) => {

--- a/src/lib/auth/upn.ts
+++ b/src/lib/auth/upn.ts
@@ -27,8 +27,9 @@ export function roleFromUpn(upn: string): UserRole | null {
 
 /** `firstname.lastname`, hyphens allowed inside either part — no digits, no other separators. */
 const NAME_PART = "[a-z]+(?:-[a-z]+)*";
-const anyDomainOf = (...domains: string[]) =>
-  `(?:${domains.map((domain) => domain.replace(/\./g, "\\.")).join("|")})`;
+/** Everything the regex grammar gives meaning to, so a domain can only ever match itself. */
+const escapeForRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const anyDomainOf = (...domains: string[]) => `(?:${domains.map(escapeForRegExp).join("|")})`;
 const SCHOOL_UPN = new RegExp(
   `^${NAME_PART}\\.${NAME_PART}@${anyDomainOf(TEACHER_DOMAIN, STUDENT_DOMAIN)}$`,
 );


### PR DESCRIPTION
Two commits that missed the #65 merge, plus the reason CodeQL stopped reporting.

## The escaping fix

CodeQL flagged `js/incomplete-sanitization` on the domain pattern helper: it escaped dots and left backslashes alone, so a domain carrying one would produce a pattern that no longer means what it says. Inert today — both domains are letters and dots — but `anyDomainOf(...domains: string[])` accepts any string, so the signature promised more than it delivered. Now uses the full metacharacter escape.

The alert on #65 was analysed at `45cbdef`, two commits before this fix, so it was stale rather than unfixed.

More usefully, **the behaviour it protects was untested**. Nothing proved the dot was matched literally, and unescaped it is a wildcard — `jane.doe@htldornbirnXat` would have passed as a staff address. The suite would have stayed green straight through the bug the escaping exists to prevent. Now covered for both domains.

## Why CodeQL went quiet

Default setup scans the default branch and pull requests **into** it. Once features started merging into `staging`, that stopped covering them — nothing would be analysed until the promotion to `main`, by which point the code has already been deployed to staging and tried out. The stale alert is what made it visible: CodeQL simply stopped running once the base branch changed.

This replaces default setup with an advanced workflow, which puts the branch list in the repository:

- `push` and `pull_request` on both `main` and `staging`
- weekly schedule, so newly published problems still surface in code that has stopped changing
- `javascript-typescript` and `actions`

The `actions` language is there deliberately, not for completeness: it is the analysis that catches a workflow expression spliced into a `run:` block, which is exactly the injection shape the promotion gate had to be written around.

Once this lands and the check names are confirmed, `CodeQL (actions)` and `CodeQL (javascript-typescript)` should become required on both branch rulesets.
