### PR TITLE
Refuse the edits that would strand an answer, instead of cascading

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,61 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
+        { "fieldPath": "class", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
+        { "fieldPath": "program", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
+        { "fieldPath": "skillLevel", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
+        { "fieldPath": "seasonPassOption", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
+        { "fieldPath": "busPickupPoint", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
+        { "fieldPath": "foodOption", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
+        { "fieldPath": "rentedEquipment", "arrayConfig": "CONTAINS" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/spec/refactoring-event-series.md
+++ b/spec/refactoring-event-series.md
@@ -29,9 +29,10 @@ grow into the union of everything every event ever needed.
 an item that any registration of any non-archived season still holds, because the edit would
 reach into a season nobody was looking at. The rule is correct given the model, and it is also
 the single most obstructive thing in the application: a teacher who mistyped a class name in
-October cannot fix it in November. Once each event series owns its own lists, an edit can only
-ever reach the registrations of that one series — which is what makes cascading them safe, and
-what lets the rule be withdrawn instead of worked around.
+October cannot fix it in November. The rule is correct given the model, and once each event series
+owns its own lists it stops being obstructive: an edit can only ever reach the registrations of
+that one series, so it bites only where the same series' own students have already answered —
+which is the case where changing the question behind their backs would be wrong anyway.
 
 **One season is "active", and everything hangs off that.** Registration, assignment and the
 report all read the active season, so the application can only ever be about one event at a
@@ -44,22 +45,22 @@ event series, labelled "Eventreihe".
 
 ## What changes, in one page
 
-| Today                                                    | After                                                                                |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `seasons` collection, one of them `isActive`             | `eventSeries` collection, none of them privileged over the others                    |
-| Seven collections of master data, shared by every season | Seven ordered arrays on the event series document                                    |
-| Master data item identified by a document id             | Identified by its name, which is already unique within its list                      |
-| An item in use cannot be edited or removed               | Any item can be renamed, and removed too — unless it is a class a registration holds |
-| A registration is a snapshot nothing may disturb         | A registration is kept in step with the lists its series offers                      |
-| `savedReports` collection, shared by every season        | Saved reports belong to one event series                                             |
-| Registration joins `users` for the student's name        | Registration carries the name, so a report is one read                               |
-| `studentMasterData`, which was never master data         | `registrations`, which is what a student's answers are                               |
-| `studentMasterData.eventId` points at an event document  | `registration.event` names the event, like every other list value                    |
-| One season is active; students write to that one         | Each series is open to students or not; several may be open at once                  |
-| Registration opens when a teacher activates a season     | A series is opened by generating its invitation link                                 |
-| The statistics page shows figures                        | The overview page runs the series: figures, invitation links and the open switch     |
-| The page decides which season it is about                | The header decides, once, for every page                                             |
-| Uniqueness via the `reservedNames` collection            | In-document for lists; a transactional query on `nameKey` for series names           |
+| Today                                                    | After                                                                                           |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `seasons` collection, one of them `isActive`             | `eventSeries` collection, none of them privileged over the others                               |
+| Seven collections of master data, shared by every season | Seven ordered arrays on the event series document                                               |
+| Master data item identified by a document id             | Identified by its name, which is already unique within its list                                 |
+| An item in use cannot be edited or removed               | An item **this series'** students have chosen cannot be renamed or removed; everything else can |
+| A registration is a snapshot nothing may disturb         | Unchanged — and now true by construction rather than by luck                                    |
+| `savedReports` collection, shared by every season        | Saved reports belong to one event series                                                        |
+| Registration joins `users` for the student's name        | Registration carries the name, so a report is one read                                          |
+| `studentMasterData`, which was never master data         | `registrations`, which is what a student's answers are                                          |
+| `studentMasterData.eventId` points at an event document  | `registration.event` names the event, like every other list value                               |
+| One season is active; students write to that one         | Each series is open to students or not; several may be open at once                             |
+| Registration opens when a teacher activates a season     | A series is opened by generating its invitation link                                            |
+| The statistics page shows figures                        | The overview page runs the series: figures, invitation links and the open switch                |
+| The page decides which season it is about                | The header decides, once, for every page                                                        |
+| Uniqueness via the `reservedNames` collection            | In-document for lists; a transactional query on `nameKey` for series names                      |
 
 ## The shape it moves to
 
@@ -85,10 +86,6 @@ event series, labelled "Eventreihe".
   "isOpenToStudents": true,
   "hasRegistrations": false, // mirror, server-owned, so the client can gate archive/delete
   "position": 0, // the order of the header tags (see Ordering)
-  "revision": 41, // incremented by every write; what concurrent work checks against
-  // The lock of US-27 while a cascade is running, and the only thing the trigger of Q15 reads:
-  // which list changed, from what to what, how far it has got, and how many attempts it has had.
-  "pendingCascade": null,
 
   // The maintained lists, in the order the master data menu states (US-14) — the one order the
   // report fields, the filter categories and the registration form already follow. Array order
@@ -108,8 +105,8 @@ event series, labelled "Eventreihe".
 
   // A saved report is a selection the teacher asked to be remembered, and nothing else: a name,
   // which students are shown, and which detail lines they show (US-13, US-25). It is here for
-  // the same reason the lists are — it belongs to this series and filters on these lists, and a
-  // cascade that fixed the lists but left the reports behind would have fixed nothing. Array
+  // the same reason the lists are — it belongs to this series and filters on these lists, so one
+  // transaction writes both and they cannot disagree. Array
   // order is the order the tags were dragged into, so no report carries a position either.
   "savedReports": [
     {
@@ -156,10 +153,11 @@ student's answers, and nothing a student can write. See Q1.
   "lastName": "Müller",
   "email": "anna.mueller@student.htldornbirn.at",
 
-  "isIncomplete": true, // recomputed by the server on every write, including a cascade
+  "isIncomplete": true, // recomputed by the server on every write
   "isAttendingSportsWeek": true,
 
-  // Values chosen from the event series' lists, held by name. Kept in step by US-24.
+  // Values chosen from the event series' lists, held by name. Stored as plain text, and left
+  // alone once given: US-24 refuses the edits that would strand one.
   "event": "Woche 2", // was eventId; null while unassigned
   "class": "2bWI", // set from the invitation link, not answered by the student (US-23)
   "program": "Ski",
@@ -266,8 +264,7 @@ actually runs, and so that two of them can be prepared at once.
 - Because archiving implies closed, the student-side check is **one flag rather than two**: a
   student may write when the series is open, and that already excludes every archived series.
 - An event series stores its name, whether it is a template, whether it is archived, whether it
-  is open to students, whether it holds registrations, its place in the teacher's order, and its
-  revision.
+  is open to students, whether it holds registrations, and its place in the teacher's order.
 - **A template is an event series that can never be opened to students** (US-22, Q21). That is
   the whole of it: it is selected from the header row and scoped like any other, its lists are
   maintained like any other's, and the report, overview and assignment scoped to it show the
@@ -417,14 +414,14 @@ its lists with a Wintersportwoche.
   chooses from its lists and subscribes to them live. A rule grants the whole document, so a
   student can also read the saved reports in it; that is accepted rather than overlooked, and
   Q1 says why. Nobody writes the document from a client.
-- The in-use restriction of US-5 to US-10 is withdrawn, with **one exception**: an item of a
-  non-archived series may be renamed at any time, and removed at any time _unless_ it is a class
-  that some registration of that series holds (Q16). What an edit does to the registrations and
-  saved reports holding it is US-24 and US-25.
-- The exception is as narrow as it can be stated: **classes only, removal only, one series only.**
-  Everything that enforced or explained the old restriction is still deleted, because the surviving
-  rule asks one question about one list and a teacher already reads every registration of the
-  selected series — so which classes are in use is derived from data on hand rather than fetched.
+- The in-use restriction of US-5 to US-10 **survives, narrowed twice over**: it now asks about one
+  event series rather than every non-archived one, and about one item rather than a whole list.
+  Adding and reordering are free at all times; renaming or removing is refused only for an item
+  some registration of that series holds (US-24).
+- That narrowing is the whole of what the move buys here. The rule was obstructive because the
+  lists were global, so another season's registration froze this season's identically-named item.
+  Scoped to one series, it bites only where this series' own students have already answered — and
+  during setup, when mistakes are actually caught, nothing is in use and everything is editable.
 - **A newly created event series is blank.** Every list is empty and the application seeds
   nothing into it (Q9): it cannot know whether it is being asked for a Wintersportwoche or a
   Kulturwoche, and guessing wrong is worse than not guessing. Starting from something instead of
@@ -555,9 +552,10 @@ everybody at once.
 - The token is generated from a cryptographically secure random source and is long enough that
   guessing is not a strategy.
 - Each class's link is regenerated on its own, which invalidates only that class's previous link.
-- **A link is cascaded like anything else that holds a list value** (US-24): renaming a class
-  rewrites the class its links name, and removing a class invalidates them, because a link into a
-  class that no longer exists could only produce a registration with no class. Invitations are
+- **A link holds a list value, so the same refusal covers it** (US-24): a class named by a link
+  cannot be removed while a registration holds it, and a class whose links exist but whose
+  registrations do not can still go — nobody used them, so nothing is lost, and the links are
+  invalidated with it. What a link may never become is an enrolment into a class that is gone.
   the third thing a list change reaches, after the registrations and the saved reports.
 - The link selects an event series and does nothing else. It signs nobody in and grants no
   identity: a student following it still signs in through Entra ID (US-1) and still has the role
@@ -608,87 +606,67 @@ everybody at once.
   the one who made it, checking it before sending it out, and a refusal would be a message for
   somebody who has done nothing wrong.
 
-### US-24: A change to a list reaches the registrations that hold it
+### US-24: An answer a student has given cannot be taken away from them
 
-As a teacher, when I rename or remove an item, the registrations holding it are brought into
-line, so that no registration is left holding a value its event series no longer offers.
-
-**Acceptance criteria:**
-
-- Renaming an item rewrites that value in every registration of the same event series that holds
-  it. A class renamed from "3aWI" to "3AWI" is what the report, the assignment board, the filters
-  and every export then show, none of which has to know the old name.
-- Removing an item clears that value from every registration of the same event series that holds
-  it. The registration itself is kept: a student whose program was removed has no program, not no
-  registration.
-- Removing a program also clears the rented equipment of the students who chose it, because a
-  rental is only meaningful as an entry of that program's list. Renaming a required equipment
-  item rewrites the rentals naming it; removing one drops it from them.
-- Removing an event unassigns the students assigned to it, which is what US-4 already requires
-  and is now the same rule as every other removal rather than a special case.
-- **A class that any registration holds cannot be removed** (Q16). It is the one list value a
-  student cannot be asked for again, because it comes from the invitation link rather than from
-  them — so clearing it would strand the registration outside every class, permanently. Renaming
-  is always allowed and cascades like anything else; removal is refused while the class is in use,
-  and the row's remove control is disabled with a hint saying so.
-- **The invitation links are cascaded too** (US-23): renaming a class rewrites the class its
-  links name, and removing a class invalidates them. A link is the third thing that holds a list
-  value, after a registration and a saved report, and it would otherwise go on enrolling students
-  into a class that no longer exists. Removing a class that has links but no registrations is
-  therefore still allowed — nobody used them, so nothing is lost.
-- Every registration the cascade touches has its outstanding-answers flag (US-11) recomputed,
-  since clearing a value can only make a registration less complete.
-- The cascade is scoped to the event series whose list changed and reaches no other. That is
-  precisely what moving master data into the series bought, and it is what makes the withdrawal
-  of the in-use rule safe.
-- No cascade can ever arise from an archived event series, because it cannot be selected and so
-  its lists cannot be edited (US-19, US-20). This is not a case the cascade has to exclude — it is
-  a case that cannot occur.
-- The invariant this exists to preserve, stated so it can be tested: on a non-archived series,
-  every list value on every registration is either unanswered or one the series currently offers.
-  The cascade is one half of holding it, and US-27's validation of a student's save is the other.
-- Before confirming a removal the teacher is told what it will do, including how many
-  registrations will lose the value, so that a destructive edit is a decision and not a surprise.
-  A rename says the same thing in the terms a rename deserves: how many registrations will be
-  rewritten.
-- **Removing the last item of a list says so too**, because it does more than clear a value: the
-  question stops being asked altogether (US-21), and every registration that answered it becomes
-  one answer shorter rather than one answer poorer.
-- The cascade is not atomic with the edit that caused it. US-27 is what makes it safe anyway.
-
-### US-25: A change to a list reaches the saved reports that filter on it
-
-As a teacher, my saved reports go on meaning what I saved them as when the lists they filter on
-change, so that opening one shows the report rather than a report widened by tags that quietly
-stopped matching.
+As a teacher, I can shape a list freely until students start answering from it, and after that
+the application refuses the edits that would strand what they said — so that no registration is
+ever left holding a value its event series no longer offers.
 
 **Acceptance criteria:**
 
-- Renaming an item rewrites that tag in every saved report of the same event series that selects
-  it.
-- Removing an item removes that tag from every saved report of the same event series that selects
-  it. A report left with no tag in that category simply stops restricting by that category, which
-  is what an empty category already means (US-12).
-- The event filter tag holds the event's name rather than its id, so that removing or renaming an
-  event is the same rule as every other category. It is the only tag storing an id today, and
-  with it goes the `ReportFieldContext` that existed to translate ids back into names.
-- The activated field tags are not master data and are never touched by a cascade.
+- **Adding an item is always allowed**, before and during registration. A new option strands
+  nothing: every answer already given stays valid, and the question simply gains a choice. A
+  teacher who notices a missing class after the invitations have gone out adds it.
+- **Reordering is always allowed**, for the same reason: the order is how a teacher wants to read
+  the list (see Ordering) and no stored value changes.
+- **Renaming or removing an item some registration of that series holds is refused.** The row's
+  controls are disabled with a hint saying why, and the server refuses it as well — the disabled
+  control is a convenience, and a client is not a trust boundary.
+- The refusal is **per item, not per list**: only the entries students have actually chosen are
+  frozen. Everything else on the same list stays editable, which is what keeps the rule from
+  becoming "the series is finished" the moment the first student answers.
+- The refusal is **per event series**. An item of one series is never held back by another
+  series' registrations, which is precisely what moving the lists into the document bought
+  (US-21) — and it is the whole of the complaint this refactoring set out to fix.
+- Required equipment follows the same rule one entry at a time: an entry a student still rents
+  cannot be renamed away or removed, and a program cannot be deleted while one of its entries is
+  rented, since deleting it would take that entry along (US-5).
+- Removing an event is refused while a student is assigned to it. Unassigning them first is what
+  makes it removable, which is a teacher's decision rather than a silent consequence.
+- **Nothing is rewritten behind a student's back.** Renaming "Vegetarisch" to "Vegan" would
+  change what a hundred students said they wanted, and no automatic rewrite can know whether
+  they still mean it. Where an answer has to change, the answer is asked again.
+- The invariant, stated so it can be tested: on any series, every list value on every
+  registration is either unanswered or one the series currently offers. The refusal is what
+  holds it, and US-27 is what stops a concurrent save slipping past.
+- **What a teacher does when a list is genuinely wrong** is not a smaller edit but a larger
+  decision: the answers already given were given against the old list, so correcting it means
+  asking for them again. Deleting the series and running registration afresh is the honest
+  version of that, and it is a decision only the school can take.
+
+### US-25: Saved reports live with the lists they filter on
+
+As a teacher, my saved reports keep meaning what I saved them as, so that opening one shows the
+report rather than a report widened by tags that quietly stopped matching.
+
+**Acceptance criteria:**
+
 - Saved reports belong to one event series and are stored in its document, beside the lists they
   filter on: they are created in it, listed only while it is selected, deleted with it, and their
-  order is the array's. That is also what makes this cascade cheap — a rename rewrites the lists
-  and the reports that filter on them in the same transaction, so the two can never disagree,
-  which the cascade into registrations (US-24) cannot promise.
+  order is the array's.
 - A saved report is a selection that was remembered, and nothing else: a name, a filter and a set
   of field keys. It names nobody and records nothing about how it came to exist.
-- Opening a saved report stays as tolerant as US-13 requires: a tag nothing offers any more
-  restricts nothing, and a field key nothing offers adds no detail line. The cascade and the
-  tolerance are both kept and neither replaces the other — the cascade is what stops a rename
-  silently widening a report, the tolerance is what keeps a report saved by an older release
-  readable.
+- The event filter tag holds the event's name rather than its id, so an event is the same kind of
+  value as every other list entry. It was the only tag storing an id, and with it goes the
+  `ReportFieldContext` that existed to translate ids back into names.
+- **A tag can only be left stranded by a removal the lock allows**, which is an item no
+  registration holds (US-24). Opening the report then stays as tolerant as US-13 requires: a tag
+  nothing offers any more restricts nothing, and a field key nothing offers adds no detail line.
+  That tolerance also keeps a report saved by an older release readable.
+- The activated field tags are not master data and are never rewritten.
 - The same pruning runs **when a report is copied into a new series** (US-22, Q10): a tag the
-  copied lists do not offer is dropped there and then. Copying and removing are the same
-  situation from the report's point of view — a value its series does not have — so they get the
-  same treatment rather than one being left to the reader.
+  copied lists do not offer is dropped there and then, so a copy is consistent with its own
+  lists from the moment it exists rather than relying on the read-time tolerance later.
 
 ### US-26: A registration is self-contained
 
@@ -733,7 +711,7 @@ to the records around it.
   let a teacher read every user record is narrowed to reading their own. The fake login's list of
   existing users (US-16) is unaffected: it is already read server-side.
 
-### US-27: Concurrent writes are serialised and cascades are resumable
+### US-27: A concurrent registration cannot slip past the guard
 
 As the system, I keep one event series consistent while several teachers and a class full of
 students write to it at the same time.
@@ -742,54 +720,34 @@ students write to it at the same time.
 
 - Every write to an event series' lists is a transaction on its document, so two edits to two
   different lists cannot lose one another and two edits to the same list are ordered. The saved
-  reports are in that document, so the cascade of US-25 is part of the same transaction as the
-  edit that caused it and needs nothing below.
-- The event series carries a revision that every write increments. Anything that depends on what
-  the lists currently say — a student saving a registration, a teacher assigning students, a
-  cascade — reads it, and is retried rather than committed if it moved underneath.
-- The cascade into the registrations (US-24) is the one that cannot join that transaction, because
-  the registrations are documents of their own and there may be hundreds of them. An edit that
-  needs one records on the event series, before it starts, what changed: which list, what the
-  value was, what it became or that it went, and at which revision.
-- While that record stands, further edits to that event series' lists are refused with a conflict
-  and the interface says so through the application's shared spinner and busy region, as it
-  already does while an assignment or a saved report is being written. That refusal is the lock,
-  and it is held in the database, so it holds across tabs, teachers and processes rather than
-  only within one client.
-- The cascade is expressed as "wherever this value is still the old one, make it the new one",
-  which makes it idempotent: running it a second time changes nothing the first run did not.
-- The cascade is performed in bounded batches and records how far it has got, so an interrupted
-  run is resumed rather than restarted, and no run is bounded by how many registrations an event
-  series holds.
-- **What runs it is a Firestore trigger on the event series document** (Q15), so the fan-out
-  outlives the request that caused it and is retried by the platform rather than by a person.
-- **The trigger acts on stored state, never on the event's payload.** It re-reads
-  `pendingCascade` in a transaction and works from that; the `before`/`after` deltas are not
-  consulted. This is what makes at-least-once delivery and out-of-order delivery both harmless,
-  and it is the one implementation rule that cannot be relaxed — a delta applied out of order
-  would corrupt rather than merely lag.
-- Ordering cannot arise in any case, because the lock permits **at most one cascade record per
-  series at a time**. There is never a second cascade to arrive before the first.
-- The trigger returns immediately where the document carries no pending cascade. That one
-  condition is also what stops it recursing when the cascade clears the lock, and what keeps a
-  reorder or a saved report edit from starting anything.
-- **The progress write is what schedules the next batch**, since it is itself a write to the
-  document the trigger watches. There is no queue and no scheduler, and no continuation is passed
-  anywhere.
-- `pendingCascade` carries an **attempt count**, and the cascade stops after a fixed number of
-  them, so a batch that can never succeed comes to rest instead of looping for ever.
-- A cascade that cannot be finished leaves its record standing rather than clearing it, so the
-  inconsistency is visible and retriable instead of silent, and the event series list says which
-  series is in that state — with a control on that row to resume it, which resets the attempt
-  count.
-- **A pending cascade never blocks a class.** It refuses list edits, not registrations: a student
-  saving validates against the lists, and those are already correct, since the list edit committed
-  in the first transaction and only the fan-out is outstanding.
-- A student saving a registration has every list value validated against the event series as it
-  stands in the same transaction. A value the series no longer offers is refused rather than
-  stored, which closes the window in which a save races a removal.
-- Deleting an event series, and creating one from a copy, take the same lock, so neither races a
-  cascade.
+  reports are in that document, so a report and the lists it filters on can never disagree.
+- **The in-use check runs inside the transaction that writes the list**, not before it. Asked
+  beforehand its answer is already stale: a student choosing the value being removed in between
+  would be left holding something the series no longer offers, and with no cascade nothing would
+  repair it. A guard with that hole is worse than none, because it claims an invariant it does
+  not hold.
+- The check is a query for the registrations of that series holding **that one value**, so
+  Firestore locks a narrow index range: a student answering anything else never conflicts, and
+  the only save that does is one choosing the very item being edited — which is exactly the save
+  that ought to conflict.
+- **The student's save reads the event series inside its own transaction** and validates every
+  list value against it. That closes the other direction: a teacher's edit writes that document,
+  so a save which read the older one conflicts, retries, and is then refused rather than storing
+  a value nothing offers.
+- Either order is therefore safe. Whichever commits first invalidates the other's read, and the
+  loser retries and sees the winner.
+- **The student never pays for this.** A transaction retries by itself, so a save caught by a
+  concurrent list edit re-reads, re-validates and commits without the student noticing. The one
+  case they are refused is the case that deserves it: the option they chose has just been
+  removed, and they are asked to reload and choose again.
+- **The teacher pays**, which is the right way round: they are doing the rare and questionable
+  thing — editing lists mid-registration — so theirs is the request that waits, and is told to
+  try again if it cannot get through.
+- The narrow queries need one composite index per answer a list supplies, plus one for the
+  rentals. They are temporary: once a registration lives beneath the series it belongs to
+  (US-26), the series is the path rather than a field, and every one of them goes.
+- Nothing outlives the request. There is no lock left standing, no progress record, no attempt
+  count and nothing to resume, because an edit either commits whole or does not commit.
 
 ### US-28: A teacher removes a registration
 
@@ -825,8 +783,9 @@ reached them by mistake does not stay in the series for good.
 - **`hasRegistrations` is recomputed in the same transaction.** Deleting the last registration of
   a series puts the mirror back to false, which is the first time it has ever had to go down
   (Q5) — and it is what the archive and delete controls of US-19 read.
-- A delete that races a running cascade is harmless: the cascade is expressed as "wherever this
-  value is still the old one" (US-27), and a document that is gone simply is not among them.
+- Deleting one registration can free the last hold on a list item, so an edit a teacher was
+  refused a moment ago may be allowed afterwards (US-24). The guard is asked again on every
+  write, so nothing has to be told that this changed.
 
 ### US-29: The overview page is where an event series is run from
 
@@ -896,7 +855,7 @@ series up is one place rather than three.
 | US-1                    | Provisioning gains one step: the names it refreshes at every login are carried into that student's registrations (US-26).                                                                                                                                                                                               |
 | US-2, US-3              | Unchanged.                                                                                                                                                                                                                                                                                                              |
 | US-4                    | Rewritten as US-19 and US-21. The active season, its transaction and its empty states go; the delete and archive rules survive, the archive gate loosens.                                                                                                                                                               |
-| US-5 to US-10           | Kept as descriptions of the seven lists. The in-use restriction preceding them is withdrawn and replaced by US-24 and US-25. Storage moves (US-21).                                                                                                                                                                     |
+| US-5 to US-10           | Kept as descriptions of the seven lists. The in-use restriction preceding them is narrowed to one series and one item (US-24). Storage moves (US-21).                                                                                                                                                                   |
 | US-11                   | The season becomes the event series the invitation named, and the class comes from that invitation rather than being answered (US-23). **A question whose list is empty is not asked at all** (US-21). List values stop being snapshots and become references the server keeps in step (Q4). Self-containment is US-26. |
 | US-12                   | Scoped to the selected event series rather than the active season. `eventId` becomes `event`. Otherwise unchanged.                                                                                                                                                                                                      |
 | US-13                   | Scoped to the selected event series. Saved reports become per series (US-25). The tolerance on opening a saved report is kept.                                                                                                                                                                                          |
@@ -991,9 +950,9 @@ follow, the answer label each list is named by, and the field a registration sto
 in. The tests that pin those four lists to one another are what says the move preserved them, so
 a slice that has to relax one of them has gone wrong somewhere else.
 
-The in-use rule of US-5 to US-10 **stays** for this slice, rewritten against the new storage, so
-that nothing a teacher can do changes yet. Withdrawing it is slice 3b, where the cascade that
-makes withdrawing it safe arrives.
+The in-use rule of US-5 to US-10 **stays**, rewritten against the new storage: it is now per
+series rather than global, which is most of what made it obstructive. Making it sound under a
+concurrent registration is slice 3.
 
 Three things are finished here rather than left half-done:
 
@@ -1012,34 +971,27 @@ Three things are finished here rather than left half-done:
   against an empty list rather than excepted from it — one document has one loading flag, so a
   list nobody filled in and a list still being read stop looking alike.
 
-### 3a. The functions codebase
+### 3. Closing the race in the in-use rule, and the saved reports
 
-The `functions/` codebase arrives on its own, carrying nothing but the trigger's guard clause and
-the test that proves it returns on a document with no pending cascade.
+US-24, US-25 and US-27 land together, and there is no cascade in any of them.
 
-It is separate from 3b because of what it costs rather than what it does: its own dependency tree
-and lockfile, a second install and test run in CI, the functions and eventarc emulators beside
-the firestore one, a deploy workflow, and **a widening of what the deploy identity may reach** —
-Cloud Build, Artifact Registry, Cloud Run and service-account-user, where deploying rules needs
-almost none of it. That is the largest real cost of Q15 and the part to review rather than copy
-from a template, and it is not reviewable buried under the cascade.
+The in-use rule **stays** and is made sound. It moves inside the transaction that writes the
+list, and it stops reading the whole series: the check is a query for the registrations holding
+the one value being touched, so the locked index range is narrow. The student's save becomes a
+transaction too, reading the event series and validating its answers against it, which closes
+the other direction. Those two changes are the whole of US-27.
 
-### 3b. The cascade, and withdrawing the in-use rule
+The narrow queries bring one composite index per answer a list supplies, plus one for the
+rentals. They are temporary and go again in slice 4, when a registration moves beneath its
+series and the series stops being a field to filter by.
 
-US-24, US-25 and US-27 land together, and the in-use machinery goes with them: `usage-guard.ts`,
-`GET /api/master-data/[category]`, `useUsageReport`, and the five hints that explained the rule.
-
-The saved reports move into the event series document in this slice rather than the last, because
-what makes their cascade cheap is being in the same transaction as the edit that caused it
-(US-25) — moving them earlier would mean writing that cascade twice.
-
-What survives of the old restriction is one refusal: a class held by any registration of that
-series cannot be removed (Q16). It needs none of the deleted machinery, being a reduce over
-registrations a teacher already reads.
+The saved reports move into the event series document in this slice, beside the lists they filter
+on — one document, one transaction, so a report and its lists cannot disagree.
 
 This is the slice that needs the concurrency tests, and the invariant of US-24 is the one worth
-writing first: after any edit to a non-archived series, every list value on every registration is
-either unanswered or one the series currently offers.
+writing first: after any edit, every list value on every registration is either unanswered or one
+the series currently offers. Both races are worth a test of their own, since neither is visible
+in a single-threaded run.
 
 ### 4. Self-contained registrations
 
@@ -1155,32 +1107,33 @@ their registrations as well, so a name can never be more than one login stale, a
 never opens their form again is still corrected the next time they sign in at all. This is also
 the answer to Q17.
 
-**Q4 — They are denormalised references the server keeps in step, not snapshots. Decided.** US-11
-states at length that a list value is stored "redundantly as plain text, not as a foreign key"
-precisely so that "later changes to the maintained list do not alter already-stored master data
-records". US-24 says the opposite, and US-24 is what we want. The values keep the same shape —
-a name or nothing — but they stop being a record of what was chosen and become a reference whose
-spelling the server maintains. **US-11 is rewritten rather than left to contradict US-24.**
+**Q4 — They are snapshots after all, and US-11 was right. Reversed.** This question originally
+decided the opposite: US-11 says a list value is stored "redundantly as plain text, not as a
+foreign key" precisely so that "later changes to the maintained list do not alter already-stored
+master data records", and the cascade of US-24 contradicted it, so US-11 was to be rewritten.
 
-Saying it that way is what gives the model an invariant worth testing: on a non-archived series,
-every list value on every registration is either unanswered or one the series currently offers.
-The cascade exists to preserve it, US-27's validation of a student's save is the other half of
-it, and a test can assert it outright after any edit.
+With the cascade gone (Q15), **nothing rewrites a stored answer**, and US-11's sentence is simply
+true again. It is left exactly as it stands.
 
-It also sorts the registration's fields into three kinds, which is worth keeping straight because
-each is repaired by a different mechanism:
+The invariant survives the reversal and is easier to hold: on any series, every list value on
+every registration is either unanswered or one the series currently offers. What preserves it is
+no longer a repair after the fact but a refusal before it — US-24 will not let an item a
+registration holds be renamed or removed, and US-27 makes that refusal sound against a concurrent
+save. A test can assert it outright after any edit.
+
+It still sorts the registration's fields into three kinds, which is worth keeping straight
+because each stays honest by a different means:
 
 | Kind                                                            | Kept honest by            |
 | --------------------------------------------------------------- | ------------------------- |
 | Answers the student owns (birth date, phone, health, free text) | Nothing — they are theirs |
-| List values (class, program, skill level, event, …)             | The cascade, US-24        |
+| List values (class, program, skill level, event, …)             | The refusal, US-24        |
 | Identity copies (first name, last name, e-mail)                 | The next login, US-26     |
 
-Archiving then needs no rule of its own to freeze these values. An archived series has no tag in
-the header, so it cannot be selected, and every editing view acts on the selected series — so
-there is no screen from which its lists can be changed, and no edit that could start a cascade.
-Its list values simply stop moving, which makes them exactly the snapshots US-11 used to
-describe. Archiving is the point at which a reference becomes a record again.
+Archiving needs no rule of its own here either. An archived series has no tag in the header, so
+it cannot be selected, and every editing view acts on the selected series — so there is no screen
+from which its lists can be changed. Its values stop moving because nothing can reach them, not
+because anything freezes them.
 
 **Q5 — Any event series can be archived. Decided.** US-4 forbids archiving a season that holds no
 student data, on the grounds that archiving signs off on that data. The reasoning behind that
@@ -1539,153 +1492,70 @@ only ever report on a path its own caller was not taking.
 
 ### Consistency and delivery
 
-**Q15 — The cascade runs in a Firestore trigger, and the trigger reads state rather than the
-change. Decided.** The architecture table says that reacting to a document change belongs in an
-event-driven function, and this repository has no Cloud Functions codebase — it is App Hosting
-and Next.js. **One is added.**
+**Q15 — There is no cascade, so there is no trigger. Withdrawn.** This question originally decided
+that the fan-out belonged in a Firestore trigger, and a `functions/` codebase was added for it.
+Both are gone, because the thing they carried turned out not to be worth having.
 
-One argument is dismissed before the others, because it would otherwise decide this by accident:
-**portability is not a consideration here.** This application is committed to Firebase and
-Firestore in ways that are load-bearing rather than incidental — the access rules are the
-authorisation model, the live subscriptions are the update mechanism, and the uniqueness rule of
-Q14 rests on Firestore's transactional-query locking specifically. Moving off it would be a
-rewrite, not a refactoring, and one we are deliberately not paying for. So "a Cloud Function
-deepens the lock-in" carries no weight: there is nothing left to protect, and if that rewrite ever
-happens it is a rewrite whether or not a Functions codebase exists. **The right tool for the job
-wins, and a Cloud Function is one of the tools.**
+The cascade existed to make an edit safe _after_ students had answered from the list. But renaming
+"Vegetarisch" to "Vegan" rewrites what a hundred students said they wanted, and no automatic
+rewrite can know whether they still mean it; removing an option leaves them holding nothing. The
+honest outcome in both cases is that the answers are asked for again, which is an organisational
+decision and not something a fan-out can paper over. **A cascade dresses a re-registration up as a
+data migration.**
 
-It does not turn on throughput either. A school-sized series is a few hundred registrations —
-twenty classes of thirty is six hundred — which is two or three batched commits and well under a
-second of work. Nothing here is near a request's budget.
+What made this affordable to drop is that the in-use rule stops being obstructive once the lists
+belong to one series (US-21). The original complaint — a teacher who mistyped a class in October
+cannot fix it in November — was a symptom of the lists being **global**: another season's
+registration froze this season's identically-named item. Scoped per series, the rule bites only
+where the same series' own students have already answered, which is the case where a rewrite would
+have been wrong anyway. During setup, when mistakes are actually caught, nothing is in use and
+everything is editable.
 
-It turns on the one thing a request cannot do: **outlive its own client.** A teacher who closes
-the tab mid-cascade, or a transient error halfway through, leaves the fan-out half-done with the
-lock standing, and a Route Handler has no retry of its own. The tempting answer — let the next
-teacher to edit that series finish it, since the lock blocks them anyway — has a hole that is not
-as rare as it sounds: **if nobody edits that series again, the cascade never finishes.** The
-likeliest moment to rename a class is at the end of setup, after which master data goes untouched
-for weeks. Recovery cannot depend on somebody happening to come back.
+So the refusal replaces the repair (US-24), and it is narrow: per item rather than per list, and
+adding and reordering stay free at all times.
 
-### It is a database trigger, with one difference that decides the design
+**What this deletes.** `pendingCascade`, the revision counter, the batching, the attempt count, the
+resume control, the lock that had to survive across processes — and with them the whole of the
+`functions/` codebase: its own dependency tree and lockfile, a second install and test run in CI,
+the functions and eventarc emulators beside the firestore one, a deploy workflow, and **a widening
+of what the deploy identity may reach** — Cloud Build, Artifact Registry, Cloud Run and
+service-account-user, where deploying rules needs almost none of it. That widening was named here
+as the largest real cost of the trigger, and not paying it is the largest gain from dropping it.
 
-The comparison is apt and worth making precisely, because where it breaks is where the bugs would
-be:
+**What replaces it is a guard that has to be sound**, which is US-27: the in-use check runs inside
+the transaction that writes the list, and the student's save reads the series inside its own. A
+check made before the write is stale by the time it lands, and with nothing to repair the result,
+a guard with that hole would be worse than none — it would claim an invariant it does not hold.
 
-| Postgres `AFTER UPDATE`           | Firestore trigger                        |
-| --------------------------------- | ---------------------------------------- |
-| Runs **inside** the transaction   | Fires **after** commit, asynchronously   |
-| A failure rolls the original back | Cannot roll anything back                |
-| Fires once, in order              | **At-least-once**, no ordering guarantee |
+**When the trigger would come back.** Not for retry — for **scale**. A series far larger than a
+school's would stop fitting inside a request, and then the work has to outlive it. That is not
+this application, and building for it now would cost the IAM widening today for a load that may
+never arrive.
 
-So the trigger does **not** supply the atomicity that makes a SQL trigger trustworthy. It replaces
-exactly one thing — who retries — and every other guarantee in US-27 is still carried by the lock,
-the idempotence and the batching. Nothing there is softened.
+**Q16 — The class was the case that generalised. Subsumed into US-24.** This question originally
+carved out one exception to the cascade: a class held by a registration could not be removed,
+because unlike the other six values a class cannot be re-answered — US-23 takes it away from the
+student and sets it from the invitation link, so clearing it would strand the registration outside
+every class with no path back.
 
-**Which is why the trigger carries no payload that matters.** It means only "there may be work on
-series X"; the function re-reads `pendingCascade` in a transaction and acts on **that**. Acting on
-the event's `before`/`after` deltas is the mistake this rule exists to forbid, because deltas are
-order-sensitive and a redelivered or out-of-order one would apply a rename that no longer
-describes anything — corruption rather than staleness.
+That reasoning stands, and it turned out to be the general case rather than the exception. Once
+the cascade went (Q15), **every** list value is refused rather than rewritten, so classes need no
+special pleading — they are simply the value where the harm was easiest to see.
 
-With that rule, **ordering cannot bite at all**, and the reason is the lock: a standing
-`pendingCascade` refuses every further list edit, so **at most one cascade record exists per
-series at any moment**. There is never a second cascade to arrive out of order. The mechanism
-specified for concurrency turns out to be what makes delivery order irrelevant.
+The rule is now US-24, stated once for all seven lists: adding and reordering are always allowed;
+renaming or removing an item some registration holds is refused, per item and per series.
 
-### Why a trigger and not a task queue
+What Q16 still contributes is why the refusal costs so little. **The class list is the one a
+teacher is made to check before it is used**: an invitation link is generated per class (US-23),
+so setting the links up means reading the list and picking from it. The review is built into the
+ceremony that makes the classes matter, so a wrong class is caught before any registration can
+exist — and until one does, every edit is free. The same holds more loosely for the other lists,
+which are read in order to answer the questions they supply.
 
-A task queue (`onTaskDispatched`) was weighed and rejected. It gives the same retry and backoff,
-fires only when enqueued, and needs no filtering — but it has a gap the trigger does not: the
-handler commits, and **then** enqueues. A process that dies in between leaves a lock with no task
-behind it, which is the same hole as waiting for the next teacher, merely narrower. Closing it
-needs a scheduled sweeper, so the queue costs two functions to the trigger's one.
-
-**A trigger has no gap, because delivery is the platform's job and is inseparable from the write.**
-That is precisely the property that made the SQL comparison attractive in the first place.
-
-The two objections to a trigger both collapse into a single guard: `if (!after.pendingCascade)
-return;`. That one line discards the writes that are not cascades — a reorder, a saved report, a
-`hasRegistrations` update — **and** terminates the recursion when the cascade clears the lock,
-because after clearing there is nothing left to do.
-
-And it yields something better than a scheduler: **the cascade's own progress write re-fires the
-trigger, so it schedules its own next batch.** The document is both the state and the clock, and
-no continuation is passed anywhere.
-
-That needs one safeguard, which is not optional: **`pendingCascade` carries an attempt count, and
-the cascade stops after a fixed number of them.** Without it a permanently failing batch loops for
-ever. With it, a cascade that cannot succeed comes to rest in exactly the state US-27 already
-describes — standing, visible in the event series list, and resumable by hand.
-
-### What it costs
-
-Stated plainly, since it is the first second deployment target this repository has had:
-
-- A `functions/` directory with its **own `package.json`, lockfile and dependency tree**, versioned
-  and patched separately. `firebase.json` already ignores `functions` in its App Hosting block, so
-  the two do not collide.
-- **CI**: the root `npm ci` does not reach it. A second install, typecheck, lint and test run in
-  `ci.yml`, or a workspaces setup.
-- **Deploy**: a new workflow, and **wider IAM on the workload identity federation** — a functions
-  deploy needs Cloud Build, Artifact Registry, Cloud Run and service-account-user where the rules
-  deploy needs almost none of it. This is the largest real cost, because it widens what a
-  compromised workflow could reach, and it is the part to review rather than copy from a template.
-- **Emulators**: `firebase.json` declares only firestore, and `test:rules` runs
-  `emulators:exec --only firestore`. Testing the trigger needs the functions and eventarc
-  emulators alongside it.
-- **Licence headers cost nothing**: the check walks `git ls-files`, so new sources are stamped
-  automatically and `functions/node_modules` never appears.
-- Blaze billing is already required by App Hosting, and the runtime volume sits inside the free
-  tier.
-
-**Q16 — A class that any registration holds cannot be removed. Decided.** The cascade clears a
-removed value from every registration that held it, and for six of the seven lists that is
-harmless — the student is asked the question again next time they open the form, and answers it.
-**The class is the one value that cannot be re-answered**, because US-23 deliberately took it away
-from the student: it is set from the invitation link, and removing the class invalidates that link.
-
-So clearing a class is not "one answer poorer". It leaves a registration with no class and no path
-that could give it one:
-
-- the student cannot supply it, since it is not a question they are asked;
-- the teacher has no control that sets it, since a class comes from a link;
-- re-creating a class of the same name reattaches nobody, because the cascade already blanked the
-  field.
-
-What is left belongs to no class: absent from the per-class cards, from every grouped figure and
-from the class column of the statistics, while still counting as a registration. **Removing a
-class is therefore closer to deleting that class's registrations than to clearing a field** — and
-it does it silently, without the confirmation US-19 demands before any registration is destroyed.
-
-There is a recovery, and naming it precisely is what shows it is not one: re-create the class,
-generate a fresh link, and get every affected student to follow it again. For a class of thirty
-that is a second registration drive rather than a repair, and it works only for the students who
-act on it.
-
-**So this one is refused rather than confirmed: a class cannot be removed while any registration
-of that series holds it.** Renaming stays free and cascades like everything else, which is what
-fixes the mistake teachers actually make.
-
-**And it costs almost nothing**, because the class list is the one list a teacher is made to check
-before it is used: an invitation link is generated **per class** (US-23), so setting the links up
-means reading the list and picking from it. The review is built into the ceremony that makes the
-classes matter, so a wrong class is caught before any registration can exist — and until one does,
-removal is free.
-
-**What survives of the old rule, and what still goes.** This is the single exception to the
-withdrawal in US-21: **classes only, removal only, one series only.** The machinery does not come
-back — `usage-guard.ts`, the usage endpoint and `useUsageReport` are still deleted — because the
-question is now one question about one list, and a teacher already reads every registration of the
-selected series, so which classes are in use is a reduce over data on hand rather than an endpoint.
-
-Two smaller things fall out:
-
-- **The class list can be emptied only in a series with no registrations at all**, so US-21's "an
-  empty list asks no question" never fires for classes in a series that has students. That is the
-  right shape rather than a gap: a series with registrations is by definition a series with
-  classes.
-- **Removing a class that has links but no registrations stays allowed.** The links are
-  invalidated (US-24) and nothing is lost, because nobody used them.
+One consequence to keep: **the class list can be emptied only in a series with no registrations at
+all**, so US-21's "an empty list asks no question" never fires for classes in a series that has
+students. That is the right shape rather than a gap — a series with registrations is by definition
+a series with classes.
 
 **Q17 — A copied name is repaired at the next login. Decided, with Q3.** The worry was that a
 name copied into a registration goes stale if the student never saves again. It does not: signing
@@ -1715,7 +1585,7 @@ shapes. Which is the whole argument for doing it now.
   is also every later amendment, which is no longer registration. The same objection sinks
   `acceptsRegistrations`, `isEnrolmentOpen` and `isSubmissionOpen`.
 - **`isLocked`**, inverted, is good English for "no more changes" but makes every rule read as a
-  double negative, and it collides with the cascade lock of US-27.
+  double negative, and it says nothing about who is shut out.
 
 **`isOpenToStudents`** avoids all three. "Open" names a **period** rather than an act — an open
 enrolment, an open call — so it covers joining and amending alike; and "to students" fixes the
@@ -1801,9 +1671,9 @@ What it costs, and how it is paid:
 
 Two things fall out pleasantly:
 
-- **A template never needs the cascade lock of US-27.** It holds no registrations, so renaming or
-  removing one of its list items reaches only its own saved reports — same document, one
-  transaction, nothing to fan out and nothing to resume.
+- **A template's lists are never locked**, since the refusal of US-24 turns on registrations and a
+  template can hold none. Its items stay renameable and removable for as long as it exists, which
+  is what a pattern to copy has to be.
 - **The delete rule never bites on a template**, since it can never hold registrations and so can
   never be one of the series that must be archived before it can go.
 

--- a/src/lib/master-data/master-data-service.test.ts
+++ b/src/lib/master-data/master-data-service.test.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeFirestore } from "@/test/fake-firestore";
 import { storedEventSeries } from "@/test/event-series";
 import type { EventSeries } from "@/lib/schemas/event-series";
@@ -29,6 +29,7 @@ const { MAX_LIST_ITEMS } = await import("@/lib/schemas/master-data");
 const ACTIVE = "s1";
 
 beforeEach(() => firestore.reset());
+afterEach(() => vi.restoreAllMocks());
 
 function seedActiveEventSeries(lists: Partial<Omit<EventSeries, "id" | "nameKey">> = {}) {
   firestore.seed("eventSeries", ACTIVE, storedEventSeries({ isActive: true, ...lists }));
@@ -420,6 +421,76 @@ describe("deleteMasterDataItem", () => {
     await deleteMasterDataItem("programs", "Ski");
 
     expect(storedList("programs")).toEqual([]);
+  });
+});
+
+/**
+ * US-27: the whole edit is one transaction, and the in-use question is asked inside it. Asked
+ * beforehand the answer is already stale — a student choosing the value being removed in between
+ * would be left holding something the series no longer offers, and no cascade repairs that.
+ */
+describe("the transaction a list edit runs in", () => {
+  function recordOrder(): string[] {
+    const order: string[] = [];
+    const runQuery = firestore.runQuery.bind(firestore);
+    const applyWrite = firestore.applyWrite.bind(firestore);
+
+    vi.spyOn(firestore, "runQuery").mockImplementation((collection, filters, limitCount) => {
+      order.push(`read ${collection}`);
+      return runQuery(collection, filters, limitCount);
+    });
+    vi.spyOn(firestore, "applyWrite").mockImplementation((write) => {
+      order.push(`write ${write.ref.collectionPath}`);
+      applyWrite(write);
+    });
+
+    return order;
+  }
+
+  it("asks whether the item is in use before it writes the list", async () => {
+    seedActiveEventSeries({ classOptions: ["3AHIT", "4BHIT"] });
+    seedRegistration("r1", { class: "4BHIT" });
+    const order = recordOrder();
+
+    await updateMasterDataItem("classes", "3AHIT", { name: "3BHIT" });
+
+    expect(order).toEqual(["read eventSeries", "read registrations", "write eventSeries"]);
+  });
+
+  it("asks again before deleting, so a hold taken since the list was read still counts", async () => {
+    seedActiveEventSeries({ classOptions: ["3AHIT", "4BHIT"] });
+    seedRegistration("r1", { class: "4BHIT" });
+    const order = recordOrder();
+
+    await deleteMasterDataItem("classes", "3AHIT");
+
+    expect(order).toEqual(["read eventSeries", "read registrations", "write eventSeries"]);
+  });
+
+  /** One transaction, so the list the guard was asked about is the list that gets written. */
+  it("reads the event series, guards and writes in a single transaction", async () => {
+    seedActiveEventSeries({ classOptions: ["3AHIT"] });
+
+    await updateMasterDataItem("classes", "3AHIT", { name: "3BHIT" });
+
+    expect(firestore.transactionCount).toBe(1);
+  });
+
+  /** Adding takes nothing away, so it asks nobody and never waits on a registration. */
+  it("asks nothing of the registrations when the edit strands nothing", async () => {
+    seedActiveEventSeries({ classOptions: ["3AHIT"] });
+    seedRegistration("r1", { class: "3AHIT" });
+    const order = recordOrder();
+
+    await createMasterDataItem("classes", { name: "4BHIT" });
+    await reorderMasterDataItems("classes", ["4BHIT", "3AHIT"]);
+
+    expect(order).toEqual([
+      "read eventSeries",
+      "write eventSeries",
+      "read eventSeries",
+      "write eventSeries",
+    ]);
   });
 });
 

--- a/src/lib/master-data/master-data-service.ts
+++ b/src/lib/master-data/master-data-service.ts
@@ -4,6 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import "server-only";
+import type { Transaction } from "firebase-admin/firestore";
 import { adminDb } from "@/lib/firebase/admin";
 import { normalizeName } from "@/lib/firebase/name-key";
 import { ErrorCode } from "@/lib/errors";
@@ -121,10 +122,12 @@ function duplicate(name: string): ServiceError {
   return new ServiceError(ErrorCode.Conflict, `Den Namen „${name.trim()}" gibt es hier bereits.`);
 }
 
+/** What a list edit is handed so its guard can run inside the write's own transaction. */
+type EditContext = { transaction: Transaction; eventSeriesId: string };
+
 /**
- * The event series the master data views act on. Until the header selection arrives there is
- * exactly one candidate — the active series (US-4) — so no caller names one, and none can point
- * at a series it was never shown.
+ * The event series the master data views act on, for the one caller that only reads: the in-use
+ * report, which needs the items to key its answer by.
  */
 async function readActiveEventSeries(): Promise<EventSeries> {
   const found = await adminDb
@@ -141,27 +144,39 @@ async function readActiveEventSeries(): Promise<EventSeries> {
 }
 
 /**
- * Rewrites one list of one event series in a single transaction, so two teachers editing two
- * different lists cannot lose one another's work (US-21). The document is re-read inside it and
- * `change` is applied to what it actually holds, never to the list the client was holding — so a
- * stale caller edits the list as it stands or fails, rather than overwriting what it never saw.
- */ async function writeList(
-  eventSeriesId: string,
+ * Everything one list edit does, in a single transaction: resolve the event series, apply the
+ * change to the list as it actually stands, and write it.
+ *
+ * `change` is handed the transaction because the in-use guard has to run inside it. Asked
+ * beforehand, its answer is stale by the time the write lands — a student choosing the value
+ * being removed in between would be left holding something the series no longer offers, and
+ * nothing repairs that (US-5 to US-10). Firestore locks the ranges the guard's queries scan, so
+ * such a save conflicts and one of the two retries and sees the other.
+ *
+ * The list is re-read here rather than taken from the client, so a stale caller edits the list
+ * as it stands or fails, rather than overwriting one it never saw (US-21).
+ */
+async function editList(
   category: MasterDataCategory,
-  change: (items: MasterDataItem[]) => MasterDataItem[],
+  change: (items: MasterDataItem[], context: EditContext) => Promise<MasterDataItem[]>,
 ): Promise<void> {
-  const reference = adminDb.collection(COLLECTIONS.eventSeries).doc(eventSeriesId);
-
   await adminDb.runTransaction(async (transaction) => {
-    const snapshot = await transaction.get(reference);
-    if (!snapshot.exists) {
-      throw new ServiceError(ErrorCode.NotFound, "Diese Eventreihe gibt es nicht.");
+    // Until the header selection arrives there is exactly one candidate — the active series
+    // (US-4) — so no caller names one, and none can point at a series it was never shown.
+    const found = await transaction.get(
+      adminDb.collection(COLLECTIONS.eventSeries).where("isActive", "==", true).limit(1),
+    );
+
+    const stored = found.docs[0];
+    if (stored === undefined) {
+      throw new ServiceError(ErrorCode.Conflict, NO_ACTIVE_EVENT_SERIES_HINT);
     }
 
-    const series = eventSeriesSchema.parse({ id: eventSeriesId, ...snapshot.data() });
-    const next = storedList(category, change(itemsOf(series, category)));
+    const series = eventSeriesSchema.parse({ id: stored.id, ...stored.data() });
+    const context = { transaction, eventSeriesId: series.id };
+    const next = storedList(category, await change(itemsOf(series, category), context));
 
-    transaction.update(reference, { [category.field]: next });
+    transaction.update(stored.ref, { [category.field]: next });
   });
 }
 
@@ -189,12 +204,12 @@ export async function createMasterDataItem(
       ? undefined
       : parseEquipment(category, input.requiredEquipment ?? []);
 
-  const series = await readActiveEventSeries();
   const item: MasterDataItem =
     equipment === undefined ? { name } : { name, requiredEquipment: equipment };
 
-  // A new item goes to the end of the teacher's order (see Ordering).
-  await writeList(series.id, category, (items) => {
+  // Adding strands nothing, so it needs no guard: a value nobody could have chosen yet cannot
+  // be one a registration holds. A new item goes to the end of the order (see Ordering).
+  await editList(category, async (items) => {
     if (indexOf(items, name) !== -1) throw duplicate(name);
     return [...items, item];
   });
@@ -202,15 +217,14 @@ export async function createMasterDataItem(
   return item;
 }
 
-/** Ordering touches no name, so it is deliberately not subject to the in-use guard (see Ordering). */
+/** Ordering touches no stored value, so it too is free of the guard (see Ordering). */
 export async function reorderMasterDataItems(
   key: MasterDataCategoryKey,
   orderedNames: readonly string[],
 ): Promise<void> {
   const category = categoryOf(masterDataCategorySchema.parse(key));
-  const series = await readActiveEventSeries();
 
-  await writeList(series.id, category, (items) => {
+  await editList(category, async (items) => {
     // A permutation and nothing else: an order naming an item that has since gone, or leaving one
     // out, would silently drop it — so it is refused and the list is left as it stands.
     if (orderedNames.length !== items.length) {
@@ -241,29 +255,33 @@ export async function updateMasterDataItem(
       ? undefined
       : parseEquipment(category, update.requiredEquipment);
 
-  const series = await readActiveEventSeries();
-  const current = itemAt(itemsOf(series, category), item);
+  let next!: MasterDataItem;
 
-  if (name !== undefined) await assertNotInUse(series.id, category, current.name);
-
-  if (equipment !== undefined) {
-    const kept = new Set(equipment.map(normalizeName));
-    const dropped = (current.requiredEquipment ?? []).filter(
-      (entry) => !kept.has(normalizeName(entry)),
-    );
-    await assertEquipmentNotInUse(series.id, dropped);
-  }
-
-  const carried =
-    current.requiredEquipment === undefined ? {} : { requiredEquipment: current.requiredEquipment };
-  const next: MasterDataItem = {
-    name: name ?? current.name,
-    ...(equipment === undefined ? carried : { requiredEquipment: equipment }),
-  };
-
-  await writeList(series.id, category, (items) => {
+  await editList(category, async (items, { transaction, eventSeriesId }) => {
     const index = indexOf(items, item);
     if (index === -1) throw new ServiceError(ErrorCode.NotFound, "Diesen Eintrag gibt es nicht.");
+    const current = items[index]!;
+
+    if (name !== undefined) {
+      await assertNotInUse(transaction, eventSeriesId, category, current.name);
+    }
+
+    if (equipment !== undefined) {
+      const kept = new Set(equipment.map(normalizeName));
+      const dropped = (current.requiredEquipment ?? []).filter(
+        (entry) => !kept.has(normalizeName(entry)),
+      );
+      await assertEquipmentNotInUse(transaction, eventSeriesId, dropped);
+    }
+
+    const carried =
+      current.requiredEquipment === undefined
+        ? {}
+        : { requiredEquipment: current.requiredEquipment };
+    next = {
+      name: name ?? current.name,
+      ...(equipment === undefined ? carried : { requiredEquipment: equipment }),
+    };
 
     const clash = indexOf(items, next.name);
     if (clash !== -1 && clash !== index) throw duplicate(next.name);
@@ -285,15 +303,14 @@ export async function deleteMasterDataItem(
 ): Promise<void> {
   const category = categoryOf(masterDataCategorySchema.parse(key));
 
-  const series = await readActiveEventSeries();
-  const current = itemAt(itemsOf(series, category), item);
-
-  await assertNotInUse(series.id, category, current.name);
-  await assertEquipmentNotInUse(series.id, current.requiredEquipment ?? []);
-
-  await writeList(series.id, category, (items) => {
+  await editList(category, async (items, { transaction, eventSeriesId }) => {
     const index = indexOf(items, item);
     if (index === -1) throw new ServiceError(ErrorCode.NotFound, "Diesen Eintrag gibt es nicht.");
+    const current = items[index]!;
+
+    await assertNotInUse(transaction, eventSeriesId, category, current.name);
+    await assertEquipmentNotInUse(transaction, eventSeriesId, current.requiredEquipment ?? []);
+
     return items.filter((_, at) => at !== index);
   });
 }

--- a/src/lib/master-data/usage-guard.test.ts
+++ b/src/lib/master-data/usage-guard.test.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
+import type { Transaction } from "firebase-admin/firestore";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeFirestore } from "@/test/fake-firestore";
 import { IN_USE_HINT, MASTER_DATA_CATEGORIES } from "./categories";
@@ -13,8 +14,8 @@ vi.mock("@/lib/firebase/admin", () => ({
   adminDb: firestore,
 }));
 
-const { assertEquipmentNotInUse, assertNotInUse, equipmentNamesInUse, namesInUse, usageReport } =
-  await import("./usage-guard");
+const { assertEquipmentNotInUse, assertNotInUse, usageReport } = await import("./usage-guard");
+const { adminDb } = await import("@/lib/firebase/admin");
 const { ServiceError } = await import("@/lib/service-error");
 
 /** The lists belong to one event series (US-21), so the question is asked of one series. */
@@ -26,12 +27,22 @@ function seedRegistration(id: string, eventSeriesId: string, answers: Record<str
   firestore.seed("registrations", id, { userId: `u-${id}`, eventSeriesId, ...answers });
 }
 
+/**
+ * The guards read through the transaction that is about to write the list (US-27), so asking one
+ * a question means opening the write it belongs to.
+ */
+function guard(work: (transaction: Transaction) => Promise<void>): Promise<void> {
+  return adminDb.runTransaction(work);
+}
+
 describe("assertNotInUse", () => {
   it("blocks an item a registration of this event series selected", async () => {
     seedRegistration("r1", SERIES, { class: "3AHIT" });
 
     await expect(
-      assertNotInUse(SERIES, MASTER_DATA_CATEGORIES.classes, "3AHIT"),
+      guard((transaction) =>
+        assertNotInUse(transaction, SERIES, MASTER_DATA_CATEGORIES.classes, "3AHIT"),
+      ),
     ).rejects.toBeInstanceOf(ServiceError);
   });
 
@@ -39,7 +50,9 @@ describe("assertNotInUse", () => {
     seedRegistration("r1", SERIES, { class: "3AHIT" });
 
     await expect(
-      assertNotInUse(SERIES, MASTER_DATA_CATEGORIES.classes, "3AHIT"),
+      guard((transaction) =>
+        assertNotInUse(transaction, SERIES, MASTER_DATA_CATEGORIES.classes, "3AHIT"),
+      ),
     ).rejects.toMatchObject({ code: "CONFLICT", message: IN_USE_HINT });
   });
 
@@ -48,7 +61,9 @@ describe("assertNotInUse", () => {
     seedRegistration("r1", "s2", { class: "3AHIT" });
 
     await expect(
-      assertNotInUse(SERIES, MASTER_DATA_CATEGORIES.classes, "3AHIT"),
+      guard((transaction) =>
+        assertNotInUse(transaction, SERIES, MASTER_DATA_CATEGORIES.classes, "3AHIT"),
+      ),
     ).resolves.toBeUndefined();
   });
 
@@ -56,23 +71,34 @@ describe("assertNotInUse", () => {
     seedRegistration("r1", SERIES, { class: "3AHIT" });
 
     await expect(
-      assertNotInUse(SERIES, MASTER_DATA_CATEGORIES.classes, "4BHIT"),
+      guard((transaction) =>
+        assertNotInUse(transaction, SERIES, MASTER_DATA_CATEGORIES.classes, "4BHIT"),
+      ),
     ).resolves.toBeUndefined();
   });
 
-  it("compares names the way the rest of the app does, ignoring case and surrounding space", async () => {
+  /**
+   * Names compare normalized everywhere else; here the match is exact, because a student picks
+   * from the list and so stores the list's own spelling. A respelling is not a value any
+   * registration can hold — it could only arrive through the rename this guard refuses.
+   */
+  it("matches the stored answer exactly, since that is the spelling the list handed out", async () => {
     seedRegistration("r1", SERIES, { class: "3AHIT" });
 
     await expect(
-      assertNotInUse(SERIES, MASTER_DATA_CATEGORIES.classes, " 3ahit "),
-    ).rejects.toBeInstanceOf(ServiceError);
+      guard((transaction) =>
+        assertNotInUse(transaction, SERIES, MASTER_DATA_CATEGORIES.classes, " 3ahit "),
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it("keeps the categories apart, so a program named like a class is not blocked by it", async () => {
     seedRegistration("r1", SERIES, { class: "Alternativ", program: "Ski" });
 
     await expect(
-      assertNotInUse(SERIES, MASTER_DATA_CATEGORIES.programs, "Alternativ"),
+      guard((transaction) =>
+        assertNotInUse(transaction, SERIES, MASTER_DATA_CATEGORIES.programs, "Alternativ"),
+      ),
     ).resolves.toBeUndefined();
   });
 
@@ -80,8 +106,41 @@ describe("assertNotInUse", () => {
     seedRegistration("r1", SERIES, { class: "3AHIT", program: "Ski" });
 
     await expect(
-      assertNotInUse(SERIES, MASTER_DATA_CATEGORIES.programs, "Ski"),
+      guard((transaction) =>
+        assertNotInUse(transaction, SERIES, MASTER_DATA_CATEGORIES.programs, "Ski"),
+      ),
     ).rejects.toBeInstanceOf(ServiceError);
+  });
+
+  /**
+   * The read has to go through the transaction, or Firestore locks nothing and a save choosing
+   * the value being edited slips past between the question and the write (US-27). A transaction
+   * refuses a read once it has written, so a guard reading around it would answer here instead.
+   */
+  it("reads through the transaction it is given rather than around it", async () => {
+    seedRegistration("r1", SERIES, { class: "3AHIT" });
+
+    await expect(
+      adminDb.runTransaction(async (transaction) => {
+        transaction.set(adminDb.collection("eventSeries").doc(SERIES), { classOptions: [] });
+        await assertNotInUse(transaction, SERIES, MASTER_DATA_CATEGORIES.classes, "4BHIT");
+      }),
+    ).rejects.toThrow(/every read before the first write/);
+  });
+
+  /** Only the registrations holding this one value are scanned, so nobody else's save waits. */
+  it("reads one registration however many the event series has", async () => {
+    for (const id of ["r1", "r2", "r3", "r4", "r5"]) {
+      seedRegistration(id, SERIES, { class: "3AHIT" });
+    }
+    firestore.queryDocumentsRead = 0;
+
+    await expect(
+      guard((transaction) =>
+        assertNotInUse(transaction, SERIES, MASTER_DATA_CATEGORIES.classes, "3AHIT"),
+      ),
+    ).rejects.toBeInstanceOf(ServiceError);
+    expect(firestore.queryDocumentsRead).toBe(1);
   });
 });
 
@@ -89,79 +148,64 @@ describe("assertEquipmentNotInUse", () => {
   it("blocks an entry a student of this event series rented", async () => {
     seedRegistration("r1", SERIES, { program: "Ski", rentedEquipment: ["Helm"] });
 
-    await expect(assertEquipmentNotInUse(SERIES, ["Helm"])).rejects.toBeInstanceOf(ServiceError);
+    await expect(
+      guard((transaction) => assertEquipmentNotInUse(transaction, SERIES, ["Helm"])),
+    ).rejects.toBeInstanceOf(ServiceError);
   });
 
   it("ignores what students of another event series rented", async () => {
     seedRegistration("r1", "s2", { program: "Ski", rentedEquipment: ["Helm"] });
 
-    await expect(assertEquipmentNotInUse(SERIES, ["Helm"])).resolves.toBeUndefined();
+    await expect(
+      guard((transaction) => assertEquipmentNotInUse(transaction, SERIES, ["Helm"])),
+    ).resolves.toBeUndefined();
   });
 
   /** Requiring an item is the program's business; only renting one makes it used (US-5). */
   it("does not match through the program field, only through the rental selections", async () => {
     seedRegistration("r1", SERIES, { class: "3AHIT", program: "Ski" });
 
-    await expect(assertEquipmentNotInUse(SERIES, ["Ski"])).resolves.toBeUndefined();
+    await expect(
+      guard((transaction) => assertEquipmentNotInUse(transaction, SERIES, ["Ski"])),
+    ).resolves.toBeUndefined();
   });
 
   it("rejects as soon as any one of the names is rented", async () => {
     seedRegistration("r1", SERIES, { program: "Ski", rentedEquipment: ["Helm"] });
 
-    await expect(assertEquipmentNotInUse(SERIES, ["Stöcke", " helm "])).rejects.toMatchObject({
-      code: "CONFLICT",
-      message: IN_USE_HINT,
-    });
+    await expect(
+      guard((transaction) => assertEquipmentNotInUse(transaction, SERIES, ["Stöcke", "Helm"])),
+    ).rejects.toMatchObject({ code: "CONFLICT", message: IN_USE_HINT });
+  });
+
+  /** A rental was picked from the program's own list, so it carries the program's spelling. */
+  it("matches a rental exactly, as the program spelled the entry it offered", async () => {
+    seedRegistration("r1", SERIES, { program: "Ski", rentedEquipment: ["Helm"] });
+
+    await expect(
+      guard((transaction) => assertEquipmentNotInUse(transaction, SERIES, [" helm "])),
+    ).resolves.toBeUndefined();
   });
 
   it("reads nothing when there is nothing to check", async () => {
     seedRegistration("r1", SERIES, { program: "Ski", rentedEquipment: ["Helm"] });
     firestore.queryDocumentsRead = 0;
 
-    await expect(assertEquipmentNotInUse(SERIES, [])).resolves.toBeUndefined();
+    await expect(
+      guard((transaction) => assertEquipmentNotInUse(transaction, SERIES, [])),
+    ).resolves.toBeUndefined();
     expect(firestore.queryDocumentsRead).toBe(0);
   });
-});
 
-describe("namesInUse", () => {
-  it("reports the names normalized, since that is what the comparison uses", async () => {
-    seedRegistration("r1", SERIES, { class: " 3AHIT " });
-    seedRegistration("r2", "s2", { class: "4BHIT" });
+  it("reads through the transaction it is given rather than around it", async () => {
+    seedRegistration("r1", SERIES, { program: "Ski", rentedEquipment: ["Helm"] });
 
-    await expect(namesInUse(SERIES, MASTER_DATA_CATEGORIES.classes)).resolves.toEqual(
-      new Set(["3ahit"]),
-    );
-  });
-
-  it("is empty when nothing is in use", async () => {
-    seedRegistration("r1", SERIES, { class: "3AHIT" });
-
-    await expect(namesInUse(SERIES, MASTER_DATA_CATEGORIES["skill-levels"])).resolves.toEqual(
-      new Set(),
-    );
-  });
-
-  it("skips a registration whose answer was never given", async () => {
-    seedRegistration("r1", SERIES, { class: "3AHIT", skillLevel: null });
-
-    await expect(namesInUse(SERIES, MASTER_DATA_CATEGORIES["skill-levels"])).resolves.toEqual(
-      new Set(),
-    );
-  });
-});
-
-describe("equipmentNamesInUse", () => {
-  it("gathers the rental selections of this event series", async () => {
-    seedRegistration("r1", SERIES, { rentedEquipment: ["Helm", " Stöcke "] });
-    seedRegistration("r2", "s2", { rentedEquipment: ["Brille"] });
-
-    await expect(equipmentNamesInUse(SERIES)).resolves.toEqual(new Set(["helm", "stöcke"]));
-  });
-
-  it("treats a registration stored before the field existed as renting nothing", async () => {
-    seedRegistration("r1", SERIES, { program: "Ski" });
-
-    await expect(equipmentNamesInUse(SERIES)).resolves.toEqual(new Set());
+    await expect(
+      adminDb.runTransaction(async (transaction) => {
+        transaction.set(adminDb.collection("eventSeries").doc(SERIES), { programs: [] });
+        await assertEquipmentNotInUse(transaction, SERIES, ["Stöcke"]);
+      }),
+    ).rejects.toThrow(/every read before the first write/);
   });
 });
 
@@ -180,6 +224,22 @@ describe("usageReport", () => {
     ).resolves.toEqual({ blockedNames: [], blockedEquipment: {} });
   });
 
+  it("leaves the registrations of another event series out of it", async () => {
+    seedRegistration("r1", "s2", { class: "3AHIT" });
+
+    await expect(
+      usageReport(SERIES, MASTER_DATA_CATEGORIES.classes, [{ name: "3AHIT" }]),
+    ).resolves.toEqual({ blockedNames: [], blockedEquipment: {} });
+  });
+
+  it("skips a registration whose answer was never given", async () => {
+    seedRegistration("r1", SERIES, { class: "3AHIT", skillLevel: null });
+
+    await expect(
+      usageReport(SERIES, MASTER_DATA_CATEGORIES["skill-levels"], [{ name: "Anfänger" }]),
+    ).resolves.toEqual({ blockedNames: [], blockedEquipment: {} });
+  });
+
   /** Renaming the program is still fine — only removing the rented entry with it is not. */
   it("names the rented entries of a program, keyed by the program's own name", async () => {
     seedRegistration("r1", SERIES, { program: "Snowboard", rentedEquipment: [" helm "] });
@@ -189,6 +249,16 @@ describe("usageReport", () => {
         { name: "Ski", requiredEquipment: ["Helm", "Stöcke"] },
       ]),
     ).resolves.toEqual({ blockedNames: [], blockedEquipment: { Ski: ["Helm"] } });
+  });
+
+  it("treats a registration stored before the rental field existed as renting nothing", async () => {
+    seedRegistration("r1", SERIES, { program: "Snowboard" });
+
+    await expect(
+      usageReport(SERIES, MASTER_DATA_CATEGORIES.programs, [
+        { name: "Ski", requiredEquipment: ["Helm"] },
+      ]),
+    ).resolves.toEqual({ blockedNames: [], blockedEquipment: {} });
   });
 
   it("blocks a program outright once it is itself selected", async () => {

--- a/src/lib/master-data/usage-guard.ts
+++ b/src/lib/master-data/usage-guard.ts
@@ -4,6 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import "server-only";
+import type { Query, Transaction } from "firebase-admin/firestore";
 import { adminDb } from "@/lib/firebase/admin";
 import { normalizeName } from "@/lib/firebase/name-key";
 import { ErrorCode } from "@/lib/errors";
@@ -12,88 +13,73 @@ import { COLLECTIONS } from "@/lib/schemas/collections";
 import { IN_USE_HINT, type MasterDataCategory } from "./categories";
 
 /**
- * The registrations of one event series. Now that a list belongs to a series rather than to the
- * whole application (US-21), what an edit can reach is exactly this — which is why the question
- * is asked of one series instead of every non-archived one.
+ * A registration of this event series holding this exact value, if there is one.
+ *
+ * The equality is exact where names elsewhere compare normalized, and that is deliberate: a
+ * student picks from the list, so what they store is the list's own spelling, and a list holds
+ * one spelling because its uniqueness rule already folds case and surrounding space. A second
+ * spelling could only arrive through a rename — which is what this guard refuses.
  */
-async function registrationsOf(eventSeriesId: string) {
-  const found = await adminDb
+function holdersOf(eventSeriesId: string, field: string, name: string): Query {
+  return adminDb
     .collection(COLLECTIONS.registrations)
     .where("eventSeriesId", "==", eventSeriesId)
-    .get();
-
-  return found.docs;
-}
-
-function normalizedNames(values: unknown[]): string[] {
-  return values.flatMap((value) =>
-    typeof value === "string" && value.trim() !== "" ? [normalizeName(value)] : [],
-  );
-}
-
-/**
- * The names an editing teacher may not touch, normalized for comparison.
- *
- * The lists store names, and so do the registrations that select from them — a registration
- * keeps the plain text rather than a reference (US-11), which is exactly why this is a name
- * match and not a join.
- */
-export async function namesInUse(
-  eventSeriesId: string,
-  category: MasterDataCategory,
-): Promise<Set<string>> {
-  const registrations = await registrationsOf(eventSeriesId);
-  const field = category.usage.field;
-
-  return new Set(normalizedNames(registrations.map((record) => record.data()?.[field])));
+    .where(field, "==", name)
+    .limit(1);
 }
 
 /**
  * Required equipment is chosen per student, so it is the rental selections that mark an entry as
- * used — never the program that requires it (US-5). They are a field of the registration, so the
- * records already read above are the whole answer.
+ * used — never the program that requires it (US-5).
  */
-export async function equipmentNamesInUse(eventSeriesId: string): Promise<Set<string>> {
-  const registrations = await registrationsOf(eventSeriesId);
-
-  return new Set(
-    registrations.flatMap((record) => {
-      const rented = record.data()?.rentedEquipment;
-      return Array.isArray(rented) ? normalizedNames(rented) : [];
-    }),
-  );
+function rentersOf(eventSeriesId: string, name: string): Query {
+  return adminDb
+    .collection(COLLECTIONS.registrations)
+    .where("eventSeriesId", "==", eventSeriesId)
+    .where("rentedEquipment", "array-contains", name)
+    .limit(1);
 }
 
 /**
- * The server-side half of the in-use restriction. The list also disables the controls, but that
- * is a convenience: a client that skips the UI still has to come through here.
+ * The server-side half of the in-use restriction (US-5 to US-10). The list also disables the
+ * controls, but that is a convenience: a client that skips the UI still comes through here.
+ *
+ * It takes the transaction that is about to write the list, and that is the whole point. Asked
+ * beforehand, the answer is stale by the time the write lands: a student choosing this very
+ * value in between would be left holding something the series no longer offers, and nothing
+ * repairs that. Inside the transaction, Firestore locks the range this query scans, so such a
+ * save conflicts and one of the two retries and sees the other. Every read has to precede the
+ * first write, so this runs before the list is written.
  */
 export async function assertNotInUse(
+  transaction: Transaction,
   eventSeriesId: string,
   category: MasterDataCategory,
   name: string,
 ): Promise<void> {
-  const blocked = await namesInUse(eventSeriesId, category);
-  if (blocked.has(normalizeName(name))) {
+  const holders = await transaction.get(holdersOf(eventSeriesId, category.usage.field, name));
+  if (!holders.empty) {
     throw new ServiceError(ErrorCode.Conflict, IN_USE_HINT);
   }
 }
 
 /** Rejects as soon as one of `names` is still rented by a student of this event series (US-5). */
 export async function assertEquipmentNotInUse(
+  transaction: Transaction,
   eventSeriesId: string,
   names: readonly string[],
 ): Promise<void> {
-  if (names.length === 0) return;
+  const renters = await Promise.all(
+    names.map((name) => transaction.get(rentersOf(eventSeriesId, name))),
+  );
 
-  const blocked = await equipmentNamesInUse(eventSeriesId);
-  if (names.some((name) => blocked.has(normalizeName(name)))) {
+  if (renters.some((found) => !found.empty)) {
     throw new ServiceError(ErrorCode.Conflict, IN_USE_HINT);
   }
 }
 
 export type MasterDataUsageReport = {
-  /** In use itself, so it can be neither edited nor deleted. Names, since a name is the identity. */
+  /** In use itself, so it can be neither renamed nor deleted. Names, since a name is an identity. */
   blockedNames: string[];
   /**
    * Per program name, the entries of its own equipment list a student still rents, spelled
@@ -103,33 +89,54 @@ export type MasterDataUsageReport = {
   blockedEquipment: Record<string, string[]>;
 };
 
+function normalizedNames(values: unknown[]): string[] {
+  return values.flatMap((value) =>
+    typeof value === "string" && value.trim() !== "" ? [normalizeName(value)] : [],
+  );
+}
+
 /**
- * The same answer keyed by name, which is what the list view needs. Resolving it here rather
- * than in the browser keeps one definition of "the same name" — the client would otherwise have
- * to re-implement the comparison, and drift the moment either side changed.
+ * What the list view greys out. One read of the series' registrations rather than the guard's
+ * narrow queries, because this answers for every item at once — a query per item would be a
+ * hundred round trips to disable some buttons. It is advisory either way: the guard above is
+ * what decides, inside the write that matters.
  */
 export async function usageReport(
   eventSeriesId: string,
   category: MasterDataCategory,
   items: readonly { name: string; requiredEquipment?: readonly string[] }[],
 ): Promise<MasterDataUsageReport> {
-  const blocked = await namesInUse(eventSeriesId, category);
+  const registrations = (
+    await adminDb
+      .collection(COLLECTIONS.registrations)
+      .where("eventSeriesId", "==", eventSeriesId)
+      .get()
+  ).docs;
+
+  const held = new Set(
+    normalizedNames(registrations.map((record) => record.data()?.[category.usage.field])),
+  );
   const blockedNames = items
-    .filter((item) => blocked.has(normalizeName(item.name)))
+    .filter((item) => held.has(normalizeName(item.name)))
     .map((item) => item.name);
 
   if (category.equipmentField === undefined) {
     return { blockedNames, blockedEquipment: {} };
   }
 
-  const blockedEquipmentNames = await equipmentNamesInUse(eventSeriesId);
-  const blockedEquipment: Record<string, string[]> = {};
+  const rented = new Set(
+    registrations.flatMap((record) => {
+      const entries = record.data()?.rentedEquipment;
+      return Array.isArray(entries) ? normalizedNames(entries) : [];
+    }),
+  );
 
+  const blockedEquipment: Record<string, string[]> = {};
   for (const item of items) {
-    const rented = (item.requiredEquipment ?? []).filter((entry) =>
-      blockedEquipmentNames.has(normalizeName(entry)),
+    const stillRented = (item.requiredEquipment ?? []).filter((entry) =>
+      rented.has(normalizeName(entry)),
     );
-    if (rented.length > 0) blockedEquipment[item.name] = rented;
+    if (stillRented.length > 0) blockedEquipment[item.name] = stillRented;
   }
 
   return { blockedNames, blockedEquipment };

--- a/src/lib/registration/registration-service.test.ts
+++ b/src/lib/registration/registration-service.test.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeFirestore } from "@/test/fake-firestore";
 import { storedEventSeries } from "@/test/event-series";
 import type { RegistrationInput } from "@/lib/schemas/registration";
@@ -15,20 +15,36 @@ vi.mock("@/lib/firebase/admin", () => ({
 }));
 
 const { saveRegistration } = await import("./registration-service");
-const { REGISTRATION_NOT_OPEN_HINT, recordIdFor } = await import("./registration");
+const { ANSWER_NO_LONGER_OFFERED_HINT, REGISTRATION_NOT_OPEN_HINT, recordIdFor } =
+  await import("./registration");
+const { FOOD_OPTION_OTHER } = await import("@/lib/schemas/master-data");
 const { ServiceError } = await import("@/lib/service-error");
 
 const STUDENT = "jane.doe@student.htldornbirn.at";
 const RECORD_ID = recordIdFor("s1", STUDENT);
 
 beforeEach(() => firestore.reset());
+afterEach(() => vi.restoreAllMocks());
 
-/** Registering needs a class to pick from as much as it needs an event series (US-6, US-11). */
+/**
+ * Registering needs a class to pick from as much as it needs an event series (US-6, US-11), and
+ * every other answer has to be one the series offers (US-27) — so the lists a student picks from
+ * are part of what makes a series registrable at all.
+ */
 function seedEventSeries(id: string, fields: Record<string, unknown> = {}) {
   firestore.seed(
     "eventSeries",
     id,
-    storedEventSeries({ name: `Eventreihe ${id}`, classOptions: ["3AHME"], ...fields }),
+    storedEventSeries({
+      name: `Eventreihe ${id}`,
+      classOptions: ["3AHME", "4AHME"],
+      programs: [{ name: "Ski", requiredEquipment: [] }],
+      skillLevels: ["Anfänger"],
+      seasonPassOptions: ["Keine"],
+      busPickupPoints: ["HTL Dornbirn"],
+      foodOptions: ["Vegetarisch"],
+      ...fields,
+    }),
   );
 }
 
@@ -128,6 +144,76 @@ describe("saveRegistration", () => {
       code: "CONFLICT",
       message: REGISTRATION_NOT_OPEN_HINT,
     });
+    expect(firestore.count("registrations")).toBe(0);
+  });
+
+  /**
+   * The other half of closing the in-use race (US-27): the series is read inside this save's own
+   * transaction, so a teacher removing an option makes the save conflict, retry, and be refused
+   * here rather than storing a value the series no longer offers.
+   */
+  it("refuses an answer the event series no longer offers", async () => {
+    seedEventSeries("s1", {
+      isActive: true,
+      programs: [{ name: "Snowboard", requiredEquipment: [] }],
+    });
+
+    await expect(saveRegistration(STUDENT, attending)).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: ANSWER_NO_LONGER_OFFERED_HINT,
+    });
+    expect(firestore.count("registrations")).toBe(0);
+  });
+
+  it("asks the student to reload rather than storing an answer nothing offers", async () => {
+    seedEventSeries("s1", { isActive: true, skillLevels: ["Profi"] });
+
+    await expect(saveRegistration(STUDENT, attending)).rejects.toMatchObject({
+      message: ANSWER_NO_LONGER_OFFERED_HINT,
+    });
+    expect(firestore.get("eventSeries", "s1")).toMatchObject({ hasRegistrations: false });
+  });
+
+  it("checks every list-backed answer, not only the one the form asks first", async () => {
+    seedEventSeries("s1", { isActive: true, busPickupPoints: ["Bregenz"] });
+
+    await expect(saveRegistration(STUDENT, attending)).rejects.toMatchObject({
+      message: ANSWER_NO_LONGER_OFFERED_HINT,
+    });
+  });
+
+  /** An empty list asks no question (US-21), so leaving it unanswered is not an unoffered answer. */
+  it("lets a question the event series no longer asks stay unanswered", async () => {
+    seedEventSeries("s1", { isActive: true, seasonPassOptions: [] });
+
+    const record = await saveRegistration(STUDENT, { ...attending, seasonPassOption: null });
+
+    expect(record.seasonPassOption).toBeNull();
+  });
+
+  /** "Sonstiges" is never a row a teacher keeps, but it is offered beside a non-empty list (US-9). */
+  it("accepts the free-text food choice while the food list has rows to offer", async () => {
+    seedEventSeries("s1", { isActive: true });
+
+    const record = await saveRegistration(STUDENT, {
+      ...attending,
+      foodOption: FOOD_OPTION_OTHER,
+      foodOtherText: "Laktosefrei",
+    });
+
+    expect(record.foodOption).toBe(FOOD_OPTION_OTHER);
+  });
+
+  it("refuses the free-text food choice where the food question is not asked at all", async () => {
+    seedEventSeries("s1", { isActive: true, foodOptions: [] });
+
+    await expect(
+      saveRegistration(STUDENT, {
+        ...attending,
+        foodOption: FOOD_OPTION_OTHER,
+        foodOtherText: "Laktosefrei",
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT", message: ANSWER_NO_LONGER_OFFERED_HINT });
     expect(firestore.count("registrations")).toBe(0);
   });
 
@@ -263,17 +349,25 @@ describe("saveRegistration", () => {
 
   it("writes the record and the mirror together, so neither can land without the other", async () => {
     seedEventSeries("s1", { isActive: true });
+    const writes = vi.spyOn(firestore, "applyWrite");
 
     await saveRegistration(STUDENT, attending);
 
-    expect(firestore.batchSizes).toEqual([2]);
+    expect(firestore.transactionCount).toBe(1);
+    expect(writes.mock.calls.map(([write]) => write.ref.path)).toEqual([
+      `registrations/${RECORD_ID}`,
+      "eventSeries/s1",
+    ]);
   });
 
   it("leaves the mirror alone once it already says so", async () => {
     seedEventSeries("s1", { isActive: true, hasRegistrations: true });
+    const writes = vi.spyOn(firestore, "applyWrite");
 
     await saveRegistration(STUDENT, attending);
 
-    expect(firestore.batchSizes).toEqual([1]);
+    expect(writes.mock.calls.map(([write]) => write.ref.path)).toEqual([
+      `registrations/${RECORD_ID}`,
+    ]);
   });
 });

--- a/src/lib/registration/registration-service.ts
+++ b/src/lib/registration/registration-service.ts
@@ -4,11 +4,14 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import "server-only";
+import type { Transaction } from "firebase-admin/firestore";
 import { adminDb } from "@/lib/firebase/admin";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
 import { COLLECTIONS } from "@/lib/schemas/collections";
 import { eventSeriesSchema, type EventSeries } from "@/lib/schemas/event-series";
+import { FOOD_OPTION_OTHER } from "@/lib/schemas/master-data";
+import { MASTER_DATA_CATEGORIES } from "@/lib/master-data/categories";
 import {
   registrationInputSchema,
   registrationSchema,
@@ -17,7 +20,11 @@ import {
 } from "@/lib/schemas/registration";
 import { activeEventSeriesOf } from "@/lib/event-series/event-series-state";
 import { isRegistrationIncomplete } from "./completeness";
-import { recordIdFor, REGISTRATION_NOT_OPEN_HINT } from "./registration";
+import {
+  ANSWER_NO_LONGER_OFFERED_HINT,
+  recordIdFor,
+  REGISTRATION_NOT_OPEN_HINT,
+} from "./registration";
 
 /**
  * Registering needs two things a teacher sets up, and neither is one the student can do without:
@@ -26,11 +33,10 @@ import { recordIdFor, REGISTRATION_NOT_OPEN_HINT } from "./registration";
  * with the same answer as no event series at all — from where the student stands they are the same
  * thing, and the client shows exactly this message rather than a form it cannot fill in.
  */
-async function requireOpenRegistration(): Promise<EventSeries> {
-  const snapshot = await adminDb
-    .collection(COLLECTIONS.eventSeries)
-    .where("isActive", "==", true)
-    .get();
+async function requireOpenRegistration(transaction: Transaction): Promise<EventSeries> {
+  const snapshot = await transaction.get(
+    adminDb.collection(COLLECTIONS.eventSeries).where("isActive", "==", true),
+  );
 
   const active = activeEventSeriesOf(
     snapshot.docs.map((eventSeries) =>
@@ -59,47 +65,83 @@ function parseInput(input: RegistrationInput): RegistrationInput {
 }
 
 /**
+ * Every list value a registration carries has to be one the event series currently offers.
+ *
+ * Checked against the series read inside the save's own transaction, which is the other half of
+ * closing the race the in-use guard opens: a teacher removing an option writes the series
+ * document, so a save that read the older one conflicts, retries, and is refused here rather
+ * than storing a value nothing offers. Without a cascade there is nothing to repair it later.
+ */
+function assertAnswersAreOffered(eventSeries: EventSeries, fields: RegistrationInput): void {
+  for (const category of Object.values(MASTER_DATA_CATEGORIES)) {
+    const answer = fields[category.usage.field as keyof RegistrationInput];
+    if (typeof answer !== "string" || answer === "") continue;
+
+    const list = eventSeries[category.field];
+    const offered = list.map((entry) => (typeof entry === "string" ? entry : entry.name));
+
+    // The free-text choice is never a row a teacher keeps, but it is offered alongside a
+    // non-empty list (US-9, US-21), so it is a legitimate answer wherever the question is asked.
+    const permitted =
+      category.usage.field === "foodOption" && offered.length > 0
+        ? [...offered, FOOD_OPTION_OTHER]
+        : offered;
+
+    if (!permitted.includes(answer)) {
+      throw new ServiceError(ErrorCode.Conflict, ANSWER_NO_LONGER_OFFERED_HINT);
+    }
+  }
+}
+
+/**
  * Writes the student's registration for the active event series, whole.
  *
  * A student cannot write this collection at all (see firestore.rules), and this is why: the
  * event series is resolved here rather than sent, answering "no" gives up the event assignment a
  * teacher made (US-11, US-12), and the event series' `hasRegistrations` mirror has to follow along so
  * the teacher's list can decide about archiving without reading records it may not read (US-4).
- * The record and that mirror go in one batch, so neither can land without the other.
+ *
+ * It is one transaction rather than a batch because the answers are validated against the series
+ * as it stands: reading that document inside the transaction is what makes a teacher's
+ * concurrent list edit conflict rather than slip past.
  */
 export async function saveRegistration(
   userId: string,
   input: RegistrationInput,
 ): Promise<Registration> {
   const fields = parseInput(input);
-  const eventSeries = await requireOpenRegistration();
 
-  const id = recordIdFor(eventSeries.id, userId);
-  const reference = adminDb.collection(COLLECTIONS.registrations).doc(id);
-  const stored = await reference.get();
+  return adminDb.runTransaction(async (transaction) => {
+    const eventSeries = await requireOpenRegistration(transaction);
 
-  // The teacher owns the assignment, so a save carries the stored one forward — unless the
-  // student has just said they are not coming, which unassigns them (US-11).
-  const event = fields.isAttendingSportsWeek ? ((stored.data()?.event as string) ?? null) : null;
+    const id = recordIdFor(eventSeries.id, userId);
+    const reference = adminDb.collection(COLLECTIONS.registrations).doc(id);
+    const stored = await transaction.get(reference);
 
-  const data = {
-    userId,
-    eventSeriesId: eventSeries.id,
-    event,
-    // Recomputed here rather than trusted from the client: it is what the report marks a
-    // student by (US-13), so it has to follow the answers actually stored.
-    isIncomplete: isRegistrationIncomplete(fields),
-    ...fields,
-  };
-  const record = registrationSchema.parse({ id, ...data });
+    assertAnswersAreOffered(eventSeries, fields);
 
-  const batch = adminDb.batch().set(reference, data);
-  if (!eventSeries.hasRegistrations) {
-    batch.update(adminDb.collection(COLLECTIONS.eventSeries).doc(eventSeries.id), {
-      hasRegistrations: true,
-    });
-  }
-  await batch.commit();
+    // The teacher owns the assignment, so a save carries the stored one forward — unless the
+    // student has just said they are not coming, which unassigns them (US-11).
+    const event = fields.isAttendingSportsWeek ? ((stored.data()?.event as string) ?? null) : null;
 
-  return record;
+    const data = {
+      userId,
+      eventSeriesId: eventSeries.id,
+      event,
+      // Recomputed here rather than trusted from the client: it is what the report marks a
+      // student by (US-13), so it has to follow the answers actually stored.
+      isIncomplete: isRegistrationIncomplete(fields),
+      ...fields,
+    };
+    const record = registrationSchema.parse({ id, ...data });
+
+    transaction.set(reference, data);
+    if (!eventSeries.hasRegistrations) {
+      transaction.update(adminDb.collection(COLLECTIONS.eventSeries).doc(eventSeries.id), {
+        hasRegistrations: true,
+      });
+    }
+
+    return record;
+  });
 }

--- a/src/lib/registration/registration.ts
+++ b/src/lib/registration/registration.ts
@@ -22,6 +22,15 @@ export function recordIdFor(eventSeriesId: string, userId: string): string {
  */
 export const REGISTRATION_NOT_OPEN_HINT = "Es ist noch keine Sportveranstaltung freigeschalten.";
 
+/**
+ * Shown when an answer names something the event series stopped offering while the form was
+ * open — a teacher removed it between the page being loaded and the save being sent. It asks for
+ * the one thing that helps, since the form the student is looking at is out of date.
+ */
+export const ANSWER_NO_LONGER_OFFERED_HINT =
+  "Eine der gewählten Optionen steht nicht mehr zur Verfügung. " +
+  "Bitte lade die Seite neu und wähle erneut.";
+
 /** What an unsaved registration looks like, before the student has answered anything. */
 export const EMPTY_REGISTRATION: RegistrationInput = {
   // Taking part and borrowing equipment are answers the student gives, not ones the form

--- a/src/test/fake-firestore.ts
+++ b/src/test/fake-firestore.ts
@@ -82,7 +82,7 @@ export class FakeDocumentReference {
   }
 }
 
-type Filter = { field: string; value: unknown };
+type Filter = { field: string; operator: "==" | "array-contains"; value: unknown };
 
 export class FakeAggregateSnapshot {
   constructor(private readonly matches: number) {}
@@ -101,13 +101,15 @@ export class FakeQuery {
   ) {}
 
   where(field: string, operator: string, value: unknown): FakeQuery {
-    if (operator !== "==") {
-      throw new Error(`FakeFirestore only supports "==" queries, got "${operator}"`);
+    if (operator !== "==" && operator !== "array-contains") {
+      throw new Error(
+        `FakeFirestore supports "==" and "array-contains" queries, got "${operator}"`,
+      );
     }
     return new FakeQuery(
       this.firestore,
       this.collectionPath,
-      [...this.filters, { field, value }],
+      [...this.filters, { field, operator, value }],
       this.limitCount,
     );
   }
@@ -320,7 +322,12 @@ export class FakeFirestore {
 
   private matching(collectionPath: string, filters: Filter[]): [string, DocumentData][] {
     return [...this.collectionMap(collectionPath).entries()].filter(([, data]) =>
-      filters.every((filter) => data[filter.field] === filter.value),
+      filters.every((filter) => {
+        const stored = data[filter.field];
+        return filter.operator === "array-contains"
+          ? Array.isArray(stored) && stored.includes(filter.value)
+          : stored === filter.value;
+      }),
     );
   }
 


### PR DESCRIPTION
The cascade was going to rewrite every registration holding a renamed item and clear every one
holding a removed item. It is abandoned, and the in-use rule it was meant to replace is kept and
made sound instead.

Renaming "Vegetarisch" to "Vegan" rewrites what a hundred students said they wanted, and no
automatic rewrite can know whether they still mean it; removing an option leaves them holding
nothing. The honest outcome in both cases is that the answers are asked for again — the school's
decision, not something a fan-out can paper over.

What makes that affordable is that the rule stops being obstructive once the lists belong to one
series. The original complaint — a class mistyped in October cannot be fixed in November — was a
symptom of the lists being **global**, so another season's registration froze this season's
identically-named item. Scoped per series it bites only where this series' own students have
already answered, and during setup, when mistakes are actually caught, nothing is in use at all.

## The race, which is most of this change

The guard checked before the transaction, and that is a real TOCTOU: a student choosing the value
being removed in between would be left holding something the series no longer offers, and with no
cascade nothing repairs it. A guard with that hole is worse than none, because it claims an
invariant it does not hold.

- **The in-use check now runs inside the transaction that writes the list**, and queries narrowly
  — the registrations holding the one value being touched, rather than the whole series. Firestore
  locks that index range, so a student answering anything else never conflicts, and the only save
  that does is one choosing the very item being edited.
- **Saving a registration became a transaction too.** It reads the event series inside it and
  validates every answer against it, which closes the other direction: a teacher's edit writes
  that document, so a save which read the older one retries and is refused rather than storing a
  value nothing offers.
- Either order is safe — whichever commits first invalidates the other's read.
- **The student never pays.** A transaction retries by itself, so a save caught by a concurrent
  edit re-reads, re-validates and commits unnoticed. The one refusal they see is the one that
  deserves it: the option they chose has just been removed, and they are asked to reload.
- **The teacher pays**, which is the right way round: theirs is the rare and questionable request.

The guard's equality is exact rather than normalised, and deliberately so: a student picks from
the list, so what they store is the list's own spelling, and a rename is refused while the item is
held — so no second spelling can arise. The reasoning is in the file, and the test that used to
assert normalised matching now states the new contract instead of being deleted.

## Indexes

The narrow queries bring one composite index per answer a list supplies, plus one for the
rentals. They are temporary: once a registration lives beneath the series it belongs to, the
series is the path rather than a field, and every one of them goes.

## Spec

US-24 becomes the refusal and US-27 the two-sided transaction; US-25 keeps only its storage half.
**Q4 reverses** — with nothing rewriting stored answers, US-11's "changes to the list do not alter
already-stored records" is simply true again, so the contradiction Q4 existed to resolve
disappears rather than being decided. Q15 is withdrawn along with the whole `functions/` codebase
it justified, including the IAM widening it would have required. Q16 is subsumed: the class was
not an exception but the case that generalised. Slice 3a is gone and the slices renumber to 1–8.

## Tests

1492 unit tests and 100 rules tests pass. The new ones pin the race specifically, since neither
direction is visible in a single-threaded run: the guard reads *through* the transaction it is
given rather than around it, the read is ordered before the write, a save is refused when its
answer is no longer offered, and food's "Sonstiges" is accepted beside a non-empty list and
refused beside an empty one.

`FakeFirestore` gained `array-contains`. It already refused a read after a write, which is what
catches a guard that queries outside its transaction.
