### PR TITLE
Show the fake login's UPN as a result, not a field

### DIFF
--- a/src/components/auth/fake-sign-in-dialog.test.tsx
+++ b/src/components/auth/fake-sign-in-dialog.test.tsx
@@ -82,12 +82,25 @@ describe("FakeSignInDialog", () => {
     const { user } = renderDialog();
 
     await typeName(user, "Jürgen", "Müller");
-    expect(screen.getByLabelText("E-Mail / UPN")).toHaveValue("juergen.mueller@htldornbirn.at");
+    expect(screen.getByLabelText("E-Mail / UPN")).toHaveTextContent(
+      "juergen.mueller@htldornbirn.at",
+    );
 
     await user.click(screen.getByLabelText("Schüler:in"));
-    expect(screen.getByLabelText("E-Mail / UPN")).toHaveValue(
+    expect(screen.getByLabelText("E-Mail / UPN")).toHaveTextContent(
       "juergen.mueller@student.htldornbirn.at",
     );
+  });
+
+  // It is derived from the two names, so offering somewhere to type would invite editing it
+  // into something the tenant would never issue.
+  it("presents the UPN as a result rather than a field", async () => {
+    const { user } = renderDialog();
+
+    await typeName(user, "Jane", "Doe");
+
+    expect(screen.getByLabelText("E-Mail / UPN")).toHaveTextContent("jane.doe@htldornbirn.at");
+    expect(screen.queryByRole("textbox", { name: "E-Mail / UPN" })).not.toBeInTheDocument();
   });
 
   it("signs in with the token the server minted", async () => {

--- a/src/components/auth/fake-sign-in-dialog.tsx
+++ b/src/components/auth/fake-sign-in-dialog.tsx
@@ -184,7 +184,14 @@ export function FakeSignInDialog({ open, onClose }: { open: boolean; onClose: ()
 
         <div className="flex flex-col gap-1.5">
           <Label htmlFor={upnId}>E-Mail / UPN</Label>
-          <Input id={upnId} readOnly tabIndex={-1} value={upn ?? ""} />
+          {/* An <output>, not a read-only input: the tenant derives this from the name, so
+              there should be nowhere to put a caret and nothing to edit it into. */}
+          <output
+            id={upnId}
+            className="border-input bg-muted text-muted-foreground flex h-9 items-center rounded-lg border px-3 text-sm"
+          >
+            {upn ?? ""}
+          </output>
         </div>
 
         {submitError ? (


### PR DESCRIPTION
The UPN field was already `readOnly`, so it could not be typed into — but that stops the typing, not the impression. It rendered as a textbox identical to the two fields above it, took a caret on click, and invited an edit that would silently do nothing.

It is now an `<output>`, which is what the address actually is: derived from the name and the role, the way the tenant derives it. There is nowhere to put a caret and nothing to edit.

## On the test

The old assertion was `toHaveValue(...)` on the input. That would have passed just as well with the editing left in, because a `readOnly` input keeps the `textbox` role — it only proved the value was right, never that it was uneditable.

The test now asserts that **no textbox carries that label**, which is the property actually being asked for:

```ts
expect(screen.queryByRole("textbox", { name: "E-Mail / UPN" })).not.toBeInTheDocument();
```

Both assertions failed before the change and pass after.

## Worth knowing

`<output>` has an implicit `status` role, making it a polite live region. Screen readers will announce the address as it is derived, which is useful feedback here — you type a name and hear the account you are about to become. If that turns out to be chatty in practice it can be suppressed with `aria-live="off"`.

853 tests, lint, types, Prettier and the license check all clean.
