### PR TITLE
Write down the repository language rule

### DIFF
--- a/.github/instructions/language.instructions.md
+++ b/.github/instructions/language.instructions.md
@@ -1,0 +1,61 @@
+---
+description: "Language rule for this repository — English everywhere project-side; German only where the word is a string the program actually shows."
+applyTo: "**/*"
+---
+
+<!--
+SPDX-License-Identifier: MIT
+Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+Licensed under the MIT License. See LICENSE in the repository root for details.
+-->
+
+# Language
+
+The application speaks German to its users. Everything else about it is written in English.
+
+## English, without exception
+
+Commit messages, pull request titles and descriptions, issue text, branch names, code,
+identifiers, comments, `spec/`, and these instruction files.
+
+This holds **regardless of the language the conversation is being held in**. A request made
+in German is still answered with an English commit and an English pull request. The language
+of the discussion and the language of the repository are unrelated.
+
+## German, only as a quoted program item
+
+A German word belongs in project text only when it _is_ a string the program shows — a label,
+a button caption, a validation or error message — and then it appears quoted, as the artefact
+under discussion:
+
+```text
+Renames the first skill level from "Absoluter Anfänger" to "Keine Vorkenntnisse".
+```
+
+Never as prose. The sentence around the quote stays English, and German terms do not leak
+into the explanation:
+
+```text
+Leistungsstufe is the vocabulary the Schulsportwoche uses, where students   <- no
+are grouped by ability; the assignment produces a Gruppe, not a Stufe.
+
+"Leistungsstufe" is the term already used for ability grouping on a school   <- yes
+sports week; the assignment produces a group, this field states a level.
+```
+
+## Internals stay English behind a German label
+
+Renaming what the user sees never renames what the code calls it:
+
+| Visible label   | Route          | Collection    | Field        |
+| --------------- | -------------- | ------------- | ------------ |
+| Leistungsstufen | `skill-levels` | `skillLevels` | `skillLevel` |
+
+A caption change is a caption change. Turning it into a collection rename would be a data
+migration, which is a different decision with different consequences.
+
+## Why
+
+Reviewers, tooling and search work across one language. Commit history and pull requests are
+read long after the conversation that produced them is forgotten, often by people who were
+not part of it — and a description half in German is searchable in neither language.


### PR DESCRIPTION
The convention was only ever implicit — English commits, English spec, German confined to what the app shows — and something implicit survives exactly as long as everyone happens to remember it. Two pull requests were written in German because the conversation that produced them was, which is the mistake the rule now names: the language of the discussion and the language of the repository are unrelated.

## What it says

- **English without exception** for commit messages, pull request titles and descriptions, issue text, branch names, code, identifiers, comments, `spec/`, and the instruction files themselves.
- **German only where the word is a string the program shows** — a label, a button caption, a message — and then quoted, as the artefact under discussion. Never as prose, and never leaking into the explanation around it.
- **Internals stay English behind a German label.** Renaming a caption is not renaming a collection; that would be a data migration, which is a different decision with different consequences.

The file contrasts a rejected and an accepted sentence rather than only describing the rule, since the failure mode is subtle — the text reads as English while German terms drift into the reasoning.

## Two details

`applyTo` is `**/*` because the rule governs commit messages and pull requests as much as files, and there is no glob for those. A narrower pattern would leave the part that actually went wrong uncovered.

The licence header sits **below** the YAML frontmatter. Frontmatter is only parsed when it starts at the first byte, so a header above it silently disables the file and Prettier then reflows the block as prose, corrupting the `applyTo` glob. I verified after formatting that the frontmatter still parses and `applyTo` is intact.

License check and Prettier both clean.
