### PR TITLE
Stop the Graph token following an impersonated sign-in

### DIFF
--- a/src/components/auth/sign-in-card.test.tsx
+++ b/src/components/auth/sign-in-card.test.tsx
@@ -101,6 +101,30 @@ describe("SignInCard", () => {
     expect(body.msAccessToken).toBeUndefined();
   });
 
+  // Impersonating reaches the same listener with somebody else's session, while the Graph
+  // token in hand still belongs to the teacher who signed in for real — sending it on would
+  // file that teacher's name under the impersonated account.
+  it("keeps the Microsoft access token out of a session that is not that sign-in's", async () => {
+    const fetchMock = respondWith(200, { status: "ok" });
+    getRedirectResult.mockResolvedValue({ user: signedInUser });
+    credentialFromResult.mockReturnValue({ accessToken: "graph-token" });
+
+    let notify: ((user: unknown) => void) | undefined;
+    onIdTokenChanged.mockImplementation((_auth: unknown, callback: (u: unknown) => void) => {
+      notify = callback;
+      callback(signedInUser);
+      return () => {};
+    });
+
+    render(<SignInCard />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => notify?.(userSignedInVia("custom")));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).msAccessToken).toBeUndefined();
+  });
+
   it("shows the HTL Dornbirn logo", () => {
     respondWith(200, { status: "ok" });
 

--- a/src/lib/auth/use-sign-in.ts
+++ b/src/lib/auth/use-sign-in.ts
@@ -75,7 +75,13 @@ export function useSignIn() {
         const response = await fetch("/api/session", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ idToken: token, msAccessToken: graphAccessToken }),
+          body: JSON.stringify({
+            idToken: token,
+            // The token describes the person who signed in through Entra ID. An impersonated
+            // session reaches this same listener, and asking Graph with a token that is not
+            // that session's would store the real user's name on the impersonated account.
+            msAccessToken: signInProvider === "microsoft.com" ? graphAccessToken : undefined,
+          }),
         });
 
         // The UPN domain isn't eligible (US-3) — leave no half-authenticated client state behind.


### PR DESCRIPTION
## What went wrong

Signing in through the test environment's impersonation dialog stored the wrong name. A teacher who had signed in through Entra ID as Hannes Stauss and then continued as Max Mustermann ended up with `users/max.mustermann@htldornbirn.at` holding `firstName: "Hannes"`, `lastName: "Stauss"`.

## Why

`useSignIn` captures the Microsoft Graph access token from `getRedirectResult` in the effect's closure, because it exists only in the redirect result and only right after a sign-in. But the closure outlives that sign-in: `onIdTokenChanged` fires again when the dialog signs in with a custom token, and the same `graphAccessToken` variable is still in scope. `/api/session` received it, `provisionUser` prefers `fetchEntraName` over the token claims, and Graph — asked with the real user's token — answered with the real user's name, which was then written onto the impersonated account.

The gap is only reachable where the fake login is built in, so production is unaffected. The mechanism is not: an access token was being sent alongside an ID token that was not the one it belongs to.

## The fix

Send the Graph token only for a `microsoft.com` sign-in, which is the identity it actually describes. `signInProvider` is already read from the ID token result a line above, and it is set by Firebase rather than by the caller. An impersonated session now falls back to the `given_name`/`family_name` claims the fake route already mints into its custom token — the path the route's comment says it intended.

## Recovering the bad data

Nothing to migrate. `provisionUser` rewrites `firstName` and `lastName` on every login, so an account that was given the wrong name corrects itself the next time it signs in.

## Tests

A new case in `sign-in-card.test.tsx` drives the listener twice — once for the real sign-in that carries the credential, then for a `custom` session — and asserts the second request goes without `msAccessToken`. Red before the change with `expected 'graph-token' to be undefined`, green after. The suite is at 948 passing; lint and `tsc --noEmit` are clean.
