### PR TITLE
Rename the skill level category and its first entry

### DIFF
--- a/spec/database-erd.puml
+++ b/spec/database-erd.puml
@@ -71,7 +71,7 @@ entity "ClassOption" as classOption {
 entity "SkillLevel" as skillLevel {
   PK id : string
   --
-  name : string  ' Absoluter Anfänger, Anfänger, Fortgeschritten, Profi (US-7)
+  name : string  ' Keine Vorkenntnisse, Anfänger, Fortgeschritten, Profi (US-7)
   position : number  ' teacher-defined order — these are ranked, so alphabetical would be wrong
 }
 

--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -167,7 +167,7 @@ As a teacher, I can maintain the list of ski/snowboard skill levels so that stud
 
 - A view for maintaining the list of skill levels exists.
 - A teacher can add, edit, and remove skill levels from the list.
-- The list is pre-populated with four skill levels, shown as "Absoluter Anfänger" (complete beginner), "Anfänger" (beginner), "Fortgeschritten" (advanced), and "Profi" (expert).
+- The list is pre-populated, in this order, with four skill levels shown as "Keine Vorkenntnisse" (no prior experience), "Anfänger" (beginner), "Fortgeschritten" (advanced), and "Profi" (expert).
 - The skill level a student selects in their master data (US-11) is chosen from this maintained list.
 
 ### US-8: Teacher maintains bus pickup points

--- a/src/components/layout/teacher-nav.test.tsx
+++ b/src/components/layout/teacher-nav.test.tsx
@@ -17,7 +17,7 @@ const SUB_ITEMS = [
   "Saisonen",
   "Programme",
   "Klassen",
-  "Könnensstufen",
+  "Leistungsstufen",
   "Zustiegsstellen",
   "Verpflegung",
   "Saisonkarten",

--- a/src/components/master-data/master-data-view.test.tsx
+++ b/src/components/master-data/master-data-view.test.tsx
@@ -102,7 +102,7 @@ describe("MasterDataView — reading the list", () => {
     render(<MasterDataView category="skill-levels" />);
 
     expect(useMasterData).toHaveBeenCalledWith("skill-levels");
-    expect(screen.getByRole("heading", { name: "Könnensstufen" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Leistungsstufen" })).toBeInTheDocument();
   });
 });
 

--- a/src/lib/master-data/categories.ts
+++ b/src/lib/master-data/categories.ts
@@ -61,10 +61,10 @@ export const MASTER_DATA_CATEGORIES = {
     collection: COLLECTIONS.skillLevels,
     usage: { kind: "masterData", field: "skillLevel" },
     labels: {
-      title: "Könnensstufen",
-      singular: "Könnensstufe",
-      add: "Neue Könnensstufe",
-      empty: "Es gibt noch keine Könnensstufe.",
+      title: "Leistungsstufen",
+      singular: "Leistungsstufe",
+      add: "Neue Leistungsstufe",
+      empty: "Es gibt noch keine Leistungsstufe.",
     },
   },
   "bus-pickup-points": {

--- a/src/lib/master-data/seed-defaults.test.ts
+++ b/src/lib/master-data/seed-defaults.test.ts
@@ -56,8 +56,8 @@ describe("seedMasterDataDefaults", () => {
   it("stores the defaults with their German display text", async () => {
     await seedMasterDataDefaults();
 
-    expect(namesOf("skillLevels")).toEqual([
-      "Absoluter Anfänger",
+    expect(orderedNamesOf("skillLevels")).toEqual([
+      "Keine Vorkenntnisse",
       "Anfänger",
       "Fortgeschritten",
       "Profi",

--- a/src/lib/master-data/seed-defaults.ts
+++ b/src/lib/master-data/seed-defaults.ts
@@ -25,7 +25,7 @@ const PROGRAM_DEFAULTS = [
  * from the food options — it is always offered to students and is never a row (US-9).
  */
 const LIST_DEFAULTS: Partial<Record<MasterDataCategoryKey, readonly string[]>> = {
-  "skill-levels": ["Absoluter Anfänger", "Anfänger", "Fortgeschritten", "Profi"],
+  "skill-levels": ["Keine Vorkenntnisse", "Anfänger", "Fortgeschritten", "Profi"],
   "bus-pickup-points": ["HTL Dornbirn", "Bahnhof Bregenz", "Bahnhof Feldkirch", "Unterkunft"],
   "food-options": ["Alles", "Vegetarisch", "Vegan", "Kein Schweinefleisch"],
   "season-pass-options": [

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -19,7 +19,7 @@ export const MASTER_DATA_SECTIONS = [
   { href: "/app/master-data/seasons", label: "Saisonen" },
   { href: "/app/master-data/programs", label: "Programme" },
   { href: "/app/master-data/classes", label: "Klassen" },
-  { href: "/app/master-data/skill-levels", label: "Könnensstufen" },
+  { href: "/app/master-data/skill-levels", label: "Leistungsstufen" },
   { href: "/app/master-data/bus-pickup-points", label: "Zustiegsstellen" },
   { href: "/app/master-data/food-options", label: "Verpflegung" },
   { href: "/app/master-data/season-pass-options", label: "Saisonkarten" },


### PR DESCRIPTION
Two renames on the same list — the category itself and its first entry.

## Leistungsstufen instead of Könnensstufen

„Könnensstufe" is correct German but sits awkwardly; the Fugen-s is what makes it read as administrative rather than as something a teacher would say. „Leistungsstufe" is the vocabulary the Austrian Schulsportwoche already uses, where students are grouped by ability.

It does not collide with US-12: there the assignment produces a *Gruppe*, here a student states a *Stufe* — input and outcome keep separate words.

The route, the collection and the field stay `skill-level(s)`. Internals are English throughout, and renaming a collection for a caption would be a data migration.

## Keine Vorkenntnisse instead of Absoluter Anfänger

„Absoluter Anfänger" describes the person; the list asks what someone has done before, and the other three entries answer that. „Keine Vorkenntnisse" answers the same question, and reads as an option a student picks rather than a label they are given.

## A test that was checking nothing

The order was asserted with `namesOf`, which **sorts alphabetically**. That it matched the ranked order until now was a coincidence: `Abs` sorted before `Anf`. The assertion would have passed just as well with „Profi" seeded first.

„Keine Vorkenntnisse" sorts third and made the coincidence visible. It now asserts, via `orderedNamesOf`, the order the teacher actually sees:

```ts
expect(orderedNamesOf("skillLevels")).toEqual([
  "Keine Vorkenntnisse", "Anfänger", "Fortgeschritten", "Profi",
]);
```

Skill levels are a ranked scale — precisely the reasoning behind introducing drag ordering.

## Timing

Both Firestore databases were emptied just before this, `seedState` included. Merged **before** the next request, the list comes up with the new names directly. Otherwise the app still seeds „Absoluter Anfänger" and the new entry lands beside it as a fifth row later — as happened with „Nein"/„Keine" on the season pass options.

`spec/requirements.md` and `spec/database-erd.puml` updated to match.

852 tests, lint, types, Prettier and the license check all clean.
