### PR TITLE
Hold a list row while its write is in flight

### DIFF
--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -58,6 +58,7 @@ As a user, I log in with my Microsoft Entra ID credentials so that I can access 
 - A user record is created on the user's first login if none exists yet.
 - There is a 1:1 relationship between the Entra ID user and the user record stored in the database.
 - The user record's ID is the Entra ID user principal name (UPN).
+- Production always signs users in this way; only the test environment substitutes a fake login for the identity provider (see US-16).
 
 ### US-2: Role model
 
@@ -270,15 +271,17 @@ As a teacher, I can view a report listing all students so that I have their cont
 **Acceptance criteria:**
 
 - A report page exists, listing all students registered for the active season (see US-4).
-- For each student, the report always shows the first name and last name (see US-1).
-- The report has two independent tag lists: a filter tag list that determines which students are shown, and a columns tag list that determines which additional fields are shown for each student.
+- The report is a master-detail list rather than a table: each student is one master line showing the first name and last name (see US-1), followed by that student's detail lines.
+- Every data field activated in the fields tag list adds exactly one detail line, indented below the master line of the student it belongs to, showing the field's label and that student's value for it. With no field activated, each student is reduced to its master line.
+- The report has two independent tag lists: a filter tag list that determines which students are shown, and a fields tag list that determines which detail lines are shown below each master line.
 - The filter tag list works the same way as in the assignment dialog (see US-12): a free-text filter for the name with a clear button, and a wrapping tag row (with a first "all" tag) for class, gender, program, and skill level, each following the same within-category-OR / across-category-AND combination rules. In addition, since this report (unlike the assignment dialog) also lists students who answered "no", the tag row has an extra attendance category with the tags "attending" and "not attending" (see US-11), following the same selection rules as the other categories.
-- The columns tag list lets the teacher select which additional fields, beyond first name and last name, are shown for each student: attending status (yes/no, see US-11), class (see US-6), gender (see US-11), date of birth (see US-11), contact data (email address, see US-1; phone number and emergency contact — name, relationship, and phone number — see US-11), program (see US-5), skill level (see US-7), body measurements (weight, height, shoe size, see US-11), needed rental equipment (see US-11), bus pickup point (see US-8), season pass (see US-10), food/diet option (including its free text if "other" is selected, see US-9), and health/medication (health notes and whether medication is carried, see US-11).
+- The fields tag list lets the teacher activate the data fields shown as detail lines, beyond the first name and last name already on the master line: attending status (yes/no, see US-11), class (see US-6), gender (see US-11), date of birth (see US-11), contact data (email address, see US-1; phone number and emergency contact — name, relationship, and phone number — see US-11), program (see US-5), skill level (see US-7), body measurements (weight, height, shoe size, see US-11), needed rental equipment (see US-11), bus pickup point (see US-8), season pass (see US-10), food/diet option (including its free text if "other" is selected, see US-9), and health/medication (health notes and whether medication is carried, see US-11).
+- A tag that stands for a group of fields — contact data, body measurements, health/medication — activates every field in that group at once, and each of those fields then gets its own detail line.
 - A dropdown next to the filter tag list shows all saved filters by name, shared among all teachers (not private to the teacher who saved it); selecting one applies its saved filter tag list selection to the report. This is a custom dropdown/listbox component (e.g. a popover-based combobox), not a native HTML `<select>` element, since a native `<select>` cannot render the per-item rename/delete icons described below.
 - Next to the dropdown, a Save button lets the teacher save the current filter tag list selection under a name, entered inline (e.g. in a small popover) without leaving the report page.
 - In the dropdown, each saved filter has a rename and a delete icon, so the teacher can rename or delete it inline, directly in the dropdown, without a separate management page. On pointer-based devices (desktop) the icons appear on hover; on touch devices (tablet, mobile), where there is no hover state, the icons are always visible instead, so the feature stays usable on every supported screen size (see General).
 - Renaming a saved filter edits its name in place; deleting one requires a lightweight inline confirmation before it is removed.
-- A print button on the report page opens the report as HTML in a popup window, which the teacher can then print (e.g. to PDF or any format supported by the installed printers).
+- A print button on the report page opens the report as HTML in a popup window, keeping the master-detail structure, which the teacher can then print (e.g. to PDF or any format supported by the installed printers).
 
 ## Navigation
 
@@ -303,3 +306,25 @@ As a student, I only see my master data when I log in, so that I can go straight
 - When a student logs in, only the student master data (see US-11) is shown.
 - The student's page has the same header row as the teacher dashboard (see US-14): the application title "Sportsweek" on the left, and a logout button on the right.
 - A student's view has no left-side navigation zone (see US-14); the header is followed directly by the master data content.
+
+## Test Environment
+
+### US-16: Fake login in the test environment
+
+As a teacher trying the application out, I can continue as any teacher or student after signing in, so that the application can be exercised with a whole class of people without an Entra ID account for each of them.
+
+**Acceptance criteria:**
+
+- The fake login replaces the identity provider and nothing else. The chosen identity is signed in through the same session endpoint as a real login, so provisioning (US-1), the role derived from the UPN domain (US-3), the session cookie, and every authorization check downstream stay on the code paths production uses.
+- The fake login is opt-in per deployment, and the production project refuses it whatever the configuration says.
+- A deployment that does not opt in has no fake login to disable: the modules and the endpoint behind it are not part of the build at all, so a configuration mistake cannot turn it on after the fact.
+- The test environment is a separate Firebase project from production, because the fake login creates real authentication accounts and real user records, and neither belongs anywhere near real people's data.
+- The test environment has its own sign-in screen, marked "Testumgebung" and stating that the data is invented, so that the two environments cannot be mistaken for one another.
+- Signing in still begins with a real Entra ID sign-in (US-1). Only a teacher who has been through it is offered the choice of who to continue as, and the endpoint that mints the chosen identity refuses every other caller. While the fake login is off, that endpoint answers as if it did not exist rather than admitting that it does.
+- Whether the caller came through Entra ID is decided by the sign-in provider that Firebase records during the token exchange, which a caller cannot assert for themselves. Without that distinction, one invented identity could authorize inventing the next.
+- The proof of the real Entra ID sign-in is kept separately from the session cookie that continuing as someone else replaces, so switching identity does not give up the right to switch again.
+- A student who signs in through Entra ID is refused with "Diese Umgebung steht nur Lehrpersonen offen.", while an impersonated student is admitted — that case is what the environment exists for.
+- The choice is made in a dialog that asks for a first name, a last name, and a role, or lets one of the users already present be picked instead. Cancelling continues as the signed-in teacher.
+- The UPN is derived from the name and the role rather than typed: `firstname.lastname` at the teacher or the student domain of US-3, with German umlauts spelled out ("Müller" becomes `mueller`, never `muller`) and remaining diacritics dropped. It is shown as it is derived and cannot be edited.
+- A name from which no valid school address can be formed is refused, on the client and on the server alike, with "Aus diesem Namen lässt sich keine gültige Schul-Adresse bilden." — the fake tenant may only issue UPNs the real one could have issued.
+- Choosing a role chooses the domain; the role itself still follows from that domain (US-3). A user record that already exists keeps the role it was created with, exactly as after a real login.

--- a/src/components/events/events-view.test.tsx
+++ b/src/components/events/events-view.test.tsx
@@ -195,6 +195,49 @@ describe("EventsView — removing", () => {
   });
 });
 
+// The list refreshes from a separate subscription, so between the answer and the refresh a row
+// still offers actions against an event the write it is waiting on may already have removed.
+describe("EventsView — while a write is in flight", () => {
+  async function confirmDelete() {
+    await userEvent.click(screen.getByRole("button", { name: "Event Montafon löschen" }));
+    await userEvent.click(screen.getByRole("button", { name: "Löschen" }));
+  }
+
+  it("locks the row that is being written to", async () => {
+    stubFetch(() => new Promise(() => {}));
+    renderView();
+
+    await confirmDelete();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Event Montafon bearbeiten" })).toBeDisabled(),
+    );
+    expect(screen.getByRole("button", { name: "Montafon verschieben" })).toBeDisabled();
+  });
+
+  it("leaves every other row alone", async () => {
+    stubFetch(() => new Promise(() => {}));
+    renderView();
+
+    await confirmDelete();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Event Montafon bearbeiten" })).toBeDisabled(),
+    );
+    expect(screen.getByRole("button", { name: "Event Lech bearbeiten" })).toBeEnabled();
+  });
+
+  it("releases the row once the write is answered", async () => {
+    stubFetch(noContent);
+    renderView();
+
+    await confirmDelete();
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Event Montafon bearbeiten" })).toBeEnabled();
+  });
+});
+
 describe("EventsView — archived season", () => {
   it("does not offer adding events to an archived season", () => {
     stubFetch(created);

--- a/src/components/events/events-view.tsx
+++ b/src/components/events/events-view.tsx
@@ -19,6 +19,7 @@ import { SortableList } from "@/components/ui/sortable-list";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Label } from "@/components/ui/label";
 import { apiRequest, ApiRequestError } from "@/lib/api/client";
+import { useRowAction } from "@/lib/api/use-row-action";
 import { eventSchema, type Event } from "@/lib/schemas/season";
 import { useEvents } from "@/lib/events/use-events";
 import { useSeasons } from "@/lib/seasons/use-seasons";
@@ -33,6 +34,7 @@ export function EventsView({ seasonId }: { seasonId: string }) {
   const { events, loading, error } = useEvents(seasonId);
   const { seasons } = useSeasons();
   const [dialog, setDialog] = React.useState<OpenDialog>({ kind: "none" });
+  const { busyId, run } = useRowAction();
 
   const season = seasons.find((candidate) => candidate.id === seasonId) ?? null;
 
@@ -62,6 +64,7 @@ export function EventsView({ seasonId }: { seasonId: string }) {
         loading={loading}
         error={error}
         readOnly={season?.isArchived ?? false}
+        busyEventId={busyId}
         onEdit={(event) => setDialog({ kind: "form", event })}
         onDelete={(event) => setDialog({ kind: "delete", event })}
         onReorder={(order) =>
@@ -73,12 +76,19 @@ export function EventsView({ seasonId }: { seasonId: string }) {
         <EventFormDialog
           seasonId={seasonId}
           event={dialog.event}
+          onSubmit={(event, request) => run(event.id, request)}
           onClose={() => setDialog({ kind: "none" })}
         />
       ) : null}
 
       {dialog.kind === "delete" ? (
-        <DeleteEventDialog event={dialog.event} onClose={() => setDialog({ kind: "none" })} />
+        <DeleteEventDialog
+          event={dialog.event}
+          onDelete={(event) =>
+            run(event.id, () => apiRequest(`/api/events/${event.id}`, { method: "DELETE" }))
+          }
+          onClose={() => setDialog({ kind: "none" })}
+        />
       ) : null}
     </div>
   );
@@ -89,6 +99,8 @@ type EventListProps = {
   loading: boolean;
   error: string | null;
   readOnly: boolean;
+  /** The row a write is running on; its controls are held until the write is answered. */
+  busyEventId: string | null;
   onEdit: (event: Event) => void;
   onDelete: (event: Event) => void;
   onReorder: (orderedIds: string[]) => void | Promise<void>;
@@ -99,6 +111,7 @@ function EventList({
   loading,
   error,
   readOnly,
+  busyEventId,
   onEdit,
   onDelete,
   onReorder,
@@ -140,6 +153,7 @@ function EventList({
         onReorder={onReorder}
         // An archived season is read-only, so its order is frozen along with everything else.
         disabled={readOnly}
+        busyId={busyEventId}
         className="[&>li]:border-border [&>li]:border-b [&>li:last-child]:border-b-0"
         renderItem={(event) => (
           <div className="flex items-center justify-between gap-4 py-3 pr-4 pl-2">
@@ -151,6 +165,7 @@ function EventList({
                   <Button
                     variant="ghost"
                     size="icon-sm"
+                    disabled={event.id === busyEventId}
                     aria-label={`Event ${event.name} bearbeiten`}
                     onClick={() => onEdit(event)}
                   >
@@ -161,6 +176,7 @@ function EventList({
                   <Button
                     variant="ghost"
                     size="icon-sm"
+                    disabled={event.id === busyEventId}
                     aria-label={`Event ${event.name} löschen`}
                     onClick={() => onDelete(event)}
                     className="text-destructive hover:bg-destructive/10 hover:text-destructive"
@@ -180,10 +196,13 @@ function EventList({
 function EventFormDialog({
   seasonId,
   event,
+  onSubmit: runOnRow,
   onClose,
 }: {
   seasonId: string;
   event: Event | null;
+  /** Renaming holds the row it started from; a new event has no row yet. */
+  onSubmit: (event: Event, request: () => Promise<unknown>) => Promise<unknown>;
   onClose: () => void;
 }) {
   const isEdit = event !== null;
@@ -205,7 +224,9 @@ function EventFormDialog({
     setSubmitError(null);
     try {
       if (isEdit) {
-        await apiRequest(`/api/events/${event.id}`, { method: "PATCH", body: values });
+        await runOnRow(event, () =>
+          apiRequest(`/api/events/${event.id}`, { method: "PATCH", body: values }),
+        );
       } else {
         await apiRequest("/api/events", { method: "POST", body: { seasonId, name: values.name } });
       }
@@ -260,7 +281,15 @@ function EventFormDialog({
   );
 }
 
-function DeleteEventDialog({ event, onClose }: { event: Event; onClose: () => void }) {
+function DeleteEventDialog({
+  event,
+  onDelete,
+  onClose,
+}: {
+  event: Event;
+  onDelete: (event: Event) => Promise<unknown>;
+  onClose: () => void;
+}) {
   const [error, setError] = React.useState<string | null>(null);
   const [deleting, setDeleting] = React.useState(false);
 
@@ -268,7 +297,7 @@ function DeleteEventDialog({ event, onClose }: { event: Event; onClose: () => vo
     setDeleting(true);
     setError(null);
     try {
-      await apiRequest(`/api/events/${event.id}`, { method: "DELETE" });
+      await onDelete(event);
       onClose();
     } catch (caught) {
       setError(

--- a/src/components/master-data/crud-list.tsx
+++ b/src/components/master-data/crud-list.tsx
@@ -18,6 +18,7 @@ import { Label } from "@/components/ui/label";
 import { SortableList } from "@/components/ui/sortable-list";
 import { Tooltip } from "@/components/ui/tooltip";
 import { ApiRequestError } from "@/lib/api/client";
+import { useRowAction } from "@/lib/api/use-row-action";
 import { namedListItemSchema } from "@/lib/schemas/master-data";
 import { IN_USE_HINT } from "@/lib/master-data/categories";
 
@@ -54,7 +55,7 @@ type CrudListProps = {
   fixedItems?: readonly string[];
   fixedItemsHint?: string;
   /** One extra control per row, ahead of edit and delete — the programs list uses it. */
-  renderRowAction?: (item: CrudItem) => React.ReactNode;
+  renderRowAction?: (item: CrudItem, options: { disabled: boolean }) => React.ReactNode;
   /** Rejects with an ApiRequestError; a CONFLICT is reported on the name field. */
   onSubmit: (name: string, item: CrudItem | null) => Promise<void>;
   onDelete: (item: CrudItem) => Promise<void>;
@@ -88,8 +89,15 @@ export function CrudList({
   deleteNote,
 }: CrudListProps) {
   const [dialog, setDialog] = React.useState<OpenDialog>({ kind: "none" });
+  const { busyId, run } = useRowAction();
 
   const closeDialog = () => setDialog({ kind: "none" });
+
+  // A write started from a row holds that row until it is answered. The list refreshes from a
+  // separate subscription, so until then the remaining controls would act on an item this write
+  // may already have removed. A new item has no row yet, so there is nothing to hold.
+  const submit = (name: string, item: CrudItem | null) =>
+    item === null ? onSubmit(name, null) : run(item.id, () => onSubmit(name, item));
 
   return (
     <div className="flex flex-col gap-4 p-4 md:p-6">
@@ -114,6 +122,7 @@ export function CrudList({
         fixedItems={fixedItems}
         fixedItemsHint={fixedItemsHint}
         renderRowAction={renderRowAction}
+        busyId={busyId}
         onEdit={(item) => setDialog({ kind: "form", item })}
         onDelete={(item) => setDialog({ kind: "delete", item })}
         onReorder={onReorder}
@@ -124,7 +133,7 @@ export function CrudList({
           key={dialog.item?.id ?? "new"}
           labels={labels}
           item={dialog.item}
-          onSubmit={onSubmit}
+          onSubmit={submit}
           onClose={closeDialog}
         />
       ) : null}
@@ -135,7 +144,7 @@ export function CrudList({
           labels={labels}
           item={dialog.item}
           note={deleteNote(dialog.item)}
-          onDelete={onDelete}
+          onDelete={(item) => run(item.id, () => onDelete(item))}
           onClose={closeDialog}
         />
       ) : null}
@@ -150,7 +159,8 @@ type ItemListProps = Required<
   undeletableHint: string;
   fixedItems: readonly string[];
   fixedItemsHint?: string;
-  renderRowAction?: (item: CrudItem) => React.ReactNode;
+  renderRowAction?: (item: CrudItem, options: { disabled: boolean }) => React.ReactNode;
+  busyId: string | null;
   onEdit: (item: CrudItem) => void;
   onDelete: (item: CrudItem) => void;
   onReorder: (orderedIds: string[]) => void | Promise<void>;
@@ -167,6 +177,7 @@ function ItemList({
   fixedItems,
   fixedItemsHint,
   renderRowAction,
+  busyId,
   onEdit,
   onDelete,
   onReorder,
@@ -206,7 +217,9 @@ function ItemList({
       <SortableList
         items={items}
         onReorder={onReorder}
+        busyId={busyId}
         renderItem={(item) => {
+          const busy = item.id === busyId;
           const blocked = blockedIds.has(item.id);
           const undeletable = blocked || undeletableIds.has(item.id);
           const deleteHint = blocked ? IN_USE_HINT : undeletableHint;
@@ -217,7 +230,7 @@ function ItemList({
               <span className="truncate text-sm font-medium">{item.name}</span>
 
               <div className="flex shrink-0 items-center gap-1">
-                {renderRowAction?.(item)}
+                {renderRowAction?.(item, { disabled: busy })}
 
                 {/* Wrapped in a span because a disabled button emits no pointer events, and the
                     reason it is disabled is exactly what needs explaining here. */}
@@ -226,7 +239,7 @@ function ItemList({
                     <Button
                       variant="ghost"
                       size="icon-sm"
-                      disabled={blocked}
+                      disabled={blocked || busy}
                       aria-label={`${singular} ${item.name} bearbeiten`}
                       aria-describedby={blocked ? hintId : undefined}
                       onClick={() => onEdit(item)}
@@ -241,7 +254,7 @@ function ItemList({
                     <Button
                       variant="ghost"
                       size="icon-sm"
-                      disabled={undeletable}
+                      disabled={undeletable || busy}
                       aria-label={`${singular} ${item.name} löschen`}
                       aria-describedby={undeletable ? hintId : undefined}
                       onClick={() => onDelete(item)}

--- a/src/components/master-data/master-data-view.test.tsx
+++ b/src/components/master-data/master-data-view.test.tsx
@@ -214,6 +214,78 @@ describe("MasterDataView — deleting", () => {
   });
 });
 
+// The list refreshes from a separate subscription, so between the answer and the refresh a row
+// still offers actions against an item the write it is waiting on may already have removed.
+describe("MasterDataView — while a write is in flight", () => {
+  async function confirmDelete() {
+    await userEvent.click(screen.getByRole("button", { name: "Klasse 3AHIT löschen" }));
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "Löschen" }),
+    );
+  }
+
+  it("locks the row that is being written to", async () => {
+    stubFetch(() => new Promise(() => {}));
+    renderView();
+
+    await confirmDelete();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Klasse 3AHIT bearbeiten" })).toBeDisabled(),
+    );
+    expect(screen.getByRole("button", { name: "3AHIT verschieben" })).toBeDisabled();
+  });
+
+  it("leaves every other row alone", async () => {
+    stubFetch(() => new Promise(() => {}));
+    renderView();
+
+    await confirmDelete();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Klasse 3AHIT bearbeiten" })).toBeDisabled(),
+    );
+    expect(screen.getByRole("button", { name: "Klasse 4BHIT bearbeiten" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "4BHIT verschieben" })).toBeEnabled();
+  });
+
+  it("releases the row once the write is answered", async () => {
+    stubFetch(() => Promise.resolve(new Response(null, { status: 204 })));
+    renderView();
+
+    await confirmDelete();
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Klasse 3AHIT bearbeiten" })).toBeEnabled();
+  });
+
+  it("locks the extra action a category contributes, which acts on the same item", async () => {
+    stubFetch(() => new Promise(() => {}));
+    renderView({
+      renderRowAction: (
+        item: { id: string; name: string },
+        { disabled }: { disabled: boolean },
+      ) => (
+        <a href={`/detail/${item.id}`} aria-disabled={disabled || undefined}>
+          Details zu {item.name}
+        </a>
+      ),
+    });
+
+    await confirmDelete();
+
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: "Details zu 3AHIT" })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      ),
+    );
+    expect(screen.getByRole("link", { name: "Details zu 4BHIT" })).not.toHaveAttribute(
+      "aria-disabled",
+    );
+  });
+});
+
 describe("MasterDataView — the in-use restriction", () => {
   beforeEach(() =>
     useUsageReport.mockReturnValue({ blockedIds: new Set(["c1"]), blockedEquipment: {} }),

--- a/src/components/master-data/master-data-view.tsx
+++ b/src/components/master-data/master-data-view.tsx
@@ -20,7 +20,7 @@ type MasterDataViewProps = {
   /** Options offered to students that the teacher does not maintain, such as "Sonstiges" (US-9). */
   fixedItems?: readonly string[];
   fixedItemsHint?: string;
-  renderRowAction?: (item: CrudItem) => React.ReactNode;
+  renderRowAction?: (item: CrudItem, options: { disabled: boolean }) => React.ReactNode;
 };
 
 /** A teacher-maintained collection on the shared CRUD list (US-5 to US-10). */

--- a/src/components/master-data/programs-view.test.tsx
+++ b/src/components/master-data/programs-view.test.tsx
@@ -79,6 +79,29 @@ describe("ProgramsView", () => {
     expect(screen.getByRole("link", { name: "Benötigte Ausrüstung für Ski" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Programm Ski bearbeiten" })).toBeDisabled();
   });
+
+  it("locks the equipment link while a write on that program is in flight", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise(() => {})),
+    );
+    render(<ProgramsView />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Programm Ski löschen" }));
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "Löschen" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: "Benötigte Ausrüstung für Ski" })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      ),
+    );
+    expect(
+      screen.getByRole("link", { name: "Benötigte Ausrüstung für Alternativ" }),
+    ).not.toHaveAttribute("aria-disabled");
+  });
 });
 
 describe("ProgramEquipmentView", () => {

--- a/src/components/master-data/programs-view.tsx
+++ b/src/components/master-data/programs-view.tsx
@@ -21,12 +21,20 @@ export function ProgramsView() {
   return (
     <MasterDataView
       category="programs"
-      renderRowAction={(program) => (
+      renderRowAction={(program, { disabled }) => (
         <Tooltip label="Benötigte Ausrüstung">
           <Link
             href={`/app/master-data/programs/${program.id}`}
             aria-label={`Benötigte Ausrüstung für ${program.name}`}
-            className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }))}
+            // A link has no disabled state of its own, so a write running on this program has to
+            // be spelled out for the pointer, the keyboard and assistive technology separately.
+            aria-disabled={disabled || undefined}
+            tabIndex={disabled ? -1 : undefined}
+            onClick={disabled ? (clicked) => clicked.preventDefault() : undefined}
+            className={cn(
+              buttonVariants({ variant: "ghost", size: "icon-sm" }),
+              disabled && "pointer-events-none opacity-50",
+            )}
           >
             <Package aria-hidden className="size-3.5" />
           </Link>

--- a/src/components/seasons/season-list.test.tsx
+++ b/src/components/seasons/season-list.test.tsx
@@ -285,6 +285,53 @@ describe("SeasonList — row actions", () => {
   });
 });
 
+// Everything on a row acts on the same season, so while one control is waiting for its round
+// trip the rest must not offer a second action against a season the first one is removing.
+describe("SeasonList — while a row is busy", () => {
+  const busy = { busySeasonId: "s1" };
+
+  it.each([
+    ["Saison Wintersportwoche 2026 deaktivieren"],
+    ["Saison Wintersportwoche 2026 bearbeiten"],
+    ["Saison Wintersportwoche 2026 löschen"],
+    ["Saison Wintersportwoche 2026 archivieren"],
+  ])("locks the %s button", (accessibleName) => {
+    renderList(busy);
+
+    expect(screen.getByRole("button", { name: accessibleName })).toBeDisabled();
+  });
+
+  it("locks the events link, which a disabled button would not cover", async () => {
+    renderList(busy);
+    const link = screen.getByRole("link", { name: "Events der Saison Wintersportwoche 2026" });
+
+    expect(link).toHaveAttribute("aria-disabled", "true");
+    expect(link).toHaveAttribute("tabindex", "-1");
+
+    await userEvent.click(link);
+    expect(window.location.pathname).not.toBe("/app/master-data/seasons/s1");
+  });
+
+  it("locks the drag handle, so the row cannot be reordered mid-write", () => {
+    renderList(busy);
+
+    expect(
+      screen.getByRole("button", { name: "Wintersportwoche 2026 verschieben" }),
+    ).toBeDisabled();
+  });
+
+  it("leaves every other row alone", () => {
+    renderList(busy);
+
+    expect(
+      screen.getByRole("button", { name: "Saison Wintersportwoche 2027 bearbeiten" }),
+    ).not.toBeDisabled();
+    expect(
+      screen.getByRole("link", { name: "Events der Saison Wintersportwoche 2027" }),
+    ).not.toHaveAttribute("aria-disabled", "true");
+  });
+});
+
 describe("SeasonList — tooltips", () => {
   it.each([
     ["Saison Wintersportwoche 2027 bearbeiten", "Bearbeiten"],

--- a/src/components/seasons/season-list.tsx
+++ b/src/components/seasons/season-list.tsx
@@ -88,6 +88,7 @@ export function SeasonList({
       <SortableList
         items={seasons}
         onReorder={onReorder}
+        busyId={busySeasonId}
         className="[&>li]:border-border [&>li]:border-b [&>li:last-child]:border-b-0"
         renderItem={(season) => {
           const state = seasonState(season);
@@ -122,7 +123,15 @@ export function SeasonList({
                   <Link
                     href={`/app/master-data/seasons/${season.id}`}
                     aria-label={`Events der Saison ${season.name}`}
-                    className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }))}
+                    // A link has no disabled state of its own, so being busy has to be spelled
+                    // out for the pointer, the keyboard and assistive technology separately.
+                    aria-disabled={busy || undefined}
+                    tabIndex={busy ? -1 : undefined}
+                    onClick={busy ? (clicked) => clicked.preventDefault() : undefined}
+                    className={cn(
+                      buttonVariants({ variant: "ghost", size: "icon-sm" }),
+                      busy && "pointer-events-none opacity-50",
+                    )}
                   >
                     <CalendarDays aria-hidden className="size-3.5" />
                   </Link>

--- a/src/components/seasons/seasons-view.test.tsx
+++ b/src/components/seasons/seasons-view.test.tsx
@@ -265,3 +265,33 @@ describe("SeasonsView — deleting", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent("Hat noch Schülerdaten.");
   });
 });
+
+describe("SeasonsView — while a write is in flight", () => {
+  it("locks the row that is being written to", async () => {
+    stubFetch(() => new Promise(() => {}));
+    renderView([active, archived, inactive, noStudentData]);
+
+    await userEvent.click(screen.getByRole("button", { name: "Saison Winter 2024 löschen" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Saison Winter 2024 bearbeiten" })).toBeDisabled(),
+    );
+    expect(screen.getByRole("link", { name: "Events der Saison Winter 2024" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("releases the row once the write is answered", async () => {
+    stubFetch(noContent);
+    renderView([active, archived, inactive, noStudentData]);
+
+    await userEvent.click(screen.getByRole("button", { name: "Saison Winter 2024 löschen" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Saison Winter 2024 bearbeiten" }),
+      ).not.toBeDisabled(),
+    );
+  });
+});

--- a/src/components/seasons/seasons-view.tsx
+++ b/src/components/seasons/seasons-view.tsx
@@ -11,7 +11,8 @@ import { Button } from "@/components/ui/button";
 import { DeleteSeasonDialog } from "@/components/seasons/delete-season-dialog";
 import { SeasonFormDialog } from "@/components/seasons/season-form-dialog";
 import { SeasonList } from "@/components/seasons/season-list";
-import { apiRequest, ApiRequestError } from "@/lib/api/client";
+import { apiRequest, ApiRequestError, type RequestOptions } from "@/lib/api/client";
+import { useRowAction } from "@/lib/api/use-row-action";
 import { applyVisibleOrder } from "@/lib/schemas/position";
 import type { Season } from "@/lib/schemas/season";
 import { visibleSeasons } from "@/lib/seasons/season-state";
@@ -24,7 +25,7 @@ export function SeasonsView() {
   const { seasons, loading, error } = useSeasons();
   const [showArchived, setShowArchived] = React.useState(false);
   const [dialog, setDialog] = React.useState<OpenDialog>({ kind: "none" });
-  const [busySeasonId, setBusySeasonId] = React.useState<string | null>(null);
+  const { busyId, run } = useRowAction();
   const [actionError, setActionError] = React.useState<string | null>(null);
   const toggleId = React.useId();
 
@@ -33,31 +34,16 @@ export function SeasonsView() {
   // The list is a live Firestore subscription, so a successful write shows up on its own.
   const closeDialog = () => setDialog({ kind: "none" });
 
-  async function patchSeason(season: Season, body: Record<string, unknown>) {
-    setBusySeasonId(season.id);
+  // The whole row is held while the round trip runs, so a slow connection cannot leave the
+  // other controls offering actions against a season this one is already changing.
+  async function writeSeason(season: Season, request: RequestOptions) {
     setActionError(null);
     try {
-      await apiRequest(`/api/seasons/${season.id}`, { method: "PATCH", body });
+      await run(season.id, () => apiRequest(`/api/seasons/${season.id}`, request));
     } catch (caught) {
       setActionError(
         caught instanceof ApiRequestError ? caught.message : "Das hat leider nicht geklappt.",
       );
-    } finally {
-      setBusySeasonId(null);
-    }
-  }
-
-  async function deleteSeasonDirectly(season: Season) {
-    setBusySeasonId(season.id);
-    setActionError(null);
-    try {
-      await apiRequest(`/api/seasons/${season.id}`, { method: "DELETE" });
-    } catch (caught) {
-      setActionError(
-        caught instanceof ApiRequestError ? caught.message : "Das hat leider nicht geklappt.",
-      );
-    } finally {
-      setBusySeasonId(null);
     }
   }
 
@@ -66,7 +52,7 @@ export function SeasonsView() {
     if (season.hasStudentData) {
       setDialog({ kind: "delete", season });
     } else {
-      void deleteSeasonDirectly(season);
+      void writeSeason(season, { method: "DELETE" });
     }
   }
 
@@ -101,11 +87,15 @@ export function SeasonsView() {
         seasons={listed}
         loading={loading}
         error={error}
-        busySeasonId={busySeasonId}
+        busySeasonId={busyId}
         onEdit={(season) => setDialog({ kind: "form", season })}
         onDelete={handleDelete}
-        onActiveChange={(season, isActive) => patchSeason(season, { isActive })}
-        onArchivedChange={(season, isArchived) => patchSeason(season, { isArchived })}
+        onActiveChange={(season, isActive) =>
+          writeSeason(season, { method: "PATCH", body: { isActive } })
+        }
+        onArchivedChange={(season, isArchived) =>
+          writeSeason(season, { method: "PATCH", body: { isArchived } })
+        }
         onReorder={(orderedIds) => {
           // The list may be hiding archived seasons, so the visible order is folded back into
           // the full one rather than sent on its own (see Ordering).

--- a/src/components/ui/sortable-list.test.tsx
+++ b/src/components/ui/sortable-list.test.tsx
@@ -122,6 +122,21 @@ describe("SortableList — when reordering is not offered", () => {
   });
 });
 
+describe("SortableList — while a row is busy", () => {
+  it("locks the handle of the row being written to", () => {
+    renderList(vi.fn(), { busyId: "b" });
+
+    expect(screen.getByRole("button", { name: "Berta verschieben" })).toBeDisabled();
+  });
+
+  it("leaves every other handle alone", () => {
+    renderList(vi.fn(), { busyId: "b" });
+
+    expect(screen.getByRole("button", { name: "Anton verschieben" })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cesar verschieben" })).not.toBeDisabled();
+  });
+});
+
 describe("SortableList — showing the result of a move", () => {
   /** The rendered order, with each row's handle label stripped off. */
   function shownOrder() {
@@ -211,5 +226,41 @@ describe("SortableList — showing the result of a move", () => {
     );
 
     expect(shownOrder()).toEqual(["Anton", "Cesar"]);
+  });
+
+  // A program's equipment is identified by its name, so renaming an entry replaces its id. The
+  // local order still names the entry that is gone, and can no longer place the one that
+  // replaced it — the stored order is the only one that can.
+  it("yields to the stored order once a renamed item leaves it nothing to say", async () => {
+    const { rerender } = renderWith(vi.fn());
+    await moveAntonDown();
+
+    rerender(
+      <SortableList
+        items={[items[1], { id: "a2", name: "Amadeus" }, items[2]]}
+        onReorder={vi.fn()}
+        renderItem={(item) => <span>{item.name}</span>}
+      />,
+    );
+
+    expect(shownOrder()).toEqual(["Berta", "Amadeus", "Cesar"]);
+  });
+
+  it("still follows the stored order after an item disappeared during the move", async () => {
+    const { rerender } = renderWith(vi.fn());
+    await moveAntonDown();
+
+    const list = (shown: typeof items) => (
+      <SortableList
+        items={shown}
+        onReorder={vi.fn()}
+        renderItem={(item) => <span>{item.name}</span>}
+      />
+    );
+
+    rerender(list([items[1], items[2]]));
+    rerender(list([items[2], items[1]]));
+
+    expect(shownOrder()).toEqual(["Cesar", "Berta"]);
   });
 });

--- a/src/components/ui/sortable-list.tsx
+++ b/src/components/ui/sortable-list.tsx
@@ -39,6 +39,8 @@ type SortableListProps<T extends SortableItem> = {
   renderItem: (item: T) => React.ReactNode;
   /** Hides the handles, for a list that is read-only in its current state. */
   disabled?: boolean;
+  /** The row a write is running on; its handle is locked until the write is answered. */
+  busyId?: string | null;
   className?: string;
 };
 
@@ -55,6 +57,7 @@ export function SortableList<T extends SortableItem>({
   onReorder,
   renderItem,
   disabled = false,
+  busyId = null,
   className,
 }: SortableListProps<T>) {
   /**
@@ -66,10 +69,17 @@ export function SortableList<T extends SortableItem>({
    */
   const [dropped, setDropped] = React.useState<string[] | null>(null);
 
-  // Once the stored order says the same thing, the local one has nothing left to add. Adjusted
-  // during render rather than in an effect, which would show the list twice to say it once.
-  const storedOrder = items.map((item) => item.id).join("\u0000");
-  if (dropped !== null && dropped.join("\u0000") === storedOrder) setDropped(null);
+  // The local order speaks only for the items it was made from. Once the stored order agrees
+  // about those — whatever else was added, removed or renamed alongside — it has nothing left
+  // to say, and holding on to it would keep ordering the list by a list that no longer exists.
+  // Adjusted during render rather than in an effect, which would show the list twice to say it
+  // once.
+  if (dropped !== null) {
+    const storedIds = items.map((item) => item.id);
+    const stillStored = dropped.filter((id) => storedIds.includes(id));
+    const asStored = storedIds.filter((id) => dropped.includes(id));
+    if (stillStored.join("\u0000") === asStored.join("\u0000")) setDropped(null);
+  }
 
   const ordered = React.useMemo(() => {
     if (dropped === null) return items;
@@ -129,7 +139,7 @@ export function SortableList<T extends SortableItem>({
       <SortableContext items={ordered} strategy={verticalListSortingStrategy}>
         <ul className={className}>
           {ordered.map((item) => (
-            <SortableRow key={item.id} item={item}>
+            <SortableRow key={item.id} item={item} disabled={item.id === busyId}>
               {renderItem(item)}
             </SortableRow>
           ))}
@@ -139,9 +149,18 @@ export function SortableList<T extends SortableItem>({
   );
 }
 
-function SortableRow({ item, children }: { item: SortableItem; children: React.ReactNode }) {
+function SortableRow({
+  item,
+  disabled,
+  children,
+}: {
+  item: SortableItem;
+  disabled: boolean;
+  children: React.ReactNode;
+}) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: item.id,
+    disabled,
   });
 
   return (
@@ -152,8 +171,9 @@ function SortableRow({ item, children }: { item: SortableItem; children: React.R
     >
       <button
         type="button"
+        disabled={disabled}
         aria-label={`${item.name} verschieben`}
-        className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 ml-2 shrink-0 cursor-grab touch-none rounded-md p-1 transition-colors outline-none focus-visible:ring-3 active:cursor-grabbing"
+        className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 ml-2 shrink-0 cursor-grab touch-none rounded-md p-1 transition-colors outline-none focus-visible:ring-3 active:cursor-grabbing disabled:cursor-default disabled:opacity-50"
         {...attributes}
         {...listeners}
       >

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -19,7 +19,7 @@ export class ApiRequestError extends Error {
   }
 }
 
-type RequestOptions = {
+export type RequestOptions = {
   method: "POST" | "PATCH" | "DELETE";
   body?: unknown;
 };

--- a/src/lib/api/use-row-action.test.ts
+++ b/src/lib/api/use-row-action.test.ts
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useRowAction } from "@/lib/api/use-row-action";
+
+/** A promise plus the handles to settle it, so a test can hold a write open. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useRowAction", () => {
+  it("starts with no row busy", () => {
+    const { result } = renderHook(() => useRowAction());
+
+    expect(result.current.busyId).toBeNull();
+  });
+
+  it("names the row while its write is in flight", async () => {
+    const write = deferred<void>();
+    const { result } = renderHook(() => useRowAction());
+
+    act(() => void result.current.run("s1", () => write.promise));
+
+    await waitFor(() => expect(result.current.busyId).toBe("s1"));
+  });
+
+  it("releases the row once the write is answered", async () => {
+    const write = deferred<void>();
+    const { result } = renderHook(() => useRowAction());
+
+    act(() => void result.current.run("s1", () => write.promise));
+    await waitFor(() => expect(result.current.busyId).toBe("s1"));
+
+    await act(async () => {
+      write.resolve();
+      await write.promise;
+    });
+
+    expect(result.current.busyId).toBeNull();
+  });
+
+  it("releases the row when the write failed, so the list stays usable", async () => {
+    const { result } = renderHook(() => useRowAction());
+
+    await act(async () => {
+      await expect(
+        result.current.run("s1", () => Promise.reject(new Error("offline"))),
+      ).rejects.toThrow("offline");
+    });
+
+    expect(result.current.busyId).toBeNull();
+  });
+
+  it("hands the result back to the caller", async () => {
+    const { result } = renderHook(() => useRowAction());
+
+    await act(async () => {
+      await expect(result.current.run("s1", () => Promise.resolve("done"))).resolves.toBe("done");
+    });
+  });
+});

--- a/src/lib/api/use-row-action.ts
+++ b/src/lib/api/use-row-action.ts
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+import * as React from "react";
+
+/**
+ * Which row of a list a write is currently running on.
+ *
+ * Every control on a row acts on the same record — deleting it, activating it, opening what
+ * hangs off it — so while one of them is waiting for its round trip the others are offering
+ * actions against a record that may already be gone. On a slow connection that window is long
+ * enough to act in, and the second action then fails against data the first one removed.
+ *
+ * The row is released as soon as the write is answered: the list refreshes from a Firestore
+ * subscription that the very same write feeds, so by then the new data is already on its way.
+ */
+export function useRowAction() {
+  const [busyId, setBusyId] = React.useState<string | null>(null);
+
+  const run = React.useCallback(async <T>(id: string, action: () => Promise<T>): Promise<T> => {
+    setBusyId(id);
+    try {
+      return await action();
+    } finally {
+      setBusyId(null);
+    }
+  }, []);
+
+  return { busyId, run };
+}


### PR DESCRIPTION
Every control on a row acts on the same record — deleting it, activating it, opening what hangs off it — but each write goes through a Route Handler while the list refreshes from a separate Firestore subscription. On a slow connection the round trip is long enough to act in again, and the second action then runs against a record the first one is already removing.

## Holding the row

A row is now held from the moment one of its controls is used until the write is answered, across seasons, events and every master data category. `useRowAction` names the row a write is running on; the list disables that row's controls and leaves every other row alone.

Holding covers more than the buttons that were already disabled on the seasons list:

- the drag handle, so a row cannot be reordered mid-write;
- the links out of the row — the events link on a season, the equipment link on a program. A link has no disabled state of its own, so this is spelled out for the pointer, the keyboard and assistive technology separately.

The row is released as soon as the write is answered. The subscription that refreshes the list is fed by that very same write, so by then the new data is already on its way.

## The list that did not update

This part turned out to be a real bug rather than latency.

`SortableList` keeps the order a teacher has just dropped until the stored data reflects it, so a drop does not visibly undo itself while the write is in flight. It held on to that local order until the stored order repeated it verbatim — which never happens once anything else changes alongside the drop:

- A program's required equipment is identified by its name, so renaming an entry replaces its id. The renamed entry dropped to the bottom of the list and stayed there.
- Once the two orders could no longer match, the local one outranked every later stored one for good, so nothing arriving afterwards was shown in the order it was stored in.

The local order is now released as soon as the stored order agrees about the items the drop actually named, whatever was added, removed or renamed alongside them.

## Tests

Every change was driven from a failing test first: `sortable-list.test.tsx`, `use-row-action.test.ts`, `season-list.test.tsx`, `seasons-view.test.tsx`, `master-data-view.test.tsx`, `programs-view.test.tsx` and `events-view.test.tsx`. Full suite: 904 passing.
