### PR TITLE
Point local development at staging by default

### DIFF
--- a/apphosting.staging.yaml
+++ b/apphosting.staging.yaml
@@ -6,7 +6,7 @@
 #
 # App Hosting picks this file for any backend whose Environment name is `staging`
 # (console > App Hosting > View dashboard > Settings > Environment), falling back to
-# apphosting.yaml otherwise. `npm run dev:staging` sets APP_HOSTING_ENV=staging so
+# apphosting.yaml otherwise. `npm run dev` sets APP_HOSTING_ENV=staging so
 # next.config.ts merges it the same way locally.
 # See https://firebase.google.com/docs/app-hosting/multiple-environments.
 #

--- a/next.config.ts
+++ b/next.config.ts
@@ -20,8 +20,8 @@ function readEnv(fileName: string): Record<string, string> {
 
 // App Hosting layers apphosting.<environment>.yaml over apphosting.yaml for a backend tagged
 // with that environment name, and injects the result. APP_HOSTING_ENV reproduces that for a
-// local build, so `npm run dev:staging` points at staging without editing the production
-// config — but on App Hosting the injected values are the ones that count.
+// local build. `npm run dev` sets it to staging, so local work never reaches the production
+// database — but on App Hosting the injected values are the ones that count.
 const environment = process.env.APP_HOSTING_ENV;
 const env = preferProcessEnv(
   {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "node": ">=24"
   },
   "scripts": {
-    "dev": "next dev --experimental-https --experimental-https-key ./.certs/localhost-key.pem --experimental-https-cert ./.certs/localhost.pem",
-    "dev:staging": "APP_HOSTING_ENV=staging npm run dev",
+    "dev": "APP_HOSTING_ENV=staging npm run dev:server",
+    "dev:production": "npm run dev:server",
+    "dev:server": "next dev --experimental-https --experimental-https-key ./.certs/localhost-key.pem --experimental-https-cert ./.certs/localhost.pem",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
`npm run dev` read `apphosting.yaml` and therefore talked to **production**. Signing in provisioned a user record there; a first request seeded the master data there. Both against the live database, from a laptop, by default. The staging project exists precisely so that neither has to happen.

| script | project | auth mode |
| --- | --- | --- |
| `npm run dev` | `htld-sportsweek-staging` | `fake` |
| `npm run dev:production` | `htld-sportsweek` | `entra` |

Verified by resolving the environment exactly as `next.config.ts` does, rather than by reading the config and assuming.

`APP_HOSTING_ENV=staging` is baked into `dev` rather than offered as a second script nobody remembers to type — `dev:staging` existed already and was not what anyone typed. Production stays reachable as `dev:production`, spelled out, because debugging live data is occasionally the point; it just can no longer be what happens when you type the obvious command.

## This depends on something that is not set up yet

Staging has **no sign-in provider configured at all**. Production has `microsoft.com`; staging has none — I only initialised Identity Platform when creating the project.

Today that is invisible, because the fake login on `staging` is still ungated. The moment #73 merges, the fake login requires a real Entra ID sign-in first — and on staging there is nothing to sign in with. Local development would then be unable to authenticate at all.

Fixing it needs two things I cannot do:

1. **Firebase console → Authentication → Sign-in method → Microsoft**, using the existing app registration `029ffca6-e21b-45d0-bc7a-72acc84148e5` and its client secret. The secret is write-only through the API, so it has to come from you.
2. **Azure portal → app registration → Authentication**, adding the redirect URI `https://htld-sportsweek-staging.firebaseapp.com/__/auth/handler`. Without it Entra rejects the callback.

Merging this PR before that is safe — it changes only which project local development points at, and the ungated fake login still works there until #73 lands.

853 tests, lint, Prettier and the license check all clean.
