### PR TITLE
Keep showing progress until the fake login navigates

### DIFF
--- a/src/components/auth/sign-in-card.test.tsx
+++ b/src/components/auth/sign-in-card.test.tsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -29,9 +29,14 @@ vi.mock("@/lib/firebase/client", () => ({
   createMicrosoftAuthProvider: () => ({}),
 }));
 
+// Stable across renders, as the real hooks are: a fresh object each call would re-run the
+// auth-state effect on every render, which the card is not written to expect.
+const router = { push, refresh };
+const searchParams = new URLSearchParams();
+
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push, refresh }),
-  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => router,
+  useSearchParams: () => searchParams,
 }));
 
 vi.mock("next/image", () => ({
@@ -273,6 +278,26 @@ describe("SignInCard", () => {
 
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
       expect(signInWithRedirect).not.toHaveBeenCalled();
+    });
+
+    // The dialog closes the moment it has signed in, and the session still has to be created
+    // before anything navigates. Entra ID never shows that gap because it arrives by redirect,
+    // so the card is already busy on first render.
+    it("goes back to showing progress once the dialog has signed in", async () => {
+      let notify: (user: unknown) => void = () => {};
+      onAuthStateChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+        notify = callback;
+        callback(null);
+        return () => {};
+      });
+
+      render(<SignInCard mode="fake" />);
+      await waitFor(() => expect(screen.getByRole("button")).not.toBeDisabled());
+
+      await act(async () => notify(signedInUser));
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeDisabled();
     });
   });
 });

--- a/src/components/auth/sign-in-card.tsx
+++ b/src/components/auth/sign-in-card.tsx
@@ -58,6 +58,10 @@ export function SignInCard({ mode = "entra" }: { mode?: AuthMode }) {
         return;
       }
 
+      // A sign-in that happened in this page rather than by redirect leaves the card idle
+      // while the session is still being created — the fake login's dialog closes first.
+      setChecking(true);
+
       try {
         await redirectSettled;
         const idToken = await user.getIdToken();


### PR DESCRIPTION
The fake login's dialog closes as soon as it has signed in, but the session still has to be created before anything navigates. For that moment the card looked idle — no spinner, and an enabled button that would reopen the dialog on top of a sign-in already in flight.

## Why only the fake login

`checking` was only ever turned *off*. That was sufficient while Entra ID was the only way in: it arrives by redirect, so the card is already busy on its first render and simply stays that way. The fake login is the first thing that can sign a user in while the card is sitting idle, and nothing turned progress back on.

So the auth-state handler now sets `checking` when a user appears, not just when one doesn't.

## The test disagreed with the fix, and the mock was wrong

The regression test failed even with the fix applied. The cause was in the test, not the code: `useRouter` was mocked as `() => ({ push, refresh })`, handing back a **new object on every render**. That made the auth-state effect tear down and resubscribe on each state change, and the fresh subscription immediately reported a signed-out user — putting `checking` straight back to false.

The real `useRouter` and `useSearchParams` return stable references, so this never happened in the app. The mock now does the same.

Worth noting the mock was hiding a second thing: with an unstable dependency the effect really would resubscribe on every render, and Firebase calls a new listener immediately with the current user — a duplicate `/api/session` POST per render. Not reachable in production, but the mock made the component look more fragile than it is while testing a scenario that could not occur.

## Verification

I confirmed the test fails without the fix by stashing the source and re-running it, rather than trusting that a passing test proved anything.

852 tests, lint, types, Prettier and the license check all clean.
