### PR TITLE
Put the fake login behind a real Entra ID sign-in

### DIFF
--- a/src/app/api/auth/fake/route.fake.ts
+++ b/src/app/api/auth/fake/route.fake.ts
@@ -4,11 +4,14 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 import { z } from "zod";
 import { ErrorCode, apiError } from "@/lib/errors";
 import { adminAuth, adminDb } from "@/lib/firebase/admin";
 import { currentAuthMode } from "@/lib/auth/auth-mode";
+import { resolveRole } from "@/lib/auth/guards";
 import { buildUpn, isSchoolUpn } from "@/lib/auth/upn";
+import { SESSION_COOKIE_NAME } from "@/lib/session";
 import { COLLECTIONS } from "@/lib/schemas/collections";
 import { userRoleSchema, userSchema } from "@/lib/schemas/user";
 
@@ -19,11 +22,56 @@ import { userRoleSchema, userSchema } from "@/lib/schemas/user";
  * like any real login, so provisioning, the role claim and the session cookie stay on the
  * code path production uses.
  *
- * Anyone who can reach it can become anyone, which is why every entry point re-checks the
- * mode and otherwise answers 404 — an endpoint that is off should not advertise that it exists.
+ * Reaching it takes a real Entra ID sign-in first — see `entraTeacherCookie`. The mode check
+ * answers 404 rather than 403, because an endpoint that is off should not advertise that it
+ * exists; once it is on, refusing an unauthorised caller is no longer a secret worth keeping.
  */
 const notFound = () =>
   NextResponse.json(apiError(ErrorCode.NotFound, "Not found"), { status: 404 });
+
+const forbidden = () =>
+  NextResponse.json(apiError(ErrorCode.PermissionDenied, "Zuerst über Office 365 anmelden."), {
+    status: 403,
+  });
+
+/** Kept beside `__session`, which impersonating replaces with a custom-token one. */
+const ENTRA_COOKIE_NAME = "__entra_session";
+
+/**
+ * The credential that unlocks impersonation, and the reason it cannot be `__session` alone:
+ * this endpoint mints sessions, so one forged identity would otherwise authorise minting the
+ * next indefinitely. `sign_in_provider` is set by Firebase and survives into the session
+ * cookie, which makes it the one thing here that a caller cannot influence.
+ *
+ * Returns the cookie value so the caller can stash it — a tester who has switched identity
+ * still holds it and can switch again.
+ */
+async function entraTeacherCookie(): Promise<string | null> {
+  const store = await cookies();
+
+  for (const name of [ENTRA_COOKIE_NAME, SESSION_COOKIE_NAME]) {
+    const value = store.get(name)?.value;
+    if (!value) continue;
+
+    try {
+      const decoded = await adminAuth.verifySessionCookie(value, true);
+      if (decoded.firebase?.sign_in_provider !== "microsoft.com") continue;
+
+      // Impersonation is a staff capability: without this a student could sign in for real
+      // and then become a teacher.
+      const role = await resolveRole({
+        uid: decoded.uid,
+        email: decoded.email ?? null,
+        role: userRoleSchema.safeParse(decoded.role).data ?? null,
+      });
+      if (role === "teacher") return value;
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
 
 const bodySchema = z.object({
   firstName: userSchema.shape.firstName,
@@ -36,6 +84,7 @@ const listedUserSchema = userSchema.omit({ id: true, email: true });
 /** The UPNs already in Firestore, so a known user can be picked instead of retyped. */
 export async function GET() {
   if (currentAuthMode() !== "fake") return notFound();
+  if (!(await entraTeacherCookie())) return forbidden();
 
   try {
     const snapshot = await adminDb.collection(COLLECTIONS.users).get();
@@ -67,6 +116,9 @@ async function uidFor(upn: string, displayName: string): Promise<string> {
 export async function POST(request: Request) {
   if (currentAuthMode() !== "fake") return notFound();
 
+  const entraCookie = await entraTeacherCookie();
+  if (!entraCookie) return forbidden();
+
   const parsed = bodySchema.safeParse(await request.json());
   if (!parsed.success) {
     return NextResponse.json(
@@ -96,6 +148,15 @@ export async function POST(request: Request) {
     const customToken = await adminAuth.createCustomToken(uid, {
       given_name: firstName,
       family_name: lastName,
+    });
+
+    // Signing in with that token is about to overwrite `__session`, taking the proof of the
+    // real sign-in with it.
+    (await cookies()).set(ENTRA_COOKIE_NAME, entraCookie, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
     });
 
     return NextResponse.json({ customToken, upn });

--- a/src/app/api/auth/fake/route.test.ts
+++ b/src/app/api/auth/fake/route.test.ts
@@ -10,13 +10,18 @@ import { PRODUCTION_PROJECT_ID } from "@/lib/auth/auth-mode";
 const getUserByEmail = vi.fn();
 const createUser = vi.fn();
 const createCustomToken = vi.fn();
+const verifySessionCookie = vi.fn();
 const firestore = new FakeFirestore();
+const cookieStore = { get: vi.fn(), set: vi.fn() };
+
+vi.mock("next/headers", () => ({ cookies: () => Promise.resolve(cookieStore) }));
 
 vi.mock("@/lib/firebase/admin", () => ({
   adminAuth: {
     getUserByEmail: (...args: unknown[]) => getUserByEmail(...args),
     createUser: (...args: unknown[]) => createUser(...args),
     createCustomToken: (...args: unknown[]) => createCustomToken(...args),
+    verifySessionCookie: (...args: unknown[]) => verifySessionCookie(...args),
   },
   adminDb: firestore,
 }));
@@ -30,6 +35,21 @@ function postRequest(body: unknown) {
   });
 }
 
+const ENTRA_TEACHER = {
+  uid: "real-uid",
+  email: "jane.doe@htldornbirn.at",
+  role: "teacher",
+  firebase: { sign_in_provider: "microsoft.com" },
+};
+
+/** Whatever cookie the browser is holding when the fake login is called. */
+function signedInWith(cookies: Record<string, string>, decoded: unknown = ENTRA_TEACHER) {
+  cookieStore.get.mockImplementation((name: string) =>
+    cookies[name] === undefined ? undefined : { value: cookies[name] },
+  );
+  verifySessionCookie.mockResolvedValue(decoded);
+}
+
 describe("/api/auth/fake", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,9 +59,69 @@ describe("/api/auth/fake", () => {
     getUserByEmail.mockRejectedValue({ code: "auth/user-not-found" });
     createUser.mockImplementation(({ email }: { email: string }) => ({ uid: `uid-${email}` }));
     createCustomToken.mockResolvedValue("custom-token");
+    signedInWith({ __session: "entra-cookie" });
   });
 
   afterEach(() => vi.unstubAllEnvs());
+
+  // The fake login mints sessions, so a session alone cannot be the credential that unlocks
+  // it — one forged identity would otherwise authorise minting the next indefinitely.
+  describe("the Entra ID gate", () => {
+    it.each([
+      ["nobody is signed in", {}, ENTRA_TEACHER],
+      [
+        "the session came from a custom token",
+        { __session: "impersonated" },
+        { ...ENTRA_TEACHER, firebase: { sign_in_provider: "custom" } },
+      ],
+      [
+        "the signed-in user is a student",
+        { __session: "entra-cookie" },
+        { ...ENTRA_TEACHER, role: "student" },
+      ],
+    ])("refuses when %s", async (_case, cookies, decoded) => {
+      signedInWith(cookies, decoded);
+
+      const listed = await GET();
+      const minted = await POST(
+        postRequest({ firstName: "Jane", lastName: "Doe", role: "teacher" }),
+      );
+
+      expect(listed.status).toBe(403);
+      expect(minted.status).toBe(403);
+      expect(createCustomToken).not.toHaveBeenCalled();
+    });
+
+    it("refuses when the cookie does not verify", async () => {
+      cookieStore.get.mockReturnValue({ value: "tampered" });
+      verifySessionCookie.mockRejectedValue(new Error("invalid"));
+
+      expect((await GET()).status).toBe(403);
+    });
+
+    // Impersonating replaces __session with a custom-token one, so the Entra credential is
+    // kept aside — otherwise a tester could switch identity exactly once.
+    it("keeps admitting the tester after they have impersonated someone", async () => {
+      signedInWith({ __session: "impersonated", __entra_session: "entra-cookie" }, ENTRA_TEACHER);
+      verifySessionCookie.mockImplementation(async (cookie: string) =>
+        cookie === "entra-cookie"
+          ? ENTRA_TEACHER
+          : { ...ENTRA_TEACHER, firebase: { sign_in_provider: "custom" } },
+      );
+
+      expect((await GET()).status).toBe(200);
+    });
+
+    it("remembers the Entra session so later switches still pass", async () => {
+      await POST(postRequest({ firstName: "Jane", lastName: "Doe", role: "teacher" }));
+
+      expect(cookieStore.set).toHaveBeenCalledWith(
+        "__entra_session",
+        "entra-cookie",
+        expect.objectContaining({ httpOnly: true, sameSite: "lax" }),
+      );
+    });
+  });
 
   describe("when the fake login is not enabled", () => {
     it.each([

--- a/src/components/auth/fake-sign-in-dialog.stub.tsx
+++ b/src/components/auth/fake-sign-in-dialog.stub.tsx
@@ -10,8 +10,6 @@
  * or strings reach the bundle. next.config.ts aliases the import here — see `fakeLogin`.
  * The sign-in card never renders it in that case, so returning null is unreachable anyway.
  */
-export const FAKE_SIGN_IN_LABEL = null;
-
 export function FakeSignInDialog(): null {
   return null;
 }

--- a/src/components/auth/fake-sign-in-dialog.test.tsx
+++ b/src/components/auth/fake-sign-in-dialog.test.tsx
@@ -37,9 +37,10 @@ function stubApi(post: PostResult = { ok: true, status: 200, body: { customToken
 }
 
 function renderDialog() {
-  const onClose = vi.fn();
-  render(<FakeSignInDialog open onClose={onClose} />);
-  return { onClose, user: userEvent.setup() };
+  const onCancel = vi.fn();
+  const onImpersonated = vi.fn();
+  render(<FakeSignInDialog open onCancel={onCancel} onImpersonated={onImpersonated} />);
+  return { onCancel, onImpersonated, user: userEvent.setup() };
 }
 
 async function typeName(
@@ -105,7 +106,7 @@ describe("FakeSignInDialog", () => {
 
   it("signs in with the token the server minted", async () => {
     const fetchMock = stubApi();
-    const { user, onClose } = renderDialog();
+    const { user, onImpersonated } = renderDialog();
 
     await typeName(user, "Jane", "Doe");
     await user.click(screen.getByRole("button", { name: "Anmelden" }));
@@ -117,7 +118,7 @@ describe("FakeSignInDialog", () => {
       lastName: "Doe",
       role: "teacher",
     });
-    expect(onClose).toHaveBeenCalled();
+    expect(onImpersonated).toHaveBeenCalled();
   });
 
   it("refuses to submit a name that yields no school address", async () => {
@@ -137,7 +138,7 @@ describe("FakeSignInDialog", () => {
       status: 500,
       body: { error: { code: "INTERNAL_ERROR", message: "Test-Anmeldung derzeit nicht möglich." } },
     });
-    const { user, onClose } = renderDialog();
+    const { user, onImpersonated } = renderDialog();
 
     await typeName(user, "Jane", "Doe");
     await user.click(screen.getByRole("button", { name: "Anmelden" }));
@@ -145,6 +146,6 @@ describe("FakeSignInDialog", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Test-Anmeldung derzeit nicht möglich.",
     );
-    expect(onClose).not.toHaveBeenCalled();
+    expect(onImpersonated).not.toHaveBeenCalled();
   });
 });

--- a/src/components/auth/fake-sign-in-dialog.tsx
+++ b/src/components/auth/fake-sign-in-dialog.tsx
@@ -21,9 +21,7 @@ import { userRoleSchema, userSchema, type UserRole } from "@/lib/schemas/user";
 
 const NO_UPN = "Aus diesem Namen lässt sich keine gültige Schul-Adresse bilden.";
 const SIGN_IN_FAILED = "Test-Anmeldung fehlgeschlagen.";
-
-/** Lives here rather than on the card so the stub can drop it from a production bundle. */
-export const FAKE_SIGN_IN_LABEL = "Anmelden (Testmodus)";
+const NOT_ALLOWED = "Dafür ist eine Anmeldung als Lehrperson über Office 365 nötig.";
 
 const knownUsersSchema = z.array(
   z.object({
@@ -50,12 +48,20 @@ const SELECT_CLASS =
   "border-input focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-lg border bg-transparent px-3 text-sm outline-none focus-visible:ring-3";
 
 /**
- * Stands in for the Entra ID sign-in while developing (see `resolveAuthMode`). The name and
- * role compile into the UPN the tenant would issue, the server hands back a custom token,
- * and signing in with it puts the app on the same path as a real login — so the app can be
- * tried out as several teachers and students without tenant accounts.
+ * Impersonation, reached only after a real Entra ID sign-in (see the route's Entra gate).
+ * The name and role compile into the UPN the tenant would issue, the server hands back a
+ * custom token, and signing in with it puts the app on the same path as a real login — so
+ * the app can be tried as several teachers and students without tenant accounts.
  */
-export function FakeSignInDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+export function FakeSignInDialog({
+  open,
+  onCancel,
+  onImpersonated,
+}: {
+  open: boolean;
+  onCancel: () => void;
+  onImpersonated: () => void;
+}) {
   const [known, setKnown] = React.useState<KnownUser[]>([]);
   const [submitError, setSubmitError] = React.useState<string | null>(null);
   const knownId = React.useId();
@@ -78,12 +84,19 @@ export function FakeSignInDialog({ open, onClose }: { open: boolean; onClose: ()
     let cancelled = false;
 
     fetch("/api/auth/fake")
-      .then((response) => (response.ok ? response.json() : null))
+      .then((response) => {
+        if (response.status === 403) throw new Error(NOT_ALLOWED);
+        return response.ok ? response.json() : null;
+      })
       .then((body) => {
         const parsed = knownUsersSchema.safeParse(body?.users);
         if (!cancelled && parsed.success) setKnown(parsed.data);
       })
-      .catch(() => undefined);
+      .catch((error) => {
+        if (!cancelled && error instanceof Error && error.message === NOT_ALLOWED) {
+          setSubmitError(NOT_ALLOWED);
+        }
+      });
 
     return () => {
       cancelled = true;
@@ -123,7 +136,7 @@ export function FakeSignInDialog({ open, onClose }: { open: boolean; onClose: ()
       // The sign-in card's auth-state listener takes it from here: it trades the ID token
       // for the session cookie and navigates.
       await signInWithCustomToken(auth, minted.customToken);
-      onClose();
+      onImpersonated();
     } catch (error) {
       setSubmitError(error instanceof ApiRequestError ? error.message : SIGN_IN_FAILED);
     }
@@ -133,8 +146,8 @@ export function FakeSignInDialog({ open, onClose }: { open: boolean; onClose: ()
     <Dialog
       open={open}
       title="Test-Anmeldung"
-      description="Meldet ohne Entra ID an. Nur in der Entwicklung verfügbar."
-      onClose={onClose}
+      description="Als anderer Benutzer fortfahren, ohne dessen Entra-ID-Konto zu brauchen."
+      onClose={onCancel}
     >
       <form onSubmit={onSubmit} className="flex flex-col gap-4" noValidate>
         <div className="flex flex-col gap-1.5">
@@ -201,8 +214,8 @@ export function FakeSignInDialog({ open, onClose }: { open: boolean; onClose: ()
         ) : null}
 
         <div className="flex items-center justify-end gap-2">
-          <Button type="button" variant="outline" onClick={onClose}>
-            Abbrechen
+          <Button type="button" variant="outline" onClick={onCancel}>
+            Als ich selbst fortfahren
           </Button>
           <Button type="submit" disabled={isSubmitting}>
             Anmelden

--- a/src/components/auth/sign-in-card.test.tsx
+++ b/src/components/auth/sign-in-card.test.tsx
@@ -46,7 +46,15 @@ vi.mock("next/image", () => ({
 
 const { SignInCard } = await import("@/components/auth/sign-in-card");
 
-const signedInUser = { getIdToken: vi.fn().mockResolvedValue("id-token") };
+/** `signInProvider` is how the card tells a real sign-in from an impersonated one. */
+function userSignedInVia(provider: string) {
+  return {
+    getIdToken: vi.fn().mockResolvedValue("id-token"),
+    getIdTokenResult: vi.fn().mockResolvedValue({ token: "id-token", signInProvider: provider }),
+  };
+}
+
+const signedInUser = userSignedInVia("microsoft.com");
 
 function respondWith(status: number, body: unknown) {
   const fetchMock = vi.fn().mockResolvedValue({
@@ -264,20 +272,38 @@ describe("SignInCard", () => {
       });
     });
 
-    it("says on the button that this is not the real sign-in", async () => {
+    // Impersonating is reached through the real provider, not instead of it.
+    it("still offers the real sign-in as the way in", async () => {
       render(<SignInCard mode="fake" />);
 
-      expect(await screen.findByRole("button", { name: /Testmodus/i })).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: /Office 365/i })).not.toBeInTheDocument();
+      await userEvent.click(await screen.findByRole("button", { name: /Office 365/i }));
+
+      expect(signInWithRedirect).toHaveBeenCalled();
     });
 
-    it("opens the test-login dialog instead of handing off to Entra ID", async () => {
+    it("offers to impersonate once the real sign-in has produced a session", async () => {
+      onAuthStateChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+        callback(userSignedInVia("microsoft.com"));
+        return () => {};
+      });
+
       render(<SignInCard mode="fake" />);
 
-      await userEvent.click(await screen.findByRole("button", { name: /Testmodus/i }));
-
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
-      expect(signInWithRedirect).not.toHaveBeenCalled();
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    // Without this the impersonated session would reopen the dialog it just came from.
+    it("goes into the app instead of asking again once impersonating", async () => {
+      onAuthStateChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+        callback(userSignedInVia("custom"));
+        return () => {};
+      });
+
+      render(<SignInCard mode="fake" />);
+
+      await waitFor(() => expect(push).toHaveBeenCalledWith("/app"));
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
     // The dialog closes the moment it has signed in, and the session still has to be created
@@ -294,7 +320,7 @@ describe("SignInCard", () => {
       render(<SignInCard mode="fake" />);
       await waitFor(() => expect(screen.getByRole("button")).not.toBeDisabled());
 
-      await act(async () => notify(signedInUser));
+      await act(async () => notify(userSignedInVia("custom")));
 
       expect(screen.getByRole("status")).toBeInTheDocument();
       expect(screen.getByRole("button")).toBeDisabled();

--- a/src/components/auth/sign-in-card.tsx
+++ b/src/components/auth/sign-in-card.tsx
@@ -19,7 +19,7 @@ import {
 import { auth, createMicrosoftAuthProvider } from "@/lib/firebase/client";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { FakeSignInDialog, FAKE_SIGN_IN_LABEL } from "@/components/auth/fake-sign-in-dialog";
+import { FakeSignInDialog } from "@/components/auth/fake-sign-in-dialog";
 import { ROUTES, homeFor } from "@/lib/routes";
 import { userRoleSchema } from "@/lib/schemas/user";
 import type { AuthMode } from "@/lib/auth/auth-mode";
@@ -30,12 +30,13 @@ const SIGN_IN_FAILED = "Anmelden fehlgeschlagen. Bitte versuchen Sie es erneut."
 // Sign-in itself only starts when the user clicks the button — same window, no popup.
 // onAuthStateChanged reliably reports the signed-in user once Firebase resolves the
 // redirect (relies on the /__/auth/* proxy in next.config.ts — see redirect-best-practices).
-// It is also what finishes the fake login, which only has to put a user on `auth`.
+// It is also what finishes an impersonation, which only has to put a user on `auth`.
 export function SignInCard({ mode = "entra" }: { mode?: AuthMode }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
-  const [fakeDialogOpen, setFakeDialogOpen] = useState(false);
+  // Set together: the dialog is open, and this is where closing it without impersonating goes.
+  const [continueAs, setContinueAs] = useState<string | null>(null);
   // True until Firebase's first auth-state callback fires, which only happens once any
   // pending redirect has been resolved — avoids flashing the button during that window.
   const [checking, setChecking] = useState(true);
@@ -64,11 +65,11 @@ export function SignInCard({ mode = "entra" }: { mode?: AuthMode }) {
 
       try {
         await redirectSettled;
-        const idToken = await user.getIdToken();
+        const { token, signInProvider } = await user.getIdTokenResult();
         const response = await fetch("/api/session", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ idToken, msAccessToken: graphAccessToken }),
+          body: JSON.stringify({ idToken: token, msAccessToken: graphAccessToken }),
         });
 
         // The UPN domain isn't eligible (US-3) — leave no half-authenticated client state behind.
@@ -86,10 +87,18 @@ export function SignInCard({ mode = "entra" }: { mode?: AuthMode }) {
 
         const body = await response.json().catch(() => null);
         const role = userRoleSchema.safeParse(body?.role);
+        const destination =
+          searchParams.get("next") ?? (role.success ? homeFor(role.data) : ROUTES.appRoot);
 
-        router.push(
-          searchParams.get("next") ?? (role.success ? homeFor(role.data) : ROUTES.appRoot),
-        );
+        // Only a real sign-in unlocks the dialog, and only a real sign-in should be offered
+        // it: an impersonated session arriving here came *from* the dialog.
+        if (mode === "fake" && signInProvider === "microsoft.com") {
+          setChecking(false);
+          setContinueAs(destination);
+          return;
+        }
+
+        router.push(destination);
         router.refresh();
       } catch {
         setChecking(false);
@@ -98,14 +107,10 @@ export function SignInCard({ mode = "entra" }: { mode?: AuthMode }) {
     });
 
     return () => unsubscribe();
-  }, [router, searchParams]);
+  }, [router, searchParams, mode]);
 
   async function handleSignIn() {
     setError(null);
-    if (mode === "fake") {
-      setFakeDialogOpen(true);
-      return;
-    }
     await signInWithRedirect(auth, createMicrosoftAuthProvider());
   }
 
@@ -126,9 +131,7 @@ export function SignInCard({ mode = "entra" }: { mode?: AuthMode }) {
           </h1>
           <p className="text-muted-foreground mt-2 text-sm">Sportwochen-Verwaltung</p>
           <Button className="mt-8 h-10 w-full" onClick={handleSignIn} disabled={checking}>
-            {mode === "fake" && FAKE_SIGN_IN_LABEL
-              ? FAKE_SIGN_IN_LABEL
-              : "Anmelden über Office 365"}
+            Anmelden über Office 365
           </Button>
           {/* Always occupies its height, so the card doesn't resize when the spinner appears. */}
           <div data-slot="sign-in-status" className="mt-4 flex h-5 items-center justify-center">
@@ -146,7 +149,17 @@ export function SignInCard({ mode = "entra" }: { mode?: AuthMode }) {
           ) : null}
         </CardContent>
       </Card>
-      {fakeDialogOpen ? <FakeSignInDialog open onClose={() => setFakeDialogOpen(false)} /> : null}
+      {continueAs ? (
+        <FakeSignInDialog
+          open
+          onCancel={() => {
+            setContinueAs(null);
+            router.push(continueAs);
+            router.refresh();
+          }}
+          onImpersonated={() => setContinueAs(null)}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Anyone who could reach `/api/auth/fake` could become anyone — including a teacher — with no credential at all. It now takes a real Entra ID sign-in first, as a staff member, before any identity can be assumed.

## Why a session alone cannot be the credential

The obvious guard — "require a valid session" — does not work here, because **this endpoint mints sessions**. An impersonated session would authorise minting the next one, and one leak would become permanent access with no way back to a real identity.

The discriminator has to be something the caller cannot influence. `firebase.sign_in_provider` is set by Firebase during the token exchange and survives into the session cookie:

| sign-in | `sign_in_provider` |
| --- | --- |
| Entra ID | `microsoft.com` |
| custom token (impersonation) | `custom` |

The gate verifies the cookie with `verifySessionCookie` and requires `microsoft.com`.

## Why the Entra cookie is kept separately

Impersonating replaces `__session` with a custom-token session — which would take the proof of the real sign-in with it, leaving a tester able to switch identity exactly once and then stuck. Since testing several users is the entire point, that would have defeated the feature.

So on a successful mint the verified Entra cookie is stashed as `__entra_session`, and the gate reads that first, falling back to `__session`. It is a genuine Firebase session cookie, so it is unforgeable and revocable — no new secret, no signing scheme of our own.

## Why teacher, not merely authenticated

The tenant is the school's own, so students can sign in for real. Without a role check one could authenticate honestly and then promote themselves to teacher. The role is resolved through `resolveRole` rather than read straight off the claim, because the custom claim is absent on a first login — reading it directly would lock out a teacher signing in for the first time.

## Flow

```
Anmelden über Office 365  →  real session (microsoft.com)
                          →  dialog: continue as yourself, or become someone else
                          →  impersonated session (custom)  →  into the app
```

The card decides which of these happened from `getIdTokenResult().signInProvider`. Without that, an impersonated session arriving at the card would reopen the dialog it had just come from. That is client-side flow only — the security boundary is the server-side gate.

The dialog gained separate `onCancel` and `onImpersonated` callbacks: a single close handler could not tell continuing as yourself, which navigates, from having just assumed another identity, where the auth listener does the navigating.

## Alternatives rejected

- **Reading only the current `__session`** — simplest, but allows one impersonation before a full round trip through Entra. Rejected on the grounds that it undermines the use case.
- **A custom HMAC-signed gate cookie** — a new secret to hold and rotate, when Firebase already issues a verified, revocable credential.

## Verified

Production output still contains none of it — no route in the manifest, and none of the feature's strings, the new `__entra_session` included. The staging build still registers the route.

860 tests (7 new for the gate and the flow), lint, types, Prettier and the license check all clean.
