### PR TITLE
Declare the token scope each workflow needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+# Enough for checkout, and nothing more. Artifact upload authenticates with the runtime
+# token rather than this one, so it needs no scope here.
+permissions:
+  contents: read
+
 jobs:
   lint-and-unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [main]
 
+# The check reads the branch name out of the event payload and nothing else: no checkout,
+# no API call, so the token needs no scope at all.
+permissions: {}
+
 jobs:
   promotion-source:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CodeQL flagged `promotion.yml` on the promotion pull request (#70), and checking the rule across the repository turned up the same alert already open against `ci.yml` on `main`. Without a `permissions` block the `GITHUB_TOKEN` is handed to the job with whatever the repository default grants, which is more than either workflow has any use for.

| workflow | before | after | why |
| --- | --- | --- | --- |
| `promotion.yml` | none | `{}` | Reads the branch name out of the event payload and nothing else — no checkout, no API call |
| `ci.yml` | none | `contents: read` | What checkout needs; artifact upload authenticates with the runtime token, not this one |
| `codeql.yml` | per job | unchanged | Already declares its scope on the job, which satisfies the rule |
| `deploy-rules.yml` | `contents: read`, `id-token: write` | unchanged | Already minimal |

`promotion.yml` getting `{}` rather than `contents: read` is deliberate: the job has no `checkout` step, so even read access to the repository would be scope it never exercises.

## Where the finding came from

The `actions` language in the CodeQL matrix, added in #66 and included specifically because workflows are code too. It has now earned its place twice — first as the analysis that would catch an expression spliced into a `run:` block, and now this.

## Scope

The fix targets `staging` rather than being pushed onto the promotion branch, so it flows through the normal route. Once merged, #70 picks it up on its next update and the alert clears before production sees it.

Formatting and license checks clean. CI running on this pull request is itself the test that `contents: read` is sufficient — if checkout needed more, these jobs would fail.
