### PR TITLE
Promote the fake login, staging environment and master data relabelling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Copy to .env and adjust. .env is gitignored, so nothing set there travels with the code.
+
+# Which sign-in the app offers. Normally comes from apphosting.yaml (production: `entra`) or
+# apphosting.staging.yaml (staging: `fake`), so set it here only to override locally.
+#
+# `fake` swaps Entra ID for a dialog that mints a session from a typed name and role, so the
+# app can be tried as several teachers and students without tenant accounts. It provisions
+# real Auth accounts and real user records, which is why src/lib/auth/auth-mode.ts refuses it
+# for the production project whatever this says.
+# AUTH_MODE=fake
+
+# Only needed alongside the fake login. Minting a custom token means signing a JWT, and the
+# user credential from `gcloud auth application-default login` holds no signing key, so the
+# Admin SDK signs through the IAM API instead and has to be told which account to sign as.
+# Deployments discover this from the metadata server and must leave it unset.
+#
+# Grant yourself the right to sign as it once (staging only -- never do this for production):
+#   gcloud iam service-accounts add-iam-policy-binding \
+#     firebase-adminsdk-fbsvc@htld-sportsweek-staging.iam.gserviceaccount.com \
+#     --member="user:YOUR_EMAIL" --role="roles/iam.serviceAccountTokenCreator" \
+#     --project=htld-sportsweek-staging
+FIREBASE_SERVICE_ACCOUNT_ID=firebase-adminsdk-fbsvc@htld-sportsweek-staging.iam.gserviceaccount.com

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,6 @@
 {
-    "projects": {
-        "default": "htld-sportsweek"
-    }
+  "projects": {
+    "default": "htld-sportsweek",
+    "staging": "htld-sportsweek-staging"
+  }
 }

--- a/.github/instructions/language.instructions.md
+++ b/.github/instructions/language.instructions.md
@@ -1,0 +1,61 @@
+---
+description: "Language rule for this repository — English everywhere project-side; German only where the word is a string the program actually shows."
+applyTo: "**/*"
+---
+
+<!--
+SPDX-License-Identifier: MIT
+Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+Licensed under the MIT License. See LICENSE in the repository root for details.
+-->
+
+# Language
+
+The application speaks German to its users. Everything else about it is written in English.
+
+## English, without exception
+
+Commit messages, pull request titles and descriptions, issue text, branch names, code,
+identifiers, comments, `spec/`, and these instruction files.
+
+This holds **regardless of the language the conversation is being held in**. A request made
+in German is still answered with an English commit and an English pull request. The language
+of the discussion and the language of the repository are unrelated.
+
+## German, only as a quoted program item
+
+A German word belongs in project text only when it _is_ a string the program shows — a label,
+a button caption, a validation or error message — and then it appears quoted, as the artefact
+under discussion:
+
+```text
+Renames the first skill level from "Absoluter Anfänger" to "Keine Vorkenntnisse".
+```
+
+Never as prose. The sentence around the quote stays English, and German terms do not leak
+into the explanation:
+
+```text
+Leistungsstufe is the vocabulary the Schulsportwoche uses, where students   <- no
+are grouped by ability; the assignment produces a Gruppe, not a Stufe.
+
+"Leistungsstufe" is the term already used for ability grouping on a school   <- yes
+sports week; the assignment produces a group, this field states a level.
+```
+
+## Internals stay English behind a German label
+
+Renaming what the user sees never renames what the code calls it:
+
+| Visible label   | Route          | Collection    | Field        |
+| --------------- | -------------- | ------------- | ------------ |
+| Leistungsstufen | `skill-levels` | `skillLevels` | `skillLevel` |
+
+A caption change is a caption change. Turning it into a collection rename would be a data
+migration, which is a different decision with different consequences.
+
+## Why
+
+Reviewers, tooling and search work across one language. Commit history and pull requests are
+read long after the conversation that produced them is forgotten, often by people who were
+not part of it — and a description half in German is searchable in neither language.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+# Enough for checkout, and nothing more. Artifact upload authenticates with the runtime
+# token rather than this one, so it needs no scope here.
+permissions:
+  contents: read
+
 jobs:
   lint-and-unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+# Licensed under the MIT License. See LICENSE in the repository root for details.
+#
+
+name: CodeQL
+
+# Replaces the default setup, which only ever scanned the default branch and pull requests
+# into it. With features merging into staging first, that left every feature branch unscanned
+# and the first analysis happening after the code was already deployed to staging.
+on:
+  push:
+    branches: [main, staging]
+  pull_request:
+    branches: [main, staging]
+  schedule:
+    # Keeps finding newly published problems in code that has stopped changing.
+    - cron: "27 3 * * 1"
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # `javascript-typescript` covers both languages in one analysis. `actions` scans the
+        # workflows themselves, which is what catches an expression spliced into a run block.
+        language: [actions, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          # Nothing here is compiled, so CodeQL has no build to observe.
+          build-mode: none
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy-rules.yml
+++ b/.github/workflows/deploy-rules.yml
@@ -8,14 +8,15 @@ name: Deploy Security Rules
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, staging]
     paths:
       - "firestore.rules"
       - "storage.rules"
+      - "firestore.indexes.json"
       - ".github/workflows/deploy-rules.yml"
 
 concurrency:
-  group: deploy-rules-main
+  group: deploy-rules-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -27,6 +28,10 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Rules reach staging by the same route the code does: the branch decides the project,
+    # so nothing can be released to production that has not passed through staging first.
+    env:
+      PROJECT: ${{ github.ref_name == 'main' && 'htld-sportsweek' || 'htld-sportsweek-staging' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -36,7 +41,13 @@ jobs:
       - run: npm ci
       - uses: google-github-actions/auth@v3
         with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_RULES_DEPLOY_SERVICE_ACCOUNT }}
-      - name: Deploy firestore.rules and storage.rules
-        run: npx firebase-tools deploy --only firestore:rules,storage --project htld-sportsweek --non-interactive
+          workload_identity_provider: >-
+            ${{ github.ref_name == 'main' && vars.GCP_WORKLOAD_IDENTITY_PROVIDER
+            || vars.GCP_WORKLOAD_IDENTITY_PROVIDER_STAGING }}
+          service_account: >-
+            ${{ github.ref_name == 'main' && vars.GCP_RULES_DEPLOY_SERVICE_ACCOUNT
+            || vars.GCP_RULES_DEPLOY_SERVICE_ACCOUNT_STAGING }}
+      - name: Deploy rules and indexes to ${{ env.PROJECT }}
+        run: >-
+          npx firebase-tools deploy --only firestore:rules,firestore:indexes,storage
+          --project ${{ env.PROJECT }} --non-interactive

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+# Licensed under the MIT License. See LICENSE in the repository root for details.
+#
+
+name: Promotion
+
+# Only fires for pull requests into main, so it never appears on a PR into staging.
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  promotion-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only staging may be promoted to main
+        # Via the environment rather than an expression inside the script: a branch name is
+        # attacker-controlled text and would otherwise be pasted straight into the shell.
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          case "$HEAD_REF" in
+            staging)
+              echo "Promoting staging to main."
+              ;;
+            hotfix/*)
+              # The one way past the queue, named so it is visible in the log rather than
+              # done by disabling this check. Back-merge main into staging afterwards, or
+              # the two branches drift apart.
+              echo "Hotfix '$HEAD_REF' going straight to main."
+              ;;
+            *)
+              echo "::error::'$HEAD_REF' cannot merge into main. Changes reach production by"
+              echo "::error::merging into staging first, then opening staging -> main."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [main]
 
+# The check reads the branch name out of the event payload and nothing else: no checkout,
+# no API call, so the token needs no scope at all.
+permissions: {}
+
 jobs:
   promotion-source:
     runs-on: ubuntu-latest

--- a/apphosting.staging.yaml
+++ b/apphosting.staging.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+# Licensed under the MIT License. See LICENSE in the repository root for details.
+
+# Overrides for staging, layered over apphosting.yaml.
+#
+# App Hosting picks this file for any backend whose Environment name is `staging`
+# (console > App Hosting > View dashboard > Settings > Environment), falling back to
+# apphosting.yaml otherwise. `npm run dev:staging` sets APP_HOSTING_ENV=staging so
+# next.config.ts merges it the same way locally.
+# See https://firebase.google.com/docs/app-hosting/multiple-environments.
+#
+# Staging is a separate Firebase project on purpose: the fake login provisions real Auth
+# accounts and real user records, and none of those belong anywhere near production data.
+runConfig:
+  minInstances: 0
+  maxInstances: 1
+
+env:
+  # Public in the same sense as the production key -- it identifies the project, it does not
+  # grant access. Restrict it to this project's own origins in the Cloud console.
+  - variable: NEXT_PUBLIC_FIREBASE_API_KEY
+    value: AIzaSyABbpPwfzqZHYmxYEkHkCkFcDTd0G0tXmc
+    availability:
+      - BUILD
+      - RUNTIME
+  - variable: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+    value: htld-sportsweek-staging.firebaseapp.com
+    availability:
+      - BUILD
+      - RUNTIME
+  - variable: NEXT_PUBLIC_FIREBASE_PROJECT_ID
+    value: htld-sportsweek-staging
+    availability:
+      - BUILD
+      - RUNTIME
+  - variable: NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+    value: htld-sportsweek-staging.firebasestorage.app
+    availability:
+      - BUILD
+      - RUNTIME
+  - variable: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+    value: "124249657490"
+    availability:
+      - BUILD
+      - RUNTIME
+  - variable: NEXT_PUBLIC_FIREBASE_APP_ID
+    value: "1:124249657490:web:172cf58935cb8af74c164b"
+    availability:
+      - BUILD
+      - RUNTIME
+  # Set to `entra` to rehearse the real Microsoft sign-in here; the tenant is inherited from
+  # apphosting.yaml either way. resolveAuthMode refuses `fake` for the production project, so
+  # this value only ever takes effect where it is safe.
+  - variable: AUTH_MODE
+    value: fake
+    availability:
+      - BUILD
+      - RUNTIME

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -59,6 +59,14 @@ env:
     availability:
       - BUILD
       - RUNTIME
+  # Which sign-in the app offers. This file is the fallback for every backend without an
+  # environment name, so production reads `entra` from here; apphosting.staging.yaml
+  # overrides it. See src/lib/auth/auth-mode.ts, which refuses `fake` for this project anyway.
+  - variable: AUTH_MODE
+    value: entra
+    availability:
+      - BUILD
+      - RUNTIME
 # No service account keys are used anywhere: on App Hosting, firebase-admin uses Application
 # Default Credentials automatically via the backend's service account. Local dev uses
 # `gcloud auth application-default login` instead. The public values above are read straight

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,20 +7,48 @@ import type { NextConfig } from "next";
 import { parse } from "yaml";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { resolveAuthMode } from "./src/lib/auth/auth-mode";
+import { envFromApphostingYaml, preferProcessEnv } from "./src/lib/apphosting-env";
 
 // Public Firebase/Entra values live only in apphosting.yaml — reading them here makes
 // them available to `next dev`/`next build` without duplicating them into a .env file.
-const apphosting = parse(
-  readFileSync(fileURLToPath(new URL("./apphosting.yaml", import.meta.url)), "utf8"),
+function readEnv(fileName: string): Record<string, string> {
+  return envFromApphostingYaml(
+    parse(readFileSync(fileURLToPath(new URL(`./${fileName}`, import.meta.url)), "utf8")),
+  );
+}
+
+// App Hosting layers apphosting.<environment>.yaml over apphosting.yaml for a backend tagged
+// with that environment name, and injects the result. APP_HOSTING_ENV reproduces that for a
+// local build, so `npm run dev:staging` points at staging without editing the production
+// config — but on App Hosting the injected values are the ones that count.
+const environment = process.env.APP_HOSTING_ENV;
+const env = preferProcessEnv(
+  {
+    ...readEnv("apphosting.yaml"),
+    ...(environment ? readEnv(`apphosting.${environment}.yaml`) : {}),
+  },
+  process.env,
 );
-const env: Record<string, string> = Object.fromEntries(
-  (apphosting.env ?? [])
-    .filter((entry: { value?: string }) => entry.value !== undefined)
-    .map((entry: { variable: string; value: string }) => [entry.variable, entry.value]),
-);
+
+// Whether the fake login is part of this build at all, rather than merely disabled in it.
+// `route.fake.ts` only counts as a Route Handler while `fake.ts` is a page extension, so
+// outside staging the file never enters the graph and no /api/auth/fake is emitted.
+const fakeLogin = resolveAuthMode(env.AUTH_MODE, env.NEXT_PUBLIC_FIREBASE_PROJECT_ID) === "fake";
 
 const nextConfig: NextConfig = {
   env,
+  pageExtensions: ["ts", "tsx", ...(fakeLogin ? ["fake.ts", "fake.tsx"] : [])],
+  // Same idea for the client half: with no alias the import resolves to a stub that renders
+  // nothing, so the dialog and its German strings stay out of the bundle.
+  turbopack: {
+    resolveAlias: fakeLogin
+      ? {}
+      : {
+          "@/components/auth/fake-sign-in-dialog":
+            "./src/components/auth/fake-sign-in-dialog.stub.tsx",
+        },
+  },
   // Proxies Firebase's OAuth sign-in helper through our own domain so signInWithRedirect
   // doesn't rely on a cross-origin iframe to *.firebaseapp.com — required since
   // Chrome 115+/Firefox 109+/Safari 16.1+ block that third-party storage access by default.
@@ -29,7 +57,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/__/auth/:path*",
-        destination: "https://htld-sportsweek.firebaseapp.com/__/auth/:path*",
+        destination: `https://${env.NEXT_PUBLIC_FIREBASE_PROJECT_ID}.firebaseapp.com/__/auth/:path*`,
       },
     ];
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "dev": "next dev --experimental-https --experimental-https-key ./.certs/localhost-key.pem --experimental-https-cert ./.certs/localhost.pem",
+    "dev:staging": "APP_HOSTING_ENV=staging npm run dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/spec/database-erd.puml
+++ b/spec/database-erd.puml
@@ -71,7 +71,7 @@ entity "ClassOption" as classOption {
 entity "SkillLevel" as skillLevel {
   PK id : string
   --
-  name : string  ' Absoluter Anfänger, Anfänger, Fortgeschritten, Profi (US-7)
+  name : string  ' Keine Vorkenntnisse, Anfänger, Fortgeschritten, Profi (US-7)
   position : number  ' teacher-defined order — these are ranked, so alphabetical would be wrong
 }
 

--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -167,7 +167,7 @@ As a teacher, I can maintain the list of ski/snowboard skill levels so that stud
 
 - A view for maintaining the list of skill levels exists.
 - A teacher can add, edit, and remove skill levels from the list.
-- The list is pre-populated with four skill levels, shown as "Absoluter Anfänger" (complete beginner), "Anfänger" (beginner), "Fortgeschritten" (advanced), and "Profi" (expert).
+- The list is pre-populated, in this order, with four skill levels shown as "Keine Vorkenntnisse" (no prior experience), "Anfänger" (beginner), "Fortgeschritten" (advanced), and "Profi" (expert).
 - The skill level a student selects in their master data (US-11) is chosen from this maintained list.
 
 ### US-8: Teacher maintains bus pickup points

--- a/src/app/api/auth/fake/route.fake.ts
+++ b/src/app/api/auth/fake/route.fake.ts
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { ErrorCode, apiError } from "@/lib/errors";
+import { adminAuth, adminDb } from "@/lib/firebase/admin";
+import { currentAuthMode } from "@/lib/auth/auth-mode";
+import { buildUpn, isSchoolUpn } from "@/lib/auth/upn";
+import { COLLECTIONS } from "@/lib/schemas/collections";
+import { userRoleSchema, userSchema } from "@/lib/schemas/user";
+
+/**
+ * Stands in for Entra ID while developing, so the app can be tried out as several teachers
+ * and students without tenant accounts. It only replaces the identity provider: the client
+ * trades the custom token minted here for an ID token and then goes through `/api/session`
+ * like any real login, so provisioning, the role claim and the session cookie stay on the
+ * code path production uses.
+ *
+ * Anyone who can reach it can become anyone, which is why every entry point re-checks the
+ * mode and otherwise answers 404 — an endpoint that is off should not advertise that it exists.
+ */
+const notFound = () =>
+  NextResponse.json(apiError(ErrorCode.NotFound, "Not found"), { status: 404 });
+
+const bodySchema = z.object({
+  firstName: userSchema.shape.firstName,
+  lastName: userSchema.shape.lastName,
+  role: userRoleSchema,
+});
+
+const listedUserSchema = userSchema.omit({ id: true, email: true });
+
+/** The UPNs already in Firestore, so a known user can be picked instead of retyped. */
+export async function GET() {
+  if (currentAuthMode() !== "fake") return notFound();
+
+  try {
+    const snapshot = await adminDb.collection(COLLECTIONS.users).get();
+    const users = snapshot.docs
+      .flatMap((doc) => {
+        const parsed = listedUserSchema.safeParse(doc.data());
+        return parsed.success ? [{ upn: doc.id, ...parsed.data }] : [];
+      })
+      .sort((a, b) => a.upn.localeCompare(b.upn));
+
+    return NextResponse.json({ users });
+  } catch (err) {
+    console.error("Failed to list the fake-login users:", err);
+    return NextResponse.json(
+      apiError(ErrorCode.InternalError, "Benutzer konnten nicht geladen werden."),
+      { status: 500 },
+    );
+  }
+}
+
+async function uidFor(upn: string, displayName: string): Promise<string> {
+  try {
+    return (await adminAuth.getUserByEmail(upn)).uid;
+  } catch {
+    return (await adminAuth.createUser({ email: upn, displayName, emailVerified: true })).uid;
+  }
+}
+
+export async function POST(request: Request) {
+  if (currentAuthMode() !== "fake") return notFound();
+
+  const parsed = bodySchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      apiError(ErrorCode.ValidationError, "Invalid request body", parsed.error.flatten()),
+      { status: 400 },
+    );
+  }
+
+  const { firstName, lastName, role } = parsed.data;
+  const upn = buildUpn(firstName, lastName, role);
+  // Holds the fake tenant to the shape the real one issues, so a UPN that could never exist
+  // in Entra ID cannot exist here either — and the role still follows from the domain (US-3).
+  if (!upn || !isSchoolUpn(upn)) {
+    return NextResponse.json(
+      apiError(
+        ErrorCode.ValidationError,
+        "Aus diesem Namen lässt sich keine gültige Schul-Adresse bilden.",
+      ),
+      { status: 400 },
+    );
+  }
+
+  try {
+    const uid = await uidFor(upn, `${firstName} ${lastName}`);
+    // Carried into the ID token, so provisionUser stores the names as typed instead of
+    // re-splitting a display name.
+    const customToken = await adminAuth.createCustomToken(uid, {
+      given_name: firstName,
+      family_name: lastName,
+    });
+
+    return NextResponse.json({ customToken, upn });
+  } catch (err) {
+    console.error("Failed to mint a fake-login token:", err);
+    return NextResponse.json(
+      apiError(ErrorCode.InternalError, "Test-Anmeldung derzeit nicht möglich."),
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/auth/fake/route.test.ts
+++ b/src/app/api/auth/fake/route.test.ts
@@ -1,0 +1,178 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeFirestore } from "@/test/fake-firestore";
+import { PRODUCTION_PROJECT_ID } from "@/lib/auth/auth-mode";
+
+const getUserByEmail = vi.fn();
+const createUser = vi.fn();
+const createCustomToken = vi.fn();
+const firestore = new FakeFirestore();
+
+vi.mock("@/lib/firebase/admin", () => ({
+  adminAuth: {
+    getUserByEmail: (...args: unknown[]) => getUserByEmail(...args),
+    createUser: (...args: unknown[]) => createUser(...args),
+    createCustomToken: (...args: unknown[]) => createCustomToken(...args),
+  },
+  adminDb: firestore,
+}));
+
+const { GET, POST } = await import("@/app/api/auth/fake/route.fake");
+
+function postRequest(body: unknown) {
+  return new Request("https://example.com/api/auth/fake", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/auth/fake", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    firestore.reset();
+    vi.stubEnv("AUTH_MODE", "fake");
+    vi.stubEnv("NEXT_PUBLIC_FIREBASE_PROJECT_ID", "htld-sportsweek-staging");
+    getUserByEmail.mockRejectedValue({ code: "auth/user-not-found" });
+    createUser.mockImplementation(({ email }: { email: string }) => ({ uid: `uid-${email}` }));
+    createCustomToken.mockResolvedValue("custom-token");
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  describe("when the fake login is not enabled", () => {
+    it.each([
+      ["no one asked for it", () => vi.stubEnv("AUTH_MODE", "entra")],
+      [
+        "the project holds real data",
+        () => vi.stubEnv("NEXT_PUBLIC_FIREBASE_PROJECT_ID", PRODUCTION_PROJECT_ID),
+      ],
+    ])("answers as if the endpoint did not exist because %s", async (_case, disable) => {
+      disable();
+
+      const listed = await GET();
+      const minted = await POST(
+        postRequest({ firstName: "Jane", lastName: "Doe", role: "teacher" }),
+      );
+
+      expect(listed.status).toBe(404);
+      expect(minted.status).toBe(404);
+      expect(createCustomToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET", () => {
+    it("lists the known users by UPN so an existing one can be picked", async () => {
+      firestore.seed("users", "zoe.zimmer@student.htldornbirn.at", {
+        firstName: "Zoe",
+        lastName: "Zimmer",
+        email: "zoe.zimmer@student.htldornbirn.at",
+        role: "student",
+      });
+      firestore.seed("users", "jane.doe@htldornbirn.at", {
+        firstName: "Jane",
+        lastName: "Doe",
+        email: "jane.doe@htldornbirn.at",
+        role: "teacher",
+      });
+
+      const response = await GET();
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        users: [
+          { upn: "jane.doe@htldornbirn.at", firstName: "Jane", lastName: "Doe", role: "teacher" },
+          {
+            upn: "zoe.zimmer@student.htldornbirn.at",
+            firstName: "Zoe",
+            lastName: "Zimmer",
+            role: "student",
+          },
+        ],
+      });
+    });
+
+    it("skips a record that does not parse instead of failing the whole list", async () => {
+      firestore.seed("users", "broken@htldornbirn.at", { firstName: "Nur", role: "wizard" });
+
+      const response = await GET();
+
+      expect(await response.json()).toEqual({ users: [] });
+    });
+  });
+
+  describe("POST", () => {
+    it("derives the UPN from the name and the chosen role", async () => {
+      const response = await POST(
+        postRequest({ firstName: "Jürgen", lastName: "Müller", role: "student" }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        customToken: "custom-token",
+        upn: "juergen.mueller@student.htldornbirn.at",
+      });
+      expect(createUser).toHaveBeenCalledWith({
+        email: "juergen.mueller@student.htldornbirn.at",
+        displayName: "Jürgen Müller",
+        emailVerified: true,
+      });
+    });
+
+    // provisionUser splits a display name on whitespace, which mangles a multi-word name —
+    // carrying the parts as claims keeps the record exactly as it was typed.
+    it("passes the typed names through as token claims", async () => {
+      await POST(postRequest({ firstName: "Anna Maria", lastName: "van Berg", role: "teacher" }));
+
+      expect(createCustomToken).toHaveBeenCalledWith("uid-anna-maria.van-berg@htldornbirn.at", {
+        given_name: "Anna Maria",
+        family_name: "van Berg",
+      });
+    });
+
+    it("reuses the auth account when the UPN is already known", async () => {
+      getUserByEmail.mockResolvedValue({ uid: "existing-uid" });
+
+      await POST(postRequest({ firstName: "Jane", lastName: "Doe", role: "teacher" }));
+
+      expect(createUser).not.toHaveBeenCalled();
+      expect(createCustomToken).toHaveBeenCalledWith("existing-uid", expect.anything());
+    });
+
+    it.each([
+      ["a missing last name", { firstName: "Jane", role: "teacher" }],
+      ["an unknown role", { firstName: "Jane", lastName: "Doe", role: "admin" }],
+      ["a blank first name", { firstName: "   ", lastName: "Doe", role: "teacher" }],
+    ])("returns 400 for %s", async (_case, body) => {
+      const response = await POST(postRequest(body));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.code).toBe("VALIDATION_ERROR");
+      expect(createCustomToken).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when the name yields no UPN the tenant could issue", async () => {
+      const response = await POST(
+        postRequest({ firstName: "字", lastName: "字", role: "teacher" }),
+      );
+
+      expect(response.status).toBe(400);
+      expect(createCustomToken).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 without leaking the cause when the Admin SDK fails", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      createCustomToken.mockRejectedValue(new Error("credentials missing"));
+
+      const response = await POST(
+        postRequest({ firstName: "Jane", lastName: "Doe", role: "teacher" }),
+      );
+
+      expect(response.status).toBe(500);
+      expect(JSON.stringify(await response.json())).not.toContain("credentials missing");
+    });
+  });
+});

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -5,11 +5,12 @@
  */
 import { Suspense } from "react";
 import { SignInCard } from "@/components/auth/sign-in-card";
+import { currentAuthMode } from "@/lib/auth/auth-mode";
 
 export default function SignInPage() {
   return (
     <Suspense>
-      <SignInCard />
+      <SignInCard mode={currentAuthMode()} />
     </Suspense>
   );
 }

--- a/src/components/auth/fake-sign-in-dialog.stub.tsx
+++ b/src/components/auth/fake-sign-in-dialog.stub.tsx
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+/**
+ * Stands in for the real dialog in every build that has no fake login, so none of its markup
+ * or strings reach the bundle. next.config.ts aliases the import here — see `fakeLogin`.
+ * The sign-in card never renders it in that case, so returning null is unreachable anyway.
+ */
+export const FAKE_SIGN_IN_LABEL = null;
+
+export function FakeSignInDialog(): null {
+  return null;
+}

--- a/src/components/auth/fake-sign-in-dialog.test.tsx
+++ b/src/components/auth/fake-sign-in-dialog.test.tsx
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const signInWithCustomToken = vi.fn();
+
+vi.mock("firebase/auth", () => ({ signInWithCustomToken }));
+vi.mock("@/lib/firebase/client", () => ({ auth: {} }));
+
+const { FakeSignInDialog } = await import("@/components/auth/fake-sign-in-dialog");
+
+const KNOWN_USERS = [
+  { upn: "jane.doe@htldornbirn.at", firstName: "Jane", lastName: "Doe", role: "teacher" },
+  {
+    upn: "zoe.zimmer@student.htldornbirn.at",
+    firstName: "Zoe",
+    lastName: "Zimmer",
+    role: "student",
+  },
+];
+
+type PostResult = { ok: boolean; status: number; body: unknown };
+
+function stubApi(post: PostResult = { ok: true, status: 200, body: { customToken: "ct" } }) {
+  const fetchMock = vi.fn(async (_url: string, init?: { method?: string }) =>
+    init?.method === "POST"
+      ? { ok: post.ok, status: post.status, json: async () => post.body }
+      : { ok: true, status: 200, json: async () => ({ users: KNOWN_USERS }) },
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function renderDialog() {
+  const onClose = vi.fn();
+  render(<FakeSignInDialog open onClose={onClose} />);
+  return { onClose, user: userEvent.setup() };
+}
+
+async function typeName(
+  user: ReturnType<typeof userEvent.setup>,
+  first: string,
+  last: string,
+): Promise<void> {
+  await user.type(screen.getByLabelText("Vorname"), first);
+  await user.type(screen.getByLabelText("Nachname"), last);
+}
+
+describe("FakeSignInDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubApi();
+  });
+
+  it("offers the already known users by UPN alone", async () => {
+    renderDialog();
+
+    const dropdown = await screen.findByLabelText("Bestehende Benutzer");
+    expect([...dropdown.querySelectorAll("option")].map((option) => option.textContent)).toEqual([
+      "Neuer Benutzer",
+      ...KNOWN_USERS.map((entry) => entry.upn),
+    ]);
+  });
+
+  it("fills the form from the picked user", async () => {
+    const { user } = renderDialog();
+
+    const dropdown = await screen.findByLabelText("Bestehende Benutzer");
+    await user.selectOptions(dropdown, "zoe.zimmer@student.htldornbirn.at");
+
+    expect(screen.getByLabelText("Vorname")).toHaveValue("Zoe");
+    expect(screen.getByLabelText("Nachname")).toHaveValue("Zimmer");
+    expect(screen.getByLabelText("Schüler:in")).toBeChecked();
+  });
+
+  it("compiles the UPN from the name and the role while typing", async () => {
+    const { user } = renderDialog();
+
+    await typeName(user, "Jürgen", "Müller");
+    expect(screen.getByLabelText("E-Mail / UPN")).toHaveValue("juergen.mueller@htldornbirn.at");
+
+    await user.click(screen.getByLabelText("Schüler:in"));
+    expect(screen.getByLabelText("E-Mail / UPN")).toHaveValue(
+      "juergen.mueller@student.htldornbirn.at",
+    );
+  });
+
+  it("signs in with the token the server minted", async () => {
+    const fetchMock = stubApi();
+    const { user, onClose } = renderDialog();
+
+    await typeName(user, "Jane", "Doe");
+    await user.click(screen.getByRole("button", { name: "Anmelden" }));
+
+    await waitFor(() => expect(signInWithCustomToken).toHaveBeenCalledWith({}, "ct"));
+    const post = fetchMock.mock.calls.find(([, init]) => init?.method === "POST")!;
+    expect(JSON.parse((post[1] as { body: string }).body)).toEqual({
+      firstName: "Jane",
+      lastName: "Doe",
+      role: "teacher",
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("refuses to submit a name that yields no school address", async () => {
+    const fetchMock = stubApi();
+    const { user } = renderDialog();
+
+    await typeName(user, "字", "字");
+    await user.click(screen.getByRole("button", { name: "Anmelden" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Schul-Adresse");
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === "POST")).toBe(false);
+  });
+
+  it("stays open and shows the server's message when signing in fails", async () => {
+    stubApi({
+      ok: false,
+      status: 500,
+      body: { error: { code: "INTERNAL_ERROR", message: "Test-Anmeldung derzeit nicht möglich." } },
+    });
+    const { user, onClose } = renderDialog();
+
+    await typeName(user, "Jane", "Doe");
+    await user.click(screen.getByRole("button", { name: "Anmelden" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Test-Anmeldung derzeit nicht möglich.",
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/auth/fake-sign-in-dialog.test.tsx
+++ b/src/components/auth/fake-sign-in-dialog.test.tsx
@@ -82,12 +82,25 @@ describe("FakeSignInDialog", () => {
     const { user } = renderDialog();
 
     await typeName(user, "Jürgen", "Müller");
-    expect(screen.getByLabelText("E-Mail / UPN")).toHaveValue("juergen.mueller@htldornbirn.at");
+    expect(screen.getByLabelText("E-Mail / UPN")).toHaveTextContent(
+      "juergen.mueller@htldornbirn.at",
+    );
 
     await user.click(screen.getByLabelText("Schüler:in"));
-    expect(screen.getByLabelText("E-Mail / UPN")).toHaveValue(
+    expect(screen.getByLabelText("E-Mail / UPN")).toHaveTextContent(
       "juergen.mueller@student.htldornbirn.at",
     );
+  });
+
+  // It is derived from the two names, so offering somewhere to type would invite editing it
+  // into something the tenant would never issue.
+  it("presents the UPN as a result rather than a field", async () => {
+    const { user } = renderDialog();
+
+    await typeName(user, "Jane", "Doe");
+
+    expect(screen.getByLabelText("E-Mail / UPN")).toHaveTextContent("jane.doe@htldornbirn.at");
+    expect(screen.queryByRole("textbox", { name: "E-Mail / UPN" })).not.toBeInTheDocument();
   });
 
   it("signs in with the token the server minted", async () => {

--- a/src/components/auth/fake-sign-in-dialog.tsx
+++ b/src/components/auth/fake-sign-in-dialog.tsx
@@ -1,0 +1,207 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+import * as React from "react";
+import { useForm, useWatch } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { signInWithCustomToken } from "firebase/auth";
+import { auth } from "@/lib/firebase/client";
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { apiRequest, ApiRequestError } from "@/lib/api/client";
+import { buildUpn, isSchoolUpn } from "@/lib/auth/upn";
+import { userRoleSchema, userSchema, type UserRole } from "@/lib/schemas/user";
+
+const NO_UPN = "Aus diesem Namen lässt sich keine gültige Schul-Adresse bilden.";
+const SIGN_IN_FAILED = "Test-Anmeldung fehlgeschlagen.";
+
+/** Lives here rather than on the card so the stub can drop it from a production bundle. */
+export const FAKE_SIGN_IN_LABEL = "Anmelden (Testmodus)";
+
+const knownUsersSchema = z.array(
+  z.object({
+    upn: z.string(),
+    firstName: z.string(),
+    lastName: z.string(),
+    role: userRoleSchema,
+  }),
+);
+type KnownUser = z.infer<typeof knownUsersSchema>[number];
+
+const formSchema = z.object({
+  firstName: userSchema.shape.firstName,
+  lastName: userSchema.shape.lastName,
+  role: userRoleSchema,
+});
+type FormValues = z.infer<typeof formSchema>;
+
+const ROLE_LABELS: Record<UserRole, string> = { teacher: "Lehrperson", student: "Schüler:in" };
+
+// A native <select> rather than the design system's portalled one: this dialog never ships,
+// so it is not worth the weight to render a list of UPNs.
+const SELECT_CLASS =
+  "border-input focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-lg border bg-transparent px-3 text-sm outline-none focus-visible:ring-3";
+
+/**
+ * Stands in for the Entra ID sign-in while developing (see `resolveAuthMode`). The name and
+ * role compile into the UPN the tenant would issue, the server hands back a custom token,
+ * and signing in with it puts the app on the same path as a real login — so the app can be
+ * tried out as several teachers and students without tenant accounts.
+ */
+export function FakeSignInDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [known, setKnown] = React.useState<KnownUser[]>([]);
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+  const knownId = React.useId();
+  const firstNameId = React.useId();
+  const lastNameId = React.useId();
+  const upnId = React.useId();
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { firstName: "", lastName: "", role: "teacher" },
+  });
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    fetch("/api/auth/fake")
+      .then((response) => (response.ok ? response.json() : null))
+      .then((body) => {
+        const parsed = knownUsersSchema.safeParse(body?.users);
+        if (!cancelled && parsed.success) setKnown(parsed.data);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const [firstName, lastName, role] = useWatch({
+    control,
+    name: ["firstName", "lastName", "role"],
+  });
+  const derived = buildUpn(firstName, lastName, role);
+  const upn = derived && isSchoolUpn(derived) ? derived : null;
+
+  function pickKnown(pickedUpn: string) {
+    const picked = known.find((entry) => entry.upn === pickedUpn);
+    if (!picked) return;
+
+    setValue("firstName", picked.firstName);
+    setValue("lastName", picked.lastName);
+    setValue("role", picked.role);
+  }
+
+  const onSubmit = handleSubmit(async (values) => {
+    setSubmitError(null);
+    if (!upn) {
+      setSubmitError(NO_UPN);
+      return;
+    }
+
+    try {
+      const minted = await apiRequest<{ customToken: string }>("/api/auth/fake", {
+        method: "POST",
+        body: values,
+      });
+      if (!minted) throw new ApiRequestError(SIGN_IN_FAILED);
+
+      // The sign-in card's auth-state listener takes it from here: it trades the ID token
+      // for the session cookie and navigates.
+      await signInWithCustomToken(auth, minted.customToken);
+      onClose();
+    } catch (error) {
+      setSubmitError(error instanceof ApiRequestError ? error.message : SIGN_IN_FAILED);
+    }
+  });
+
+  return (
+    <Dialog
+      open={open}
+      title="Test-Anmeldung"
+      description="Meldet ohne Entra ID an. Nur in der Entwicklung verfügbar."
+      onClose={onClose}
+    >
+      <form onSubmit={onSubmit} className="flex flex-col gap-4" noValidate>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={knownId}>Bestehende Benutzer</Label>
+          <select
+            id={knownId}
+            className={SELECT_CLASS}
+            defaultValue=""
+            onChange={(event) => pickKnown(event.target.value)}
+          >
+            <option value="">Neuer Benutzer</option>
+            {known.map((entry) => (
+              <option key={entry.upn} value={entry.upn}>
+                {entry.upn}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={firstNameId}>Vorname</Label>
+          <Input id={firstNameId} autoFocus {...register("firstName")} />
+          {errors.firstName ? (
+            <p className="text-destructive text-sm">{errors.firstName.message}</p>
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={lastNameId}>Nachname</Label>
+          <Input id={lastNameId} {...register("lastName")} />
+          {errors.lastName ? (
+            <p className="text-destructive text-sm">{errors.lastName.message}</p>
+          ) : null}
+        </div>
+
+        <fieldset className="flex flex-col gap-1.5">
+          <legend className="text-sm leading-none font-medium">Rolle</legend>
+          <div className="flex gap-4 pt-1.5">
+            {userRoleSchema.options.map((option) => (
+              <label key={option} className="flex items-center gap-2 text-sm">
+                <input type="radio" value={option} {...register("role")} />
+                {ROLE_LABELS[option]}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={upnId}>E-Mail / UPN</Label>
+          <Input id={upnId} readOnly tabIndex={-1} value={upn ?? ""} />
+        </div>
+
+        {submitError ? (
+          <p role="alert" className="text-destructive text-sm">
+            {submitError}
+          </p>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Abbrechen
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            Anmelden
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/src/components/auth/fake-sign-in-dialog.tsx
+++ b/src/components/auth/fake-sign-in-dialog.tsx
@@ -184,7 +184,14 @@ export function FakeSignInDialog({ open, onClose }: { open: boolean; onClose: ()
 
         <div className="flex flex-col gap-1.5">
           <Label htmlFor={upnId}>E-Mail / UPN</Label>
-          <Input id={upnId} readOnly tabIndex={-1} value={upn ?? ""} />
+          {/* An <output>, not a read-only input: the tenant derives this from the name, so
+              there should be nowhere to put a caret and nothing to edit it into. */}
+          <output
+            id={upnId}
+            className="border-input bg-muted text-muted-foreground flex h-9 items-center rounded-lg border px-3 text-sm"
+          >
+            {upn ?? ""}
+          </output>
         </div>
 
         {submitError ? (

--- a/src/components/auth/sign-in-card.test.tsx
+++ b/src/components/auth/sign-in-card.test.tsx
@@ -4,6 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const onAuthStateChanged = vi.fn();
@@ -19,6 +20,7 @@ vi.mock("firebase/auth", () => ({
   signInWithRedirect,
   signOut,
   getRedirectResult,
+  signInWithCustomToken: vi.fn(),
   OAuthProvider: { credentialFromResult },
 }));
 
@@ -246,5 +248,31 @@ describe("SignInCard", () => {
     render(<SignInCard />);
 
     await waitFor(() => expect(screen.getByRole("button")).not.toBeDisabled());
+  });
+
+  describe("in fake auth mode", () => {
+    beforeEach(() => {
+      respondWith(200, { status: "ok" });
+      onAuthStateChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+        callback(null);
+        return () => {};
+      });
+    });
+
+    it("says on the button that this is not the real sign-in", async () => {
+      render(<SignInCard mode="fake" />);
+
+      expect(await screen.findByRole("button", { name: /Testmodus/i })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Office 365/i })).not.toBeInTheDocument();
+    });
+
+    it("opens the test-login dialog instead of handing off to Entra ID", async () => {
+      render(<SignInCard mode="fake" />);
+
+      await userEvent.click(await screen.findByRole("button", { name: /Testmodus/i }));
+
+      expect(await screen.findByRole("dialog")).toBeInTheDocument();
+      expect(signInWithRedirect).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/auth/sign-in-card.test.tsx
+++ b/src/components/auth/sign-in-card.test.tsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -29,9 +29,14 @@ vi.mock("@/lib/firebase/client", () => ({
   createMicrosoftAuthProvider: () => ({}),
 }));
 
+// Stable across renders, as the real hooks are: a fresh object each call would re-run the
+// auth-state effect on every render, which the card is not written to expect.
+const router = { push, refresh };
+const searchParams = new URLSearchParams();
+
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push, refresh }),
-  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => router,
+  useSearchParams: () => searchParams,
 }));
 
 vi.mock("next/image", () => ({
@@ -273,6 +278,26 @@ describe("SignInCard", () => {
 
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
       expect(signInWithRedirect).not.toHaveBeenCalled();
+    });
+
+    // The dialog closes the moment it has signed in, and the session still has to be created
+    // before anything navigates. Entra ID never shows that gap because it arrives by redirect,
+    // so the card is already busy on first render.
+    it("goes back to showing progress once the dialog has signed in", async () => {
+      let notify: (user: unknown) => void = () => {};
+      onAuthStateChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+        notify = callback;
+        callback(null);
+        return () => {};
+      });
+
+      render(<SignInCard mode="fake" />);
+      await waitFor(() => expect(screen.getByRole("button")).not.toBeDisabled());
+
+      await act(async () => notify(signedInUser));
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeDisabled();
     });
   });
 });

--- a/src/components/auth/sign-in-card.tsx
+++ b/src/components/auth/sign-in-card.tsx
@@ -19,8 +19,10 @@ import {
 import { auth, createMicrosoftAuthProvider } from "@/lib/firebase/client";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { FakeSignInDialog, FAKE_SIGN_IN_LABEL } from "@/components/auth/fake-sign-in-dialog";
 import { ROUTES, homeFor } from "@/lib/routes";
 import { userRoleSchema } from "@/lib/schemas/user";
+import type { AuthMode } from "@/lib/auth/auth-mode";
 
 const ACCOUNT_NOT_ENABLED = "Dieses Konto ist für Sportsweek nicht freigeschaltet.";
 const SIGN_IN_FAILED = "Anmelden fehlgeschlagen. Bitte versuchen Sie es erneut.";
@@ -28,10 +30,12 @@ const SIGN_IN_FAILED = "Anmelden fehlgeschlagen. Bitte versuchen Sie es erneut."
 // Sign-in itself only starts when the user clicks the button — same window, no popup.
 // onAuthStateChanged reliably reports the signed-in user once Firebase resolves the
 // redirect (relies on the /__/auth/* proxy in next.config.ts — see redirect-best-practices).
-export function SignInCard() {
+// It is also what finishes the fake login, which only has to put a user on `auth`.
+export function SignInCard({ mode = "entra" }: { mode?: AuthMode }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
+  const [fakeDialogOpen, setFakeDialogOpen] = useState(false);
   // True until Firebase's first auth-state callback fires, which only happens once any
   // pending redirect has been resolved — avoids flashing the button during that window.
   const [checking, setChecking] = useState(true);
@@ -94,6 +98,10 @@ export function SignInCard() {
 
   async function handleSignIn() {
     setError(null);
+    if (mode === "fake") {
+      setFakeDialogOpen(true);
+      return;
+    }
     await signInWithRedirect(auth, createMicrosoftAuthProvider());
   }
 
@@ -114,7 +122,9 @@ export function SignInCard() {
           </h1>
           <p className="text-muted-foreground mt-2 text-sm">Sportwochen-Verwaltung</p>
           <Button className="mt-8 h-10 w-full" onClick={handleSignIn} disabled={checking}>
-            Anmelden über Office 365
+            {mode === "fake" && FAKE_SIGN_IN_LABEL
+              ? FAKE_SIGN_IN_LABEL
+              : "Anmelden über Office 365"}
           </Button>
           {/* Always occupies its height, so the card doesn't resize when the spinner appears. */}
           <div data-slot="sign-in-status" className="mt-4 flex h-5 items-center justify-center">
@@ -132,6 +142,7 @@ export function SignInCard() {
           ) : null}
         </CardContent>
       </Card>
+      {fakeDialogOpen ? <FakeSignInDialog open onClose={() => setFakeDialogOpen(false)} /> : null}
     </div>
   );
 }

--- a/src/components/auth/sign-in-card.tsx
+++ b/src/components/auth/sign-in-card.tsx
@@ -58,6 +58,10 @@ export function SignInCard({ mode = "entra" }: { mode?: AuthMode }) {
         return;
       }
 
+      // A sign-in that happened in this page rather than by redirect leaves the card idle
+      // while the session is still being created — the fake login's dialog closes first.
+      setChecking(true);
+
       try {
         await redirectSettled;
         const idToken = await user.getIdToken();

--- a/src/components/layout/teacher-nav.test.tsx
+++ b/src/components/layout/teacher-nav.test.tsx
@@ -17,7 +17,7 @@ const SUB_ITEMS = [
   "Saisonen",
   "Programme",
   "Klassen",
-  "Könnensstufen",
+  "Leistungsstufen",
   "Zustiegsstellen",
   "Verpflegung",
   "Saisonkarten",

--- a/src/components/master-data/master-data-view.test.tsx
+++ b/src/components/master-data/master-data-view.test.tsx
@@ -102,7 +102,7 @@ describe("MasterDataView — reading the list", () => {
     render(<MasterDataView category="skill-levels" />);
 
     expect(useMasterData).toHaveBeenCalledWith("skill-levels");
-    expect(screen.getByRole("heading", { name: "Könnensstufen" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Leistungsstufen" })).toBeInTheDocument();
   });
 });
 

--- a/src/lib/apphosting-env.test.ts
+++ b/src/lib/apphosting-env.test.ts
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { describe, expect, it } from "vitest";
+import { envFromApphostingYaml, preferProcessEnv } from "@/lib/apphosting-env";
+
+describe("envFromApphostingYaml", () => {
+  it("reads the pinned values", () => {
+    expect(
+      envFromApphostingYaml({
+        env: [
+          { variable: "NEXT_PUBLIC_FIREBASE_PROJECT_ID", value: "htld-sportsweek" },
+          { variable: "AUTH_MODE", value: "entra" },
+        ],
+      }),
+    ).toEqual({ NEXT_PUBLIC_FIREBASE_PROJECT_ID: "htld-sportsweek", AUTH_MODE: "entra" });
+  });
+
+  // A secret has no literal value here — only a Cloud Secret Manager reference to resolve
+  // at rollout, so there is nothing for a local build to inline.
+  it("skips a variable backed by a secret", () => {
+    expect(
+      envFromApphostingYaml({
+        env: [
+          { variable: "API_KEY", secret: "someSecret" },
+          { variable: "AUTH_MODE", value: "entra" },
+        ],
+      }),
+    ).toEqual({ AUTH_MODE: "entra" });
+  });
+
+  it.each([[{}], [{ env: null }], [{ env: [] }]])("tolerates %o", (parsed) => {
+    expect(envFromApphostingYaml(parsed)).toEqual({});
+  });
+});
+
+describe("preferProcessEnv", () => {
+  it("falls back to the file when the variable is not in the environment", () => {
+    expect(preferProcessEnv({ AUTH_MODE: "entra" }, {})).toEqual({ AUTH_MODE: "entra" });
+  });
+
+  // The regression this exists for: App Hosting merges apphosting.<env>.yaml over the base
+  // itself and injects the result, so reading the base file here and winning silently built
+  // staging as production.
+  it("lets an injected value win over the file", () => {
+    expect(
+      preferProcessEnv(
+        { AUTH_MODE: "entra", NEXT_PUBLIC_FIREBASE_PROJECT_ID: "htld-sportsweek" },
+        { AUTH_MODE: "fake", NEXT_PUBLIC_FIREBASE_PROJECT_ID: "htld-sportsweek-staging" },
+      ),
+    ).toEqual({ AUTH_MODE: "fake", NEXT_PUBLIC_FIREBASE_PROJECT_ID: "htld-sportsweek-staging" });
+  });
+
+  // next.config.ts inlines the result into the client bundle, so the yaml files decide what
+  // is public. Anything else in the environment stays out, secrets included.
+  it("never adopts a variable the files do not declare", () => {
+    expect(preferProcessEnv({ AUTH_MODE: "entra" }, { SOME_PRIVATE_TOKEN: "shhh" })).toEqual({
+      AUTH_MODE: "entra",
+    });
+  });
+
+  it("treats an explicitly empty value as set", () => {
+    expect(preferProcessEnv({ AUTH_MODE: "entra" }, { AUTH_MODE: "" })).toEqual({ AUTH_MODE: "" });
+  });
+});

--- a/src/lib/apphosting-env.ts
+++ b/src/lib/apphosting-env.ts
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+
+/** Shape of one `env:` entry in an apphosting.yaml. A secret carries a reference, not a value. */
+type EnvEntry = { variable: string; value?: string; secret?: string };
+
+export function envFromApphostingYaml(parsed: unknown): Record<string, string> {
+  const entries = (parsed as { env?: EnvEntry[] } | null)?.env;
+  if (!Array.isArray(entries)) return {};
+
+  return Object.fromEntries(
+    entries
+      .filter((entry) => entry.value !== undefined)
+      .map((entry) => [entry.variable, entry.value as string]),
+  );
+}
+
+/**
+ * App Hosting merges `apphosting.<environment>.yaml` over the base itself and injects the
+ * result, so a value already in the environment is the authoritative one — reading the files
+ * here is only a stand-in for that when building locally. Getting this backwards silently
+ * builds staging as production.
+ *
+ * Only variables the files declare are carried over: the result is inlined into the client
+ * bundle, so the yaml is what decides which values are public.
+ */
+export function preferProcessEnv(
+  fromFiles: Record<string, string>,
+  processEnv: Record<string, string | undefined>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(fromFiles).map(([variable, value]) => [variable, processEnv[variable] ?? value]),
+  );
+}

--- a/src/lib/auth/auth-mode.test.ts
+++ b/src/lib/auth/auth-mode.test.ts
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { describe, expect, it } from "vitest";
+import { PRODUCTION_PROJECT_ID, resolveAuthMode } from "@/lib/auth/auth-mode";
+
+const STAGING = "htld-sportsweek-staging";
+
+describe("resolveAuthMode", () => {
+  it("uses Entra ID when nothing is configured", () => {
+    expect(resolveAuthMode(undefined, STAGING)).toBe("entra");
+  });
+
+  it("enables the fake login when a non-production project opts in", () => {
+    expect(resolveAuthMode("fake", STAGING)).toBe("fake");
+  });
+
+  it.each([["entra"], ["FAKE"], ["fake "], [""], ["true"], ["1"]])(
+    "falls back to Entra ID for %o",
+    (configured) => {
+      expect(resolveAuthMode(configured, STAGING)).toBe("entra");
+    },
+  );
+
+  // The fake login writes real records into whichever project it points at, so the one project
+  // holding real people's data refuses it outright — a stray `fake` in the config is not enough.
+  it("refuses the fake login in the production project", () => {
+    expect(resolveAuthMode("fake", PRODUCTION_PROJECT_ID)).toBe("entra");
+  });
+
+  it("refuses the fake login when the project is unknown", () => {
+    expect(resolveAuthMode("fake", undefined)).toBe("entra");
+  });
+});

--- a/src/lib/auth/auth-mode.ts
+++ b/src/lib/auth/auth-mode.ts
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { z } from "zod";
+
+export const authModeSchema = z.enum(["entra", "fake"]);
+export type AuthMode = z.infer<typeof authModeSchema>;
+
+/** The one project holding real people's data, and so the one that may never fake a login. */
+export const PRODUCTION_PROJECT_ID = "htld-sportsweek";
+
+/**
+ * Picks the sign-in implementation for this deployment (`AUTH_MODE`).
+ *
+ * The fake login forges an identity from a form and provisions it for real, so it is opt-in
+ * and confined to staging. Three things have to fail before it could serve real users:
+ * `apphosting.yaml` pins the mode for production, `.env` is gitignored so a local override
+ * cannot travel with the code, and the production project is refused here regardless.
+ * Deliberately not a `NEXT_PUBLIC_` variable — it is read on the server and handed to the
+ * client as a prop, so it never reaches the browser bundle.
+ */
+export function resolveAuthMode(
+  configured: string | undefined,
+  projectId: string | undefined,
+): AuthMode {
+  if (!projectId || projectId === PRODUCTION_PROJECT_ID) return "entra";
+
+  const parsed = authModeSchema.safeParse(configured);
+  return parsed.success ? parsed.data : "entra";
+}
+
+export function currentAuthMode(): AuthMode {
+  return resolveAuthMode(process.env.AUTH_MODE, process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID);
+}

--- a/src/lib/auth/upn.test.ts
+++ b/src/lib/auth/upn.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { describe, expect, it } from "vitest";
-import { roleFromUpn } from "@/lib/auth/upn";
+import { buildUpn, isSchoolUpn, roleFromUpn } from "@/lib/auth/upn";
 
 describe("roleFromUpn", () => {
   it("assigns the teacher role to the staff domain", () => {
@@ -40,5 +40,75 @@ describe("roleFromUpn", () => {
     ["two at signs", "jane@evil.com@htldornbirn.at"],
   ])("rejects %s", (_case, upn) => {
     expect(roleFromUpn(upn)).toBeNull();
+  });
+});
+
+describe("buildUpn", () => {
+  it("joins the two names with a dot and the domain the role maps to", () => {
+    expect(buildUpn("Jane", "Doe", "teacher")).toBe("jane.doe@htldornbirn.at");
+    expect(buildUpn("Jane", "Doe", "student")).toBe("jane.doe@student.htldornbirn.at");
+  });
+
+  it("trims and lowercases what was typed", () => {
+    expect(buildUpn("  JANE  ", " Doe ", "teacher")).toBe("jane.doe@htldornbirn.at");
+  });
+
+  // A UPN is ASCII, so the German spellings have to be written out rather than folded away:
+  // dropping the diaeresis would turn Müller into "muller".
+  it.each([
+    ["Jürgen", "Müller", "juergen.mueller@htldornbirn.at"],
+    ["Öznur", "Äbler", "oeznur.aebler@htldornbirn.at"],
+    ["Jan", "Weiß", "jan.weiss@htldornbirn.at"],
+  ])("writes out umlauts and ß in %s %s", (firstName, lastName, expected) => {
+    expect(buildUpn(firstName, lastName, "teacher")).toBe(expected);
+  });
+
+  it("strips the remaining diacritics", () => {
+    expect(buildUpn("Zoé", "Šimon", "teacher")).toBe("zoe.simon@htldornbirn.at");
+  });
+
+  it("keeps hyphenated names hyphenated", () => {
+    expect(buildUpn("Anna-Maria", "Bauer-Fink", "student")).toBe(
+      "anna-maria.bauer-fink@student.htldornbirn.at",
+    );
+  });
+
+  it("turns a space inside one name into a hyphen", () => {
+    expect(buildUpn("Anna Maria", "van Berg", "teacher")).toBe(
+      "anna-maria.van-berg@htldornbirn.at",
+    );
+  });
+
+  it.each([
+    ["an empty first name", "", "Doe"],
+    ["a blank last name", "Jane", "   "],
+    ["a name with no ASCII letters left", "Jane", "字"],
+    ["a name that is only punctuation", "Jane", "-.-"],
+  ])("returns null for %s", (_case, firstName, lastName) => {
+    expect(buildUpn(firstName, lastName, "teacher")).toBeNull();
+  });
+});
+
+describe("isSchoolUpn", () => {
+  it.each([
+    ["jane.doe@htldornbirn.at"],
+    ["jane.doe@student.htldornbirn.at"],
+    ["anna-maria.bauer-fink@student.htldornbirn.at"],
+  ])("accepts %s", (upn) => {
+    expect(isSchoolUpn(upn)).toBe(true);
+  });
+
+  it.each([
+    ["a missing last name", "jane@htldornbirn.at"],
+    ["a third name part", "jane.marie.doe@htldornbirn.at"],
+    ["a digit", "jane.doe2@htldornbirn.at"],
+    ["an underscore", "jane_doe@htldornbirn.at"],
+    ["an unrelated domain", "jane.doe@gmail.com"],
+    ["a lookalike domain", "jane.doe@evil-htldornbirn.at"],
+    ["a suffixed domain", "jane.doe@htldornbirn.at.evil.com"],
+    ["a dangling hyphen", "jane-.doe@htldornbirn.at"],
+    ["an empty string", ""],
+  ])("rejects %s", (_case, upn) => {
+    expect(isSchoolUpn(upn)).toBe(false);
   });
 });

--- a/src/lib/auth/upn.test.ts
+++ b/src/lib/auth/upn.test.ts
@@ -106,6 +106,9 @@ describe("isSchoolUpn", () => {
     ["an unrelated domain", "jane.doe@gmail.com"],
     ["a lookalike domain", "jane.doe@evil-htldornbirn.at"],
     ["a suffixed domain", "jane.doe@htldornbirn.at.evil.com"],
+    // Left unescaped, the dot in the domain is a wildcard and these would pass.
+    ["a staff domain with the dot substituted", "jane.doe@htldornbirnXat"],
+    ["a student domain with the dot substituted", "jane.doe@studentXhtldornbirn.at"],
     ["a dangling hyphen", "jane-.doe@htldornbirn.at"],
     ["an empty string", ""],
   ])("rejects %s", (_case, upn) => {

--- a/src/lib/auth/upn.ts
+++ b/src/lib/auth/upn.ts
@@ -27,8 +27,9 @@ export function roleFromUpn(upn: string): UserRole | null {
 
 /** `firstname.lastname`, hyphens allowed inside either part — no digits, no other separators. */
 const NAME_PART = "[a-z]+(?:-[a-z]+)*";
-const anyDomainOf = (...domains: string[]) =>
-  `(?:${domains.map((domain) => domain.replace(/\./g, "\\.")).join("|")})`;
+/** Everything the regex grammar gives meaning to, so a domain can only ever match itself. */
+const escapeForRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const anyDomainOf = (...domains: string[]) => `(?:${domains.map(escapeForRegExp).join("|")})`;
 const SCHOOL_UPN = new RegExp(
   `^${NAME_PART}\\.${NAME_PART}@${anyDomainOf(TEACHER_DOMAIN, STUDENT_DOMAIN)}$`,
 );

--- a/src/lib/auth/upn.ts
+++ b/src/lib/auth/upn.ts
@@ -24,3 +24,52 @@ export function roleFromUpn(upn: string): UserRole | null {
   if (domain === STUDENT_DOMAIN) return "student";
   return null;
 }
+
+/** `firstname.lastname`, hyphens allowed inside either part — no digits, no other separators. */
+const NAME_PART = "[a-z]+(?:-[a-z]+)*";
+const anyDomainOf = (...domains: string[]) =>
+  `(?:${domains.map((domain) => domain.replace(/\./g, "\\.")).join("|")})`;
+const SCHOOL_UPN = new RegExp(
+  `^${NAME_PART}\\.${NAME_PART}@${anyDomainOf(TEACHER_DOMAIN, STUDENT_DOMAIN)}$`,
+);
+
+/** The shape the school's tenant issues, and the only one the fake login may mint. */
+export function isSchoolUpn(upn: string): boolean {
+  return SCHOOL_UPN.test(upn.trim().toLowerCase());
+}
+
+// Written out rather than folded away, so "Müller" does not collapse into "muller".
+// Applied before the generic diacritic strip below.
+const TRANSLITERATIONS: Record<string, string> = {
+  ä: "ae",
+  ö: "oe",
+  ü: "ue",
+  ß: "ss",
+};
+
+function toNamePart(name: string): string | null {
+  const part = name
+    .trim()
+    .toLowerCase()
+    .replace(/[äöüß]/g, (char) => TRANSLITERATIONS[char])
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  return part || null;
+}
+
+/**
+ * Derives the UPN the tenant would issue for a person (US-3). Null when a name carries no
+ * character the UPN alphabet can represent.
+ */
+export function buildUpn(firstName: string, lastName: string, role: UserRole): string | null {
+  const first = toNamePart(firstName);
+  const last = toNamePart(lastName);
+  if (!first || !last) return null;
+
+  return `${first}.${last}@${role === "teacher" ? TEACHER_DOMAIN : STUDENT_DOMAIN}`;
+}

--- a/src/lib/firebase/admin.ts
+++ b/src/lib/firebase/admin.ts
@@ -17,6 +17,11 @@ function getAdminApp(): App {
   // Project ID isn't auto-discoverable from user ADC credentials, so pass it explicitly.
   return initializeApp({
     projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    // Minting a custom token means signing a JWT, and a user ADC credential holds no key to
+    // sign with. Deployed, the account is discovered from the metadata server; locally there
+    // is none, so the fake login needs to be told which account to sign as via the IAM API.
+    // Unset in every deployment, which is why it stays undefined here by default.
+    serviceAccountId: process.env.FIREBASE_SERVICE_ACCOUNT_ID,
   });
 }
 

--- a/src/lib/master-data/categories.ts
+++ b/src/lib/master-data/categories.ts
@@ -61,10 +61,10 @@ export const MASTER_DATA_CATEGORIES = {
     collection: COLLECTIONS.skillLevels,
     usage: { kind: "masterData", field: "skillLevel" },
     labels: {
-      title: "Könnensstufen",
-      singular: "Könnensstufe",
-      add: "Neue Könnensstufe",
-      empty: "Es gibt noch keine Könnensstufe.",
+      title: "Leistungsstufen",
+      singular: "Leistungsstufe",
+      add: "Neue Leistungsstufe",
+      empty: "Es gibt noch keine Leistungsstufe.",
     },
   },
   "bus-pickup-points": {

--- a/src/lib/master-data/seed-defaults.test.ts
+++ b/src/lib/master-data/seed-defaults.test.ts
@@ -56,8 +56,8 @@ describe("seedMasterDataDefaults", () => {
   it("stores the defaults with their German display text", async () => {
     await seedMasterDataDefaults();
 
-    expect(namesOf("skillLevels")).toEqual([
-      "Absoluter Anfänger",
+    expect(orderedNamesOf("skillLevels")).toEqual([
+      "Keine Vorkenntnisse",
       "Anfänger",
       "Fortgeschritten",
       "Profi",

--- a/src/lib/master-data/seed-defaults.ts
+++ b/src/lib/master-data/seed-defaults.ts
@@ -25,7 +25,7 @@ const PROGRAM_DEFAULTS = [
  * from the food options — it is always offered to students and is never a row (US-9).
  */
 const LIST_DEFAULTS: Partial<Record<MasterDataCategoryKey, readonly string[]>> = {
-  "skill-levels": ["Absoluter Anfänger", "Anfänger", "Fortgeschritten", "Profi"],
+  "skill-levels": ["Keine Vorkenntnisse", "Anfänger", "Fortgeschritten", "Profi"],
   "bus-pickup-points": ["HTL Dornbirn", "Bahnhof Bregenz", "Bahnhof Feldkirch", "Unterkunft"],
   "food-options": ["Alles", "Vegetarisch", "Vegan", "Kein Schweinefleisch"],
   "season-pass-options": [

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -19,7 +19,7 @@ export const MASTER_DATA_SECTIONS = [
   { href: "/app/master-data/seasons", label: "Saisonen" },
   { href: "/app/master-data/programs", label: "Programme" },
   { href: "/app/master-data/classes", label: "Klassen" },
-  { href: "/app/master-data/skill-levels", label: "Könnensstufen" },
+  { href: "/app/master-data/skill-levels", label: "Leistungsstufen" },
   { href: "/app/master-data/bus-pickup-points", label: "Zustiegsstellen" },
   { href: "/app/master-data/food-options", label: "Verpflegung" },
   { href: "/app/master-data/season-pass-options", label: "Saisonkarten" },


### PR DESCRIPTION
First promotion through the two-step flow. Five changes already merged into `staging` and verified there.

| PR | Change |
| --- | --- |
| #65 | Fake login standing in for Entra ID, plus a staging project of its own |
| #66 | CodeQL incomplete-escaping finding fixed; CodeQL now scans `staging` too |
| #67 | Progress stays visible until the fake login navigates |
| #68 | The dialog's UPN shown as a result rather than a field |
| #69 | Skill level category and its first entry relabelled |

## What reaches production

**The fake login does not.** It is not a disabled feature but absent from a production build: `route.fake.ts` only counts as a Route Handler while `fake.ts` is among the `pageExtensions`, and the dialog is aliased to a stub. Measured rather than assumed — a production build contains none of the strings the feature is made of, and the route is absent from the manifest.

Three independent locks would have to fail before it could serve real users: `apphosting.yaml` pins `AUTH_MODE: entra` as the fallback for any backend without an environment name, `.env` is gitignored, and `resolveAuthMode` refuses `fake` for the production project whatever the config says.

**Visible in production**, then: the sign-in progress fix, the two relabelled master data entries, and the CodeQL escaping fix.

## Database

The production database is empty, `seedState` included. The first request after the rollout re-seeds the master data — straight to the new labels, without the duplicate row that renaming an already-seeded list produces. That is what the timing was chosen for.

Firebase Auth accounts are untouched; the user record is re-provisioned on next sign-in and the role is re-derived from the UPN domain.

## Verified on staging

```
/sign-in        HTTP 200
/api/auth/fake  HTTP 200   (expected there, absent in production)
Skill levels:   "Keine Vorkenntnisse" | "Anfänger" | "Fortgeschritten" | "Profi"
```

The full sign-in path ran there for both roles — custom token, ID token, session cookie — with roles correctly derived from the domain.

## Merging

The ruleset allows only a **merge commit** into `main`. Squash or rebase would mint new commits, leaving `staging` no longer an ancestor of `main` and the two branches permanently diverged.
