### PR TITLE
Watch the ID token, not the sign-in state

### DIFF
--- a/src/components/auth/sign-in-card.test.tsx
+++ b/src/components/auth/sign-in-card.test.tsx
@@ -3,10 +3,11 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const onIdTokenChanged = vi.fn();
 const onAuthStateChanged = vi.fn();
 const signInWithRedirect = vi.fn();
 const signOut = vi.fn();
@@ -16,6 +17,7 @@ const push = vi.fn();
 const refresh = vi.fn();
 
 vi.mock("firebase/auth", () => ({
+  onIdTokenChanged,
   onAuthStateChanged,
   signInWithRedirect,
   signOut,
@@ -30,7 +32,7 @@ vi.mock("@/lib/firebase/client", () => ({
 }));
 
 // Stable across renders, as the real hooks are: a fresh object each call would re-run the
-// auth-state effect on every render, which the card is not written to expect.
+// subscription effect on every render, which the card is not written to expect.
 const router = { push, refresh };
 const searchParams = new URLSearchParams();
 
@@ -71,7 +73,7 @@ describe("SignInCard", () => {
     vi.clearAllMocks();
     getRedirectResult.mockResolvedValue(null);
     credentialFromResult.mockReturnValue(null);
-    onAuthStateChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+    onIdTokenChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
       callback(signedInUser);
       return () => {};
     });
@@ -166,7 +168,7 @@ describe("SignInCard", () => {
     ["when idle", false],
   ])("reserves the spinner's space %s so the card keeps its height", async (_case, busy) => {
     respondWith(200, { status: "ok" });
-    onAuthStateChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+    onIdTokenChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
       callback(busy ? signedInUser : null);
       return () => {};
     });
@@ -189,7 +191,7 @@ describe("SignInCard", () => {
   });
 
   it("shows no spinner once the visitor can sign in", async () => {
-    onAuthStateChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+    onIdTokenChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
       callback(null);
       return () => {};
     });
@@ -264,7 +266,7 @@ describe("SignInCard", () => {
   });
 
   it("starts the real sign-in when the button is pressed", async () => {
-    onAuthStateChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+    onIdTokenChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
       callback(null);
       return () => {};
     });
@@ -277,7 +279,7 @@ describe("SignInCard", () => {
 
   // A rejected redirect never leaves the page, so saying nothing looks like a dead button.
   it("reports a sign-in that could not even start", async () => {
-    onAuthStateChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+    onIdTokenChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
       callback(null);
       return () => {};
     });
@@ -288,5 +290,26 @@ describe("SignInCard", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent(/fehlgeschlagen/i);
     expect(screen.getByRole("button")).not.toBeDisabled();
+  });
+
+  // Impersonating yourself keeps the same uid, so the sign-in *state* never changes and
+  // onAuthStateChanged stays silent -- only the token is new. Listening to the wrong one
+  // leaves the card waiting for a callback that will not come.
+  it("notices a fresh token for the user already signed in", async () => {
+    respondWith(200, { status: "ok" });
+    let notify: (user: unknown) => void = () => {};
+    onIdTokenChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+      notify = callback;
+      callback(null);
+      return () => {};
+    });
+
+    render(<SignInCard />);
+    await waitFor(() => expect(screen.getByRole("button")).not.toBeDisabled());
+
+    await act(async () => notify(userSignedInVia("custom")));
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/app"));
+    expect(onAuthStateChanged).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/auth/use-sign-in.ts
+++ b/src/lib/auth/use-sign-in.ts
@@ -10,7 +10,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import {
   OAuthProvider,
   getRedirectResult,
-  onAuthStateChanged,
+  onIdTokenChanged,
   signInWithRedirect,
   signOut,
 } from "firebase/auth";
@@ -56,7 +56,10 @@ export function useSignIn() {
       })
       .catch(() => undefined);
 
-    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+    // Tokens rather than sign-in state: impersonating yourself keeps the same uid, and
+    // onAuthStateChanged only reports a *change* of user — it would stay silent exactly
+    // when the impersonation dialog is waiting to hand over.
+    const unsubscribe = onIdTokenChanged(auth, async (user) => {
       if (!user) {
         setChecking(false);
         return;


### PR DESCRIPTION
Follows #77, which was squash-merged while this commit was still being written.

## The bug

Impersonating the person who is already signed in does not reach the dashboard. The dialog
closes and the sign-in screen sits there; a manual reload then shows the dashboard.

## Why

Firebase distinguishes the two observers, and the SDK's own documentation says how:

| | fires on |
| --- | --- |
| `onAuthStateChanged` | "changes to the user's **sign-in state**" |
| `onIdTokenChanged` | "sign-in, sign-out, and **token refresh** events" |

Impersonating yourself signs in with a custom token for the *same uid*. The sign-in state
therefore never changes — only the token does — and `onAuthStateChanged` stays silent at
exactly the moment the impersonation dialog is waiting to hand over. `useSignIn` never runs
again, so nothing navigates.

That a reload fixes it is the same fact seen from the other side: the session cookie had been
created by the Entra sign-in all along, so the server was happy. Only the client failed to
notice it had signed in again.

`useSignIn` now watches the ID token, which covers sign-in, sign-out *and* a new token for the
same user.

## Not changed

`src/lib/firebase/live-query.ts` keeps `onAuthStateChanged`. It re-subscribes Firestore
listeners for whoever is signed in, and the same uid means the same data — switching it would
re-subscribe on every hourly token refresh for nothing.

## Test

The new test drives the callback through `onIdTokenChanged` and asserts `onAuthStateChanged`
was never subscribed to, so that quietly moving back to the wrong observer fails rather than
regresses. It failed before the change.

878 unit tests pass.
