### PR TITLE
Put classes before programs, and start every tag with a capital

### DIFF
--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -9,6 +9,7 @@ Licensed under the MIT License. See LICENSE in the repository root for details.
 ## General
 
 - All UI text is in German.
+- Every tag in a tag list starts with a capital letter, so that a wrapping row of them reads as a row of labels rather than as one sentence broken across several.
 - All UI must be responsive, supporting desktop, tablet, and mobile screen sizes.
 
 ## Design Guidelines
@@ -368,7 +369,7 @@ As a teacher, I see a dashboard when I log in so that I can navigate to the diff
 - A header row is shown at the top of the dashboard: the application title "Sportsweek" on the left, and a logout button on the right.
 - Below the header, the remaining area is split into a left-side navigation zone and a content area on the right.
 - The left-side navigation contains, from top to bottom: Report (see US-13), Assignment (see US-12), and Master data.
-- The Master data navigation item has a sub-item for each teacher-maintained category (see US-4 through US-10).
+- The Master data navigation item has a sub-item for each teacher-maintained category (see US-4 through US-10), in this order: event series, classes, programs, skill levels, bus pickup points, food/diet options, season passes. Classes come first because a class is asked of every student whether they attend or not (see US-11), so it is the list a teacher fills in before any other. The order is stated here rather than left to follow the story numbers, which are stable identifiers and not a running order.
 - Selecting the Master data navigation item expands its sub-items; deselecting it collapses them again.
 
 ### US-15: Student navigation

--- a/src/components/assignment/class-cards.tsx
+++ b/src/components/assignment/class-cards.tsx
@@ -16,14 +16,15 @@ import {
   type FilterGroup,
   type StudentFilter,
 } from "@/lib/filters/student-filter";
+import { ATTENDANCE_LABELS } from "@/lib/registration/answer-labels";
 import type { RosterStudent } from "@/lib/students/roster";
 import { cn } from "@/lib/utils";
 import { AREA, AREAS, AreaTitle, FilteredTag } from "./card-areas";
 import { GenderTable } from "./gender-table";
 import { SkillMatrix } from "./skill-matrix";
 
-const ATTENDING_LABEL = "Nimmt teil";
-const NOT_ATTENDING_LABEL = "Nimmt nicht teil";
+const ATTENDING_LABEL = ATTENDANCE_LABELS.attending;
+const NOT_ATTENDING_LABEL = ATTENDANCE_LABELS.notAttending;
 
 type ClassCardsProps = {
   rows: readonly ClassGroup[];

--- a/src/components/filters/filter-tag-list.test.tsx
+++ b/src/components/filters/filter-tag-list.test.tsx
@@ -40,8 +40,8 @@ describe("FilterTagList", () => {
       "Alle",
       "Klasse: 5AHIF",
       "Klasse: 5BHIF",
-      "Geschlecht: männlich",
-      "Geschlecht: weiblich",
+      "Geschlecht: Männlich",
+      "Geschlecht: Weiblich",
       "Programm: Ski",
       "Leistungsstufe: Fortgeschritten",
     ]);

--- a/src/components/layout/teacher-nav.test.tsx
+++ b/src/components/layout/teacher-nav.test.tsx
@@ -15,8 +15,8 @@ const { TeacherNav } = await import("@/components/layout/teacher-nav");
 
 const SUB_ITEMS = [
   "Eventreihen",
-  "Programme",
   "Klassen",
+  "Programme",
   "Leistungsstufen",
   "Zustiegsstellen",
   "Verpflegung",

--- a/src/components/report/report-view.test.tsx
+++ b/src/components/report/report-view.test.tsx
@@ -153,7 +153,7 @@ describe("ReportView", () => {
   it("offers the attendance category the assignment dialog has no use for (US-13)", async () => {
     render(<ReportView />);
 
-    await userEvent.click(screen.getByRole("button", { name: "Teilnahme: nimmt teil" }));
+    await userEvent.click(screen.getByRole("button", { name: "Teilnahme: Nimmt teil" }));
 
     expect(rows()).toHaveLength(1);
     expect(rowOf("Muster")).toBeInTheDocument();
@@ -317,7 +317,7 @@ describe("the fields tag list", () => {
     await activate("Klasse");
     expect(rows()).toHaveLength(2);
 
-    await userEvent.click(screen.getByRole("button", { name: "Teilnahme: nimmt teil" }));
+    await userEvent.click(screen.getByRole("button", { name: "Teilnahme: Nimmt teil" }));
     expect(rows()).toHaveLength(1);
     expect(detailsOf("Muster")).toEqual(["Klasse:"]);
   });
@@ -464,7 +464,7 @@ describe("exporting", () => {
 
   it("hands the PDF the students the filter leaves and the fields that are activated", async () => {
     render(<ReportView />);
-    await userEvent.click(screen.getByRole("button", { name: "Teilnahme: nimmt teil" }));
+    await userEvent.click(screen.getByRole("button", { name: "Teilnahme: Nimmt teil" }));
     await activate("Klasse");
     await userEvent.click(screen.getByRole("button", { name: "PDF" }));
 

--- a/src/lib/filters/student-filter.test.ts
+++ b/src/lib/filters/student-filter.test.ts
@@ -514,12 +514,12 @@ describe("filterSummary", () => {
   it("lists the tags chosen, grouped by the category they were chosen in", () => {
     const filter = withTags(["class", "5AHIF"], ["class", "5BHIF"], ["gender", "female"]);
 
-    expect(filterSummary(filter, GROUPS)).toBe("5AHIF, 5BHIF \u00b7 weiblich");
+    expect(filterSummary(filter, GROUPS)).toBe("5AHIF, 5BHIF \u00b7 Weiblich");
   });
 
   it("leaves out a category nothing is chosen in, which restricts nothing", () => {
     expect(filterSummary(withTags(["attendance", ATTENDANCE_VALUES.attending]), GROUPS)).toBe(
-      "nimmt teil",
+      "Nimmt teil",
     );
   });
 

--- a/src/lib/filters/student-filter.ts
+++ b/src/lib/filters/student-filter.ts
@@ -7,9 +7,11 @@ import { z } from "zod";
 import { snapshotValueSchema, type Gender } from "@/lib/schemas/common";
 import { FOOD_OPTION_OTHER, FOOD_OPTION_OTHER_LABEL } from "@/lib/schemas/master-data";
 import {
+  ATTENDANCE_LABELS,
   EQUIPMENT_RENTAL_LABEL,
   EQUIPMENT_RENTAL_NEEDED_LABEL,
   EQUIPMENT_RENTAL_NOT_NEEDED_LABEL,
+  GENDER_LABELS,
   HEALTH_LABEL,
   HEALTH_NOTED_LABEL,
   INCOMPLETE_REGISTRATION_HINT,
@@ -194,13 +196,13 @@ export function filterSummary(
 }
 
 const GENDER_OPTIONS: readonly FilterOption[] = [
-  { value: "male", label: "männlich" },
-  { value: "female", label: "weiblich" },
+  { value: "male", label: GENDER_LABELS.male },
+  { value: "female", label: GENDER_LABELS.female },
 ];
 
 const ATTENDANCE_OPTIONS: readonly FilterOption[] = [
-  { value: ATTENDANCE_VALUES.attending, label: "nimmt teil" },
-  { value: ATTENDANCE_VALUES.notAttending, label: "nimmt nicht teil" },
+  { value: ATTENDANCE_VALUES.attending, label: ATTENDANCE_LABELS.attending },
+  { value: ATTENDANCE_VALUES.notAttending, label: ATTENDANCE_LABELS.notAttending },
 ];
 
 /**

--- a/src/lib/master-data/categories.test.ts
+++ b/src/lib/master-data/categories.test.ts
@@ -73,6 +73,19 @@ describe("MASTER_DATA_SECTIONS", () => {
     expect(MASTER_DATA_SECTIONS).toHaveLength(Object.keys(MASTER_DATA_CATEGORIES).length + 1);
   });
 
+  /** A student is asked their class before their program, and the menu is read in that order. */
+  it("puts the menu in the order a teacher works through it", () => {
+    expect(MASTER_DATA_SECTIONS.map((section) => section.label)).toEqual([
+      "Eventreihen",
+      "Klassen",
+      "Programme",
+      "Leistungsstufen",
+      "Zustiegsstellen",
+      "Verpflegung",
+      "Saisonkarten",
+    ]);
+  });
+
   it("links each category under its own key, labelled with the title it already carries", () => {
     for (const [key, category] of Object.entries(MASTER_DATA_CATEGORIES)) {
       expect(MASTER_DATA_SECTIONS).toContainEqual({

--- a/src/lib/master-data/categories.ts
+++ b/src/lib/master-data/categories.ts
@@ -32,10 +32,21 @@ export type MasterDataCategory = {
 };
 
 /**
- * The six teacher-maintained lists, keyed by the URL segment under /app/master-data. EventSeries
- * are not here: they carry active/archived state of their own and keep their dedicated view.
+ * The six teacher-maintained lists, keyed by the URL segment under /app/master-data, in the order
+ * the menu shows them. EventSeries are not here: they carry active/archived state of their own and
+ * keep their dedicated view.
  */
 export const MASTER_DATA_CATEGORIES = {
+  classes: {
+    collection: COLLECTIONS.classOptions,
+    usage: { kind: "masterData", field: "class" },
+    labels: {
+      title: "Klassen",
+      singular: "Klasse",
+      add: "Neue Klasse",
+      empty: "Es gibt noch keine Klasse.",
+    },
+  },
   programs: {
     collection: COLLECTIONS.programs,
     usage: { kind: "masterData", field: "program" },
@@ -45,16 +56,6 @@ export const MASTER_DATA_CATEGORIES = {
       singular: "Programm",
       add: "Neues Programm",
       empty: "Es gibt noch kein Programm.",
-    },
-  },
-  classes: {
-    collection: COLLECTIONS.classOptions,
-    usage: { kind: "masterData", field: "class" },
-    labels: {
-      title: "Klassen",
-      singular: "Klasse",
-      add: "Neue Klasse",
-      empty: "Es gibt noch keine Klasse.",
     },
   },
   "skill-levels": {

--- a/src/lib/registration/answer-labels.ts
+++ b/src/lib/registration/answer-labels.ts
@@ -22,6 +22,12 @@ export const RELATIONSHIP_LABELS: Record<Relationship, string> = {
   other: "Sonstiges",
 };
 
+/** How the attendance answer reads where it names a group of students or a tag that selects one. */
+export const ATTENDANCE_LABELS = {
+  attending: "Nimmt teil",
+  notAttending: "Nimmt nicht teil",
+} as const;
+
 /** "Nein" first, because that is where an unanswered registration starts (US-11). */
 export const YES_NO_LABELS = { false: "Nein", true: "Ja" } as const;
 


### PR DESCRIPTION
## The master data menu

Classes now lead the menu, ahead of programs: a class is asked of every student
whether they attend or not (US-11), so it is the list a teacher fills in before
any other. `MASTER_DATA_SECTIONS` derives from `MASTER_DATA_CATEGORIES`, so the
order is changed by moving the entry, and a test states the menu in full rather
than leaving it to be inferred from the key order.

The spec now names the order instead of implying it through "US-4 through
US-10". Story numbers are stable identifiers, not a running order, so leaving
the menu to follow them meant the menu could not be rearranged without appearing
to renumber the stories.

Nothing else in the interface had to move: the report's fields row, the filter
row and the registration form all ask for the class before the program already.

## Capitals

A tag row wraps, and a tag starting lower-case reads as the tail of the tag
before it rather than as a label of its own. The two that did are the gender and
attendance tags.

Both already existed capitalised elsewhere, so neither is retyped:
`GENDER_LABELS` (which the report's "Geschlecht" line has always used) now
supplies the gender tags, and `class-cards.tsx` gives up its private
"Nimmt teil" / "Nimmt nicht teil" pair to a shared `ATTENDANCE_LABELS` that the
tags read too. The rule itself is written down once, in the spec's General
section.

## Verification

`vitest run` (1483), `npm run lint`, `npx tsc --noEmit`, `prettier --check .`
and `npm run license:check` all pass.
