### PR TITLE
Wait for checks without the alternate screen

### DIFF
--- a/.github/prompts/land-and-clean-up.prompt.md
+++ b/.github/prompts/land-and-clean-up.prompt.md
@@ -40,16 +40,22 @@ gh pr view --json number,title,state
 ```
 
 If there is no pull request, open one against `main` with `gh pr create --base main`, writing the
-body to a file and passing `--body-file` so `gh` never prompts.
+body to a file and passing `--body-file` so `gh` never prompts. If one is already open and the
+commit just made changes what it does, bring the body up to date with `gh pr edit --body-file`:
+the squash message is written from it, so a stale body outlives the pull request.
 
 ## 4. Merge it
 
 Auto-merge is disabled on this repository, so `gh pr merge --auto` fails. Wait for the checks
-instead:
+instead — redirected, because bare `--watch` draws into the alternate screen buffer, which a
+terminal without a TTY never leaves:
 
 ```bash
-gh pr checks <n> --watch
+gh pr checks <n> --watch --interval 20 > /tmp/checks.txt 2>&1; cat /tmp/checks.txt
 ```
+
+Redirecting costs nothing: `gh` prints plain lines when its output is not a terminal, and still
+blocks until every check has settled.
 
 `main` requires branches to be up to date, so a pull request opened before another merge reports
 `mergeStateStatus: BEHIND`. Rebase onto `origin/main` and force-push with `--force-with-lease`,


### PR DESCRIPTION
## Why

Running the prompt found the one step in it that could hang the run. `gh pr checks <n> --watch`
draws its refreshing table into the terminal's alternate screen buffer, and a terminal without a
TTY never leaves it — so the wait that was meant to be the safe part is the part that strands
everything after it, including the merge.

## What changed

The wait is now redirected:

```bash
gh pr checks <n> --watch --interval 20 > /tmp/checks.txt 2>&1; cat /tmp/checks.txt
```

Redirecting costs nothing. `gh` prints plain lines when its output is not a terminal, and
`--watch` still blocks until every check has settled, which is the only property the step needs.

Step 3 also says to bring an already-open pull request's body up to date before merging. The
squash message is written from that body, so a stale one outlives the pull request it belonged
to — which is exactly what nearly happened to #87 when a later commit added something the
description did not mention.

## Checks

`vitest` (1120 passed), `eslint`, `tsc --noEmit`, `prettier --check` and `license:check` green.
Markdown only; no source file changed.
