### PR TITLE
Make main the trunk and production the release branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,13 +6,13 @@
 name: CodeQL
 
 # Replaces the default setup, which only ever scanned the default branch and pull requests
-# into it. With features merging into staging first, that left every feature branch unscanned
-# and the first analysis happening after the code was already deployed to staging.
+# into it. That leaves the release branch unscanned: a promotion is a pull request into
+# production, which the default setup does not look at.
 on:
   push:
-    branches: [main, staging]
+    branches: [main, production]
   pull_request:
-    branches: [main, staging]
+    branches: [main, production]
   schedule:
     # Keeps finding newly published problems in code that has stopped changing.
     - cron: "27 3 * * 1"

--- a/.github/workflows/deploy-rules.yml
+++ b/.github/workflows/deploy-rules.yml
@@ -8,7 +8,7 @@ name: Deploy Security Rules
 on:
   workflow_dispatch:
   push:
-    branches: [main, staging]
+    branches: [main, production]
     paths:
       - "firestore.rules"
       - "storage.rules"
@@ -28,10 +28,11 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # Rules reach staging by the same route the code does: the branch decides the project,
-    # so nothing can be released to production that has not passed through staging first.
+    # Rules reach a project by the same route the code does: the branch decides the project,
+    # so nothing can be released to production that has not run against the staging project
+    # on main first.
     env:
-      PROJECT: ${{ github.ref_name == 'main' && 'htld-sportsweek' || 'htld-sportsweek-staging' }}
+      PROJECT: ${{ github.ref_name == 'production' && 'htld-sportsweek' || 'htld-sportsweek-staging' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -42,10 +43,10 @@ jobs:
       - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: >-
-            ${{ github.ref_name == 'main' && vars.GCP_WORKLOAD_IDENTITY_PROVIDER
+            ${{ github.ref_name == 'production' && vars.GCP_WORKLOAD_IDENTITY_PROVIDER
             || vars.GCP_WORKLOAD_IDENTITY_PROVIDER_STAGING }}
           service_account: >-
-            ${{ github.ref_name == 'main' && vars.GCP_RULES_DEPLOY_SERVICE_ACCOUNT
+            ${{ github.ref_name == 'production' && vars.GCP_RULES_DEPLOY_SERVICE_ACCOUNT
             || vars.GCP_RULES_DEPLOY_SERVICE_ACCOUNT_STAGING }}
       - name: Deploy rules and indexes to ${{ env.PROJECT }}
         run: >-

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -5,10 +5,10 @@
 
 name: Promotion
 
-# Only fires for pull requests into main, so it never appears on a PR into staging.
+# Only fires for pull requests into production, so it never appears on a feature PR into main.
 on:
   pull_request:
-    branches: [main]
+    branches: [production]
 
 # The check reads the branch name out of the event payload and nothing else: no checkout,
 # no API call, so the token needs no scope at all.
@@ -18,25 +18,25 @@ jobs:
   promotion-source:
     runs-on: ubuntu-latest
     steps:
-      - name: Only staging may be promoted to main
+      - name: Only main may be promoted to production
         # Via the environment rather than an expression inside the script: a branch name is
         # attacker-controlled text and would otherwise be pasted straight into the shell.
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
           case "$HEAD_REF" in
-            staging)
-              echo "Promoting staging to main."
+            main)
+              echo "Promoting main to production."
               ;;
             hotfix/*)
               # The one way past the queue, named so it is visible in the log rather than
-              # done by disabling this check. Back-merge main into staging afterwards, or
-              # the two branches drift apart.
-              echo "Hotfix '$HEAD_REF' going straight to main."
+              # done by disabling this check. Land the same fix on main as well, or the trunk
+              # keeps the defect and every later promotion has to merge around it.
+              echo "Hotfix '$HEAD_REF' going straight to production."
               ;;
             *)
-              echo "::error::'$HEAD_REF' cannot merge into main. Changes reach production by"
-              echo "::error::merging into staging first, then opening staging -> main."
+              echo "::error::'$HEAD_REF' cannot merge into production. Changes reach production"
+              echo "::error::by merging into main first, then opening main -> production."
               exit 1
               ;;
           esac


### PR DESCRIPTION
The promotion merge commit was landing on `main`, the branch everyone develops from, and a merge commit never travels back to the branch it was merged from. `staging` was therefore permanently one commit behind `main`, growing by one per release. No merge method fixes that — GitHub cannot fast-forward a pull request.

Reversing the direction removes the problem instead of managing it.

| Branch | Role | Deploys to | Merge method |
| --- | --- | --- | --- |
| `main` | trunk, default branch | `htld-sportsweek-staging` | squash (feature PRs) |
| `production` | release pointer | `htld-sportsweek` | merge commit (promotion PR) |

The promotion merge commit now lands on `production`, which nobody branches from, so the trunk cannot fall behind anything.

## What this PR changes

Only branch names, in the three branch-aware workflows:

- [.github/workflows/codeql.yml](.github/workflows/codeql.yml) — scans `main` and `production`
- [.github/workflows/deploy-rules.yml](.github/workflows/deploy-rules.yml) — `production` selects `htld-sportsweek`, everything else the staging project
- [.github/workflows/promotion.yml](.github/workflows/promotion.yml) — gates PRs into `production`, asserting the head is `main`

`ci.yml` needs no change: it triggers on `pull_request` with no branch filter, so it already covers both feature PRs and the promotion PR.

## What needed no change

- **App Hosting config** — the environment-specific `apphosting.staging.yaml` is chosen by the backend's Environment setting, not by branch name.
- **Workload identity** — both providers condition on `assertion.repository` alone, with no branch pinning, so rules deployment keeps working across the rename.

## Already done outside this PR

- `production` created at `f2b892f`, the commit production was already serving.
- Production backend live branch `main` → `production`. Nothing rolled out; same commit.
- Rulesets swapped: `~DEFAULT_BRANCH` is now squash-only with green CI; `refs/heads/production` is merge-only with green CI plus `promotion-source`.

`strict_required_status_checks_policy` is deliberately **off** on `production`: the head of a promotion PR is `main`, which is by definition newer than the branch it is being merged into. Requiring it to be "up to date" with a downstream branch would force a back-merge onto the trunk — reintroducing exactly the drift this removes.

## Still outstanding

- Staging backend live branch `staging` → `main` (you're doing this one).
- Deleting `staging` once that is repointed.
