### PR TITLE
Turn real student accounts away from test environments

### DIFF
--- a/src/app/api/session/route.test.ts
+++ b/src/app/api/session/route.test.ts
@@ -60,6 +60,19 @@ describe("POST /api/session", () => {
     expect(verifyIdToken).not.toHaveBeenCalled();
   });
 
+  // "not enabled for Sportsweek" would send a student looking for someone to enable them.
+  it("says why when a student is turned away from a test environment", async () => {
+    verifyIdToken.mockResolvedValue({ uid: "u", email: "max@student.htldornbirn.at" });
+    provisionUser.mockResolvedValue({ ok: false, reason: "students-excluded" });
+
+    const response = await POST(postRequest({ idToken: "good-token" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.message).toMatch(/Lehrpersonen/);
+    expect(cookieStore.set).not.toHaveBeenCalled();
+  });
+
   it("returns 401 when the ID token is invalid", async () => {
     verifyIdToken.mockRejectedValue(new Error("invalid token"));
 

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -57,10 +57,14 @@ export async function POST(request: Request) {
   }
 
   if (!provisioned.ok) {
-    return NextResponse.json(
-      apiError(ErrorCode.PermissionDenied, "Dieses Konto ist für Sportsweek nicht freigeschaltet."),
-      { status: 403 },
-    );
+    // A student turned away from a test environment is not an account problem, and telling
+    // them it is would send them looking for someone to enable them.
+    const message =
+      provisioned.reason === "students-excluded"
+        ? "Diese Umgebung steht nur Lehrpersonen offen."
+        : "Dieses Konto ist für Sportsweek nicht freigeschaltet.";
+
+    return NextResponse.json(apiError(ErrorCode.PermissionDenied, message), { status: 403 });
   }
 
   let sessionCookie: string;

--- a/src/lib/auth/auth-mode.ts
+++ b/src/lib/auth/auth-mode.ts
@@ -11,6 +11,11 @@ export type AuthMode = z.infer<typeof authModeSchema>;
 /** The one project holding real people's data, and so the one that may never fake a login. */
 export const PRODUCTION_PROJECT_ID = "htld-sportsweek";
 
+/** Anything else is a test environment, holding invented people and unfinished work. */
+export function isProductionProject(): boolean {
+  return process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID === PRODUCTION_PROJECT_ID;
+}
+
 /**
  * Picks the sign-in implementation for this deployment (`AUTH_MODE`).
  *

--- a/src/lib/auth/provision-user.test.ts
+++ b/src/lib/auth/provision-user.test.ts
@@ -3,7 +3,8 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PRODUCTION_PROJECT_ID } from "@/lib/auth/auth-mode";
 
 const docGet = vi.fn();
 const docSet = vi.fn();
@@ -32,6 +33,56 @@ const teacherClaims = {
 function existingRecord(data: Record<string, unknown>) {
   docGet.mockResolvedValue({ exists: true, data: () => data });
 }
+
+const ENTRA = { firebase: { sign_in_provider: "microsoft.com" } };
+const IMPERSONATED = { firebase: { sign_in_provider: "custom" } };
+
+const studentClaims = {
+  uid: "firebase-uid-2",
+  email: "max.mustermann@student.htldornbirn.at",
+  given_name: "Max",
+  family_name: "Mustermann",
+};
+
+/**
+ * A test environment holds invented people and unfinished work. A student's real account has
+ * no business there — but an impersonated student is exactly what it is for.
+ */
+describe("students outside production", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_FIREBASE_PROJECT_ID", "htld-sportsweek-staging");
+    docGet.mockResolvedValue({ exists: false, data: () => undefined });
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("turns away a student signing in with their real account", async () => {
+    const result = await provisionUser({ ...studentClaims, ...ENTRA });
+
+    expect(result).toEqual({ ok: false, reason: "students-excluded" });
+    expect(docSet).not.toHaveBeenCalled();
+  });
+
+  it("still admits a student the fake login is standing in for", async () => {
+    const result = await provisionUser({ ...studentClaims, ...IMPERSONATED });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("leaves teachers alone", async () => {
+    const result = await provisionUser({ ...teacherClaims, ...ENTRA });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("admits a real student in production, where the rule does not apply", async () => {
+    vi.stubEnv("NEXT_PUBLIC_FIREBASE_PROJECT_ID", PRODUCTION_PROJECT_ID);
+
+    const result = await provisionUser({ ...studentClaims, ...ENTRA });
+
+    expect(result.ok).toBe(true);
+  });
+});
 
 describe("provisionUser", () => {
   beforeEach(() => {

--- a/src/lib/auth/provision-user.ts
+++ b/src/lib/auth/provision-user.ts
@@ -8,6 +8,7 @@ import { adminAuth, adminDb } from "@/lib/firebase/admin";
 import { COLLECTIONS } from "@/lib/schemas/collections";
 import { userSchema, type User } from "@/lib/schemas/user";
 import { fetchEntraName } from "./graph";
+import { isProductionProject } from "./auth-mode";
 import { roleFromUpn } from "./upn";
 
 export type EntraClaims = {
@@ -17,10 +18,12 @@ export type EntraClaims = {
   given_name?: string;
   family_name?: string;
   role?: unknown;
+  firebase?: { sign_in_provider?: string };
 };
 
 export type ProvisionOutcome =
-  { ok: true; user: User } | { ok: false; reason: "missing-upn" | "unsupported-domain" };
+  | { ok: true; user: User }
+  | { ok: false; reason: "missing-upn" | "unsupported-domain" | "students-excluded" };
 
 function resolveName(claims: EntraClaims, fallback: string) {
   const given = claims.given_name?.trim();
@@ -48,6 +51,18 @@ export async function provisionUser(
 
   const derivedRole = roleFromUpn(upn);
   if (!derivedRole) return { ok: false, reason: "unsupported-domain" };
+
+  // A test environment is for staff trying things out, so a student's own account is turned
+  // away there. The provider is what separates that from the fake login standing in for a
+  // student, which is the entire point of the environment: Firebase sets it, and a caller
+  // cannot claim `microsoft.com` without having actually been through Entra ID.
+  if (
+    derivedRole === "student" &&
+    !isProductionProject() &&
+    claims.firebase?.sign_in_provider === "microsoft.com"
+  ) {
+    return { ok: false, reason: "students-excluded" };
+  }
 
   const localPart = upn.slice(0, upn.indexOf("@"));
   // Graph is the only authoritative source for the name; the token claims carry a display


### PR DESCRIPTION
A test environment holds invented people and unfinished work. A student signing in with their own credentials would be shown it as though it were the real application. Outside the production project their sign-in is now refused, before any record is written.

## The distinction that makes this work

A blanket "no students outside production" would have broken the fake login entirely — **standing in for a student is what the environment exists for**. Both paths end at the same `provisionUser`, so the rule has to tell them apart.

`sign_in_provider` does that, and it is the same value the fake login's own gate turns on:

| sign-in | provider | outside production |
| --- | --- | --- |
| student, real Entra ID account | `microsoft.com` | **refused** |
| student, impersonated by the fake login | `custom` | admitted |
| teacher, either way | — | admitted |
| student, in production | — | admitted |

Firebase sets that claim during the token exchange, so a caller cannot assert `microsoft.com` without having actually been through Entra ID. Anything the client could set would be worthless here.

## The message

Refusal says the environment is for teachers rather than reusing "Dieses Konto ist für Sportsweek nicht freigeschaltet." That would be untrue — the account is perfectly fine — and would send a student looking for someone to enable them.

## Scope

Production is keyed out by project, where students are exactly who the application is for. The check runs before the Firestore write, so a refused sign-in leaves no user record behind — otherwise a student's record would accumulate in every test environment they touched.

858 tests (5 new), lint, types, Prettier and the license check all clean.

Worth reading alongside #73: that one stops a real *teacher* becoming someone else without authenticating; this one stops a real *student* getting in at all. Different holes, same discriminator.
