### PR TITLE
Store a registration beneath its event series, carrying its own identity

### DIFF
--- a/firestore-tests/active-event-series.integration.test.ts
+++ b/firestore-tests/active-event-series.integration.test.ts
@@ -18,6 +18,7 @@ const { createEventSeries, updateEventSeries } =
   await import("@/lib/event-series/event-series-service");
 const { activeEventSeriesOf } = await import("@/lib/event-series/event-series-state");
 const { eventSeriesSchema } = await import("@/lib/schemas/event-series");
+const { registrationPath } = await import("@/lib/registration/registration");
 
 async function wipe(collection: string) {
   const snapshot = await adminDb.collection(collection).get();
@@ -25,12 +26,16 @@ async function wipe(collection: string) {
 }
 
 async function reset() {
-  for (const collection of ["eventSeries", "events", "registrations"]) await wipe(collection);
+  // The registrations go with the series they sit beneath, so wiping that collection is enough.
+  const registrations = await adminDb.collectionGroup("registrations").get();
+  await Promise.all(registrations.docs.map((doc) => doc.ref.delete()));
+  for (const collection of ["eventSeries", "events"]) await wipe(collection);
 }
 
 /** Archiving signs off on an event series' registrations (US-4), so there has to be some. */
 async function giveStudentData(eventSeriesId: string) {
-  await adminDb.collection("registrations").add({ eventSeriesId, studentId: "u1" });
+  const upn = "u1@student.htldornbirn.at";
+  await adminDb.collection(registrationPath(eventSeriesId)).doc(upn).set({ studentUpn: upn });
 }
 
 async function storedEventSeries() {

--- a/firestore-tests/master-data.rules.test.ts
+++ b/firestore-tests/master-data.rules.test.ts
@@ -139,6 +139,8 @@ describe.each([
   ["programs", { name: "Ski" }],
   ["reservedNames", { scope: "classOptions", name: "5AHIF", ownerId: "c1" }],
   ["seedState", { seededKeys: ["classes|5ahif"] }],
+  // A registration lives beneath its event series now (US-26); a top-level one is nothing.
+  ["registrations", { studentUpn: "schuelerin@student.htldornbirn.at" }],
 ])("/%s stays invisible to every client", (collection, valid) => {
   it("denies a teacher reading it", async () => {
     await seed(collection, "item1", valid);

--- a/firestore-tests/registration.rules.test.ts
+++ b/firestore-tests/registration.rules.test.ts
@@ -37,8 +37,9 @@ const student = () => signInAs(STUDENT_UPN);
 const otherStudent = () => signInAs(OTHER_STUDENT_UPN);
 const anonymous = () => testEnv.unauthenticatedContext().firestore();
 
-const OWN_RECORD = "eventSeries1__schuelerin@student.htldornbirn.at";
-const FOREIGN_RECORD = "eventSeries1__schueler@student.htldornbirn.at";
+/** Beneath the event series it belongs to, named after the student it belongs to (US-26). */
+const REGISTRATIONS = "eventSeries/eventSeries1/registrations";
+const OTHER_SERIES = "eventSeries/eventSeries2/registrations";
 
 async function seed(collection: string, id: string, data: Record<string, unknown>) {
   await testEnv.withSecurityRulesDisabled(async (context) => {
@@ -56,111 +57,110 @@ beforeEach(async () => {
     await db.collection("users").doc(NEWCOMER_UPN).set({ role: "student" });
   });
 
-  await seed("registrations", OWN_RECORD, {
-    userId: STUDENT_UPN,
-    eventSeriesId: "eventSeries1",
+  await seed(REGISTRATIONS, STUDENT_UPN, {
+    studentUpn: STUDENT_UPN,
+    firstName: "Erika",
+    lastName: "Musterfrau",
+    email: STUDENT_UPN,
     isAttendingSportsWeek: true,
     class: "5AHIF",
     emergencyContact: { firstName: "Maria", lastName: "Muster", relationship: "mother" },
     rentedEquipment: ["Helm"],
   });
-  await seed("registrations", FOREIGN_RECORD, {
-    userId: OTHER_STUDENT_UPN,
-    eventSeriesId: "eventSeries1",
+  await seed(REGISTRATIONS, OTHER_STUDENT_UPN, {
+    studentUpn: OTHER_STUDENT_UPN,
+    firstName: "Max",
+    lastName: "Mustermann",
+    email: OTHER_STUDENT_UPN,
     isAttendingSportsWeek: true,
     class: "5AHIF",
   });
 });
 
 /**
- * A student's own record is theirs to read and no other student's. It carries everything it
- * needs — the emergency contact and the rented equipment are fields of it, so there is no child
- * document whose ownership would have to be worked out separately.
+ * A student's own record is theirs to read and no other student's. Ownership is the document's
+ * own name, so the rule needs nothing from `resource` — which is what lets a student read one
+ * that does not exist yet (US-26). It carries everything it needs: the emergency contact and
+ * the rented equipment are fields of it, so there is no child document whose ownership would
+ * have to be worked out separately.
  *
- * A teacher reads all of them, which is what the assignment dialog (US-12) and the report
- * (US-13) are: a view of every registration in the active event series at once.
+ * A teacher reads the whole subcollection, which is what the assignment board (US-12) and the
+ * report (US-13) are: a view of every registration in one event series at once.
  *
  * Writes are closed for the reason they are everywhere else: a save carries invariants rules
- * cannot run a query for — it belongs to *the* active event series, answering "no" gives up the event
- * assignment (US-12), and the event series' `hasRegistrations` mirror follows it (US-4).
+ * cannot run a query for — every answer has to be one the series still offers (US-27),
+ * answering "no" gives up the event assignment (US-12), and the event series'
+ * `hasRegistrations` mirror follows it (US-4).
  */
-describe("/registration", () => {
+describe("/eventSeries/{id}/registrations", () => {
   it("lets a student read their own record", async () => {
-    await assertSucceeds(student().collection("registrations").doc(OWN_RECORD).get());
-  });
-
-  it("lets a student query for their own record, which is what the form subscribes to", async () => {
-    await assertSucceeds(
-      student().collection("registrations").where("userId", "==", STUDENT_UPN).get(),
-    );
+    await assertSucceeds(student().collection(REGISTRATIONS).doc(STUDENT_UPN).get());
   });
 
   /**
-   * Where every student starts. A `get` of the id the form could derive is denied instead —
-   * there is no `resource` on a document that does not exist, so ownership cannot be checked —
-   * which is why the form queries rather than reading that id.
+   * Where every student starts. The rule owns the document by its name rather than by a field
+   * only an existing document would have, so this is a permitted read of nothing — which is
+   * why the form reads the id it derives rather than querying for it.
    */
-  it("answers a student who has no record yet with an empty result, not a refusal", async () => {
+  it("lets a student who has no record yet read the id they would have", async () => {
     const newcomer = signInAs(NEWCOMER_UPN);
 
-    await assertSucceeds(
-      newcomer.collection("registrations").where("userId", "==", NEWCOMER_UPN).get(),
-    );
+    await assertSucceeds(newcomer.collection(REGISTRATIONS).doc(NEWCOMER_UPN).get());
   });
 
   /**
-   * The whole collection, because a teacher plans across it: the assignment dialog counts every
-   * class and every event of the active event series (US-12) and the report lists every student
+   * The whole subcollection, because a teacher plans across it: the assignment board counts
+   * every class and every event of the series (US-12) and the report lists every student
    * (US-13). Both watch it live, so the tables follow an assignment the moment it is stored.
    */
-  it("lets a teacher query every record, which is what the assignment dialog subscribes to", async () => {
-    await assertSucceeds(teacher().collection("registrations").get());
+  it("lets a teacher query every record, which is what the assignment board subscribes to", async () => {
+    await assertSucceeds(teacher().collection(REGISTRATIONS).get());
   });
 
   it("lets a teacher read a single record", async () => {
-    await assertSucceeds(teacher().collection("registrations").doc(FOREIGN_RECORD).get());
+    await assertSucceeds(teacher().collection(REGISTRATIONS).doc(OTHER_STUDENT_UPN).get());
   });
 
   it("denies a student reading another student's record", async () => {
-    await assertFails(student().collection("registrations").doc(FOREIGN_RECORD).get());
+    await assertFails(student().collection(REGISTRATIONS).doc(OTHER_STUDENT_UPN).get());
   });
 
-  it("denies a student querying the whole collection", async () => {
-    await assertFails(student().collection("registrations").get());
+  it("denies a student querying the whole subcollection", async () => {
+    await assertFails(student().collection(REGISTRATIONS).get());
   });
 
   it("denies an unauthenticated read", async () => {
-    await assertFails(anonymous().collection("registrations").doc(OWN_RECORD).get());
+    await assertFails(anonymous().collection(REGISTRATIONS).doc(STUDENT_UPN).get());
   });
 
   it("denies a student writing their own record, so the save keeps going through the handler", async () => {
     await assertFails(
-      student().collection("registrations").doc(OWN_RECORD).update({ class: "5BHIF" }),
+      student().collection(REGISTRATIONS).doc(STUDENT_UPN).update({ class: "5BHIF" }),
     );
   });
 
-  it("denies a student creating a record for an event series of their choosing", async () => {
+  it("denies a student creating a record in an event series of their choosing", async () => {
     await assertFails(
       student()
-        .collection("registrations")
-        .doc("eventSeries2__schuelerin@student.htldornbirn.at")
-        .set({ userId: STUDENT_UPN, eventSeriesId: "eventSeries2", isAttendingSportsWeek: true }),
+        .collection(OTHER_SERIES)
+        .doc(STUDENT_UPN)
+        .set({ studentUpn: STUDENT_UPN, isAttendingSportsWeek: true }),
     );
   });
 
   it("denies a student assigning themselves to an event", async () => {
     await assertFails(
-      student().collection("registrations").doc(OWN_RECORD).update({ event: "Woche 1" }),
+      student().collection(REGISTRATIONS).doc(STUDENT_UPN).update({ event: "Woche 1" }),
     );
   });
 
   it("denies a student deleting their own record", async () => {
-    await assertFails(student().collection("registrations").doc(OWN_RECORD).delete());
+    await assertFails(student().collection(REGISTRATIONS).doc(STUDENT_UPN).delete());
   });
 
   it("denies a teacher writing a record", async () => {
     await assertFails(
-      teacher().collection("registrations").doc(OWN_RECORD).update({ class: "5BHIF" }),
+      teacher().collection(REGISTRATIONS).doc(STUDENT_UPN).update({ class: "5BHIF" }),
     );
   });
 });
@@ -210,8 +210,8 @@ describe("/savedReports", () => {
 });
 
 /** Cross-checks that the record another student owns is genuinely reachable by its owner. */
-describe("ownership is read from the record, not from the id", () => {
-  it("lets the other student read the record that names them", async () => {
-    await assertSucceeds(otherStudent().collection("registrations").doc(FOREIGN_RECORD).get());
+describe("ownership is the document's own name", () => {
+  it("lets the other student read the record named after them", async () => {
+    await assertSucceeds(otherStudent().collection(REGISTRATIONS).doc(OTHER_STUDENT_UPN).get());
   });
 });

--- a/firestore-tests/users.rules.test.ts
+++ b/firestore-tests/users.rules.test.ts
@@ -37,6 +37,15 @@ async function seedUser(uid: string, data: Record<string, unknown>) {
   });
 }
 
+/** Beneath the event series it belongs to, named after the student it belongs to (US-26). */
+const REGISTRATIONS = "eventSeries/eventSeries1/registrations";
+
+async function seedRegistration(studentUpn: string) {
+  await testEnv.withSecurityRulesDisabled(async (context) => {
+    await context.firestore().collection(REGISTRATIONS).doc(studentUpn).set({ studentUpn });
+  });
+}
+
 /**
  * Production keys `/users` by UPN (see provisionUser) while `request.auth.uid` is an opaque
  * Firebase id. Signing in through this helper keeps the two distinct, so a rule that confuses
@@ -78,12 +87,24 @@ describe("/users/{uid} read access", () => {
     await assertFails(db.collection("users").doc(BOB).get());
   });
 
-  it("allows a teacher to read any user's document", async () => {
+  /**
+   * A teacher used to read every user, because the roster joined registrations to them for the
+   * student's name. The registration carries that name itself now (US-26), so the permission
+   * has no reader left and is withdrawn.
+   */
+  it("denies a teacher reading another user's document", async () => {
     await seedUser(ALICE, student());
     await seedUser(CAROL, teacher());
     const db = signInAs(CAROL);
 
-    await assertSucceeds(db.collection("users").doc(ALICE).get());
+    await assertFails(db.collection("users").doc(ALICE).get());
+  });
+
+  it("allows a teacher to read their own document", async () => {
+    await seedUser(CAROL, teacher());
+    const db = signInAs(CAROL);
+
+    await assertSucceeds(db.collection("users").doc(CAROL).get());
   });
 });
 
@@ -181,6 +202,9 @@ describe("/users/{uid} has no admin role", () => {
  * Production keys `/users` by UPN (see provisionUser), while `request.auth.uid` is an opaque
  * Firebase id. Tests that reuse one value for both silently pass rules that can never match
  * a real request, so these deliberately keep the two apart.
+ *
+ * The teacher cases read a registration rather than a user record: `/users` now answers only
+ * to `isSelf`, so a registration is the one door left that still resolves a role.
  */
 describe("identity resolution with a realistic uid", () => {
   const UID = "6Xk2p9QwErTyUiOpAsDf";
@@ -203,24 +227,31 @@ describe("identity resolution with a realistic uid", () => {
 
   it("recognises a teacher whose record is keyed by UPN", async () => {
     await seedUser(UPN, teacher({ email: UPN }));
-    await seedUser("pupil@student.htldornbirn.at", student());
+    await seedRegistration("pupil@student.htldornbirn.at");
 
-    await assertSucceeds(signedIn().collection("users").doc("pupil@student.htldornbirn.at").get());
+    await assertSucceeds(
+      signedIn().collection(REGISTRATIONS).doc("pupil@student.htldornbirn.at").get(),
+    );
   });
 
   it("recognises a teacher from the role claim, without reading the record", async () => {
-    await seedUser("pupil@student.htldornbirn.at", student());
+    await seedRegistration("pupil@student.htldornbirn.at");
 
     await assertSucceeds(
-      signedIn({ role: "teacher" }).collection("users").doc("pupil@student.htldornbirn.at").get(),
+      signedIn({ role: "teacher" })
+        .collection(REGISTRATIONS)
+        .doc("pupil@student.htldornbirn.at")
+        .get(),
     );
   });
 
   it("does not grant teacher rights to a student who forges nothing but a uid", async () => {
     await seedUser(UPN, student({ email: UPN }));
-    await seedUser("pupil@student.htldornbirn.at", student());
+    await seedRegistration("pupil@student.htldornbirn.at");
 
-    await assertFails(signedIn().collection("users").doc("pupil@student.htldornbirn.at").get());
+    await assertFails(
+      signedIn().collection(REGISTRATIONS).doc("pupil@student.htldornbirn.at").get(),
+    );
   });
 
   it("matches the UPN case-insensitively, since the record id is lowercased", async () => {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -2,59 +2,8 @@
   "indexes": [
     {
       "collectionGroup": "registrations",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
-        { "fieldPath": "class", "order": "ASCENDING" }
-      ]
-    },
-    {
-      "collectionGroup": "registrations",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
-        { "fieldPath": "program", "order": "ASCENDING" }
-      ]
-    },
-    {
-      "collectionGroup": "registrations",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
-        { "fieldPath": "skillLevel", "order": "ASCENDING" }
-      ]
-    },
-    {
-      "collectionGroup": "registrations",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
-        { "fieldPath": "seasonPassOption", "order": "ASCENDING" }
-      ]
-    },
-    {
-      "collectionGroup": "registrations",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
-        { "fieldPath": "busPickupPoint", "order": "ASCENDING" }
-      ]
-    },
-    {
-      "collectionGroup": "registrations",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
-        { "fieldPath": "foodOption", "order": "ASCENDING" }
-      ]
-    },
-    {
-      "collectionGroup": "registrations",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "eventSeriesId", "order": "ASCENDING" },
-        { "fieldPath": "rentedEquipment", "arrayConfig": "CONTAINS" }
-      ]
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [{ "fieldPath": "studentUpn", "order": "ASCENDING" }]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -39,8 +39,16 @@ service cloud.firestore {
       return upn() != '' && upn() == uid;
     }
 
+    /**
+     * A caller's own record, and nobody else's. A teacher used to read every user because the
+     * roster joined registrations to them for the student's name; the registration now carries
+     * that name itself (US-26), so the permission has no reader left and is withdrawn.
+     *
+     * The fake login's list of existing users (US-16) is unaffected: it is read server-side
+     * with the Admin SDK, which bypasses these rules.
+     */
     match /users/{uid} {
-      allow read: if isSelf(uid) || isTeacher();
+      allow read: if isSelf(uid);
 
       // Records are provisioned on first login by the Admin SDK, which bypasses these rules.
       allow create: if false;
@@ -53,23 +61,25 @@ service cloud.firestore {
     }
 
     /**
-     * A student's own registration (US-11). Ownership is the record's `userId`, which holds the
-     * UPN, so the same check serves a direct read and the query the form subscribes to. The
-     * record carries the emergency contact and the rented equipment in its own fields, so there
-     * is no child document whose ownership would have to be worked out separately.
+     * A student's own registration (US-11), stored beneath the event series it belongs to so
+     * that which series it is in is its path rather than a field it carries (US-26). Its id is
+     * the student's UPN, so ownership is the document's own name and a read needs no query.
+     * The record carries the emergency contact and the rented equipment in its own fields, so
+     * there is no child document whose ownership would have to be worked out separately.
      *
-     * A teacher reads the whole collection, because planning is what it is for: the assignment
-     * dialog counts every class and every event of the active event series (US-12) and the report
+     * A teacher reads the whole subcollection, because planning is what it is for: the
+     * assignment board counts every class and every event of the series (US-12) and the report
      * lists every student (US-13). Checked first, so a list is answered without touching
      * `resource`, which a list has none of until a document is returned.
      *
-     * Writes are closed for the reason the collections below are: a save carries invariants
-     * rules cannot run a query for — it belongs to *the* active event series, answering "no" gives
-     * up the event assignment (US-12), and the event series' `hasRegistrations` mirror follows it
-     * (US-4). The teacher's assignment goes the same way, through a handler that owns `event`.
+     * Writes are closed for the reason the event series document's are: a save carries
+     * invariants rules cannot run a query for — every answer has to be one the series still
+     * offers (US-27), answering "no" gives up the event assignment (US-12), and the series'
+     * `hasRegistrations` mirror follows it (US-4). The teacher's assignment goes the same way,
+     * through a handler that owns `event`.
      */
-    match /registrations/{recordId} {
-      allow read: if isTeacher() || (isSignedIn() && resource.data.userId == upn());
+    match /eventSeries/{eventSeriesId}/registrations/{studentUpn} {
+      allow read: if isTeacher() || isSelf(studentUpn);
       allow write: if false;
     }
 

--- a/scripts/seed-students.mts
+++ b/scripts/seed-students.mts
@@ -24,7 +24,7 @@ import { userRoleSchema, userSchema } from "@/lib/schemas/user";
 import { activeEventSeriesOf } from "@/lib/event-series/event-series-state";
 import { normalizeName } from "@/lib/firebase/name-key";
 import { isRegistrationIncomplete } from "@/lib/registration/completeness";
-import { EMPTY_REGISTRATION, recordIdFor } from "@/lib/registration/registration";
+import { EMPTY_REGISTRATION, registrationPath } from "@/lib/registration/registration";
 import { apphostingValue, fail } from "./environment.mjs";
 
 /** Where invented students are allowed. Production is absent by construction, not by a check. */
@@ -302,7 +302,8 @@ async function inBatches(
  * since the fixed seed hands the same addresses back to the same people on the next run.
  */
 async function purgeStudents(db: Firestore): Promise<{ records: number; users: number }> {
-  const records = await db.collection(COLLECTIONS.registrations).get();
+  // Across every event series, since a registration lives beneath the one it belongs to (US-26).
+  const records = await db.collectionGroup(COLLECTIONS.registrations).get();
   const users = await db
     .collection(COLLECTIONS.users)
     .where("role", "==", userRoleSchema.enum.student)
@@ -432,9 +433,12 @@ async function main(): Promise<void> {
 
       const user = userSchema.parse({ id: person.upn, ...person, email: person.upn, role: "student" }); // prettier-ignore
       const record = registrationSchema.parse({
-        id: recordIdFor(eventSeries.id, person.upn),
-        userId: person.upn,
-        eventSeriesId: eventSeries.id,
+        id: person.upn,
+        studentUpn: person.upn,
+        // Copied onto the record, which is what a reader takes the name from (US-26).
+        firstName: person.firstName,
+        lastName: person.lastName,
+        email: person.upn,
         // Unassigned on purpose: putting students into events is what the board is for (US-12).
         event: null,
         isIncomplete: isRegistrationIncomplete(registration),
@@ -445,7 +449,7 @@ async function main(): Promise<void> {
       const { id: recordId, ...recordFields } = record;
       writes.push((batch) => batch.set(db.collection(COLLECTIONS.users).doc(userId), userFields));
       writes.push((batch) =>
-        batch.set(db.collection(COLLECTIONS.registrations).doc(recordId), recordFields),
+        batch.set(db.collection(registrationPath(eventSeries.id)).doc(recordId), recordFields),
       );
     }
 

--- a/src/app/app/my-registration/page.tsx
+++ b/src/app/app/my-registration/page.tsx
@@ -12,12 +12,14 @@ import { RegistrationView } from "@/components/registration/registration-view";
 /**
  * Only the shared header sits above this page — no left-side navigation (US-15). The name comes
  * from the user record rather than the form, which shows it without letting it be edited (US-11).
+ * Not from the registration, which carries one too (US-26): the header names the student before
+ * they have registered, and there is no record to read it from until they have.
  */
 export default async function RegistrationPage() {
   const user = await requireStudent();
-  const userId = (user.email ?? "").toLowerCase();
+  const studentUpn = (user.email ?? "").toLowerCase();
 
-  const snapshot = await adminDb.collection(COLLECTIONS.users).doc(userId).get();
+  const snapshot = await adminDb.collection(COLLECTIONS.users).doc(studentUpn).get();
   const stored = userSchema.safeParse({ id: snapshot.id, ...snapshot.data() });
   const studentName = stored.success
     ? `${stored.data.firstName} ${stored.data.lastName}`
@@ -27,7 +29,7 @@ export default async function RegistrationPage() {
     // Capped rather than stretched: the form is one column of short fields, and a line of
     // inputs the full width of a desktop screen is a long way from its own label.
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-4 md:p-6">
-      <RegistrationView userId={userId} studentName={studentName} />
+      <RegistrationView studentUpn={studentUpn} studentName={studentName} />
     </div>
   );
 }

--- a/src/components/assignment/assignment-board.test.tsx
+++ b/src/components/assignment/assignment-board.test.tsx
@@ -33,7 +33,7 @@ function student(
 ): RosterStudent {
   return rosterStudent({
     id: `record-${lastName}`,
-    userId: `${lastName}@student.htldornbirn.at`,
+    studentUpn: `${lastName}@student.htldornbirn.at`,
     firstName,
     lastName,
     ...overrides,

--- a/src/components/assignment/assignment-view.test.tsx
+++ b/src/components/assignment/assignment-view.test.tsx
@@ -39,7 +39,7 @@ function student(
 ): RosterStudent {
   return rosterStudent({
     id: `record-${lastName}`,
-    userId: `${lastName}@student.htldornbirn.at`,
+    studentUpn: `${lastName}@student.htldornbirn.at`,
     firstName,
     lastName,
     ...overrides,

--- a/src/components/assignment/class-cards.test.tsx
+++ b/src/components/assignment/class-cards.test.tsx
@@ -31,7 +31,7 @@ function student(overrides: Partial<Omit<RosterStudent, "record">> = {}): Roster
   seed += 1;
   return rosterStudent({
     id: `record${seed}`,
-    userId: `student${seed}@student.htldornbirn.at`,
+    studentUpn: `student${seed}@student.htldornbirn.at`,
     firstName: `Vorname${seed}`,
     lastName: `Nachname${seed}`,
     ...overrides,

--- a/src/components/assignment/statistics-view.test.tsx
+++ b/src/components/assignment/statistics-view.test.tsx
@@ -30,7 +30,7 @@ function student(
 ): RosterStudent {
   return rosterStudent({
     id: `record-${lastName}`,
-    userId: `${lastName}@student.htldornbirn.at`,
+    studentUpn: `${lastName}@student.htldornbirn.at`,
     firstName: "Vorname",
     lastName,
     ...overrides,

--- a/src/components/registration/registration-form.test.tsx
+++ b/src/components/registration/registration-form.test.tsx
@@ -32,9 +32,11 @@ const LISTS = {
 };
 
 const storedRecord: Registration = {
-  id: "s1__jane",
-  userId: "jane@student.htldornbirn.at",
-  eventSeriesId: "s1",
+  id: "jane@student.htldornbirn.at",
+  studentUpn: "jane@student.htldornbirn.at",
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane@student.htldornbirn.at",
   event: null,
   isIncomplete: false,
   isAttendingSportsWeek: true,

--- a/src/components/registration/registration-view.test.tsx
+++ b/src/components/registration/registration-view.test.tsx
@@ -54,7 +54,7 @@ beforeEach(() => {
 });
 
 function renderView() {
-  render(<RegistrationView userId="jane@student.htldornbirn.at" studentName="Jane Doe" />);
+  render(<RegistrationView studentUpn="jane@student.htldornbirn.at" studentName="Jane Doe" />);
 }
 
 describe("RegistrationView", () => {

--- a/src/components/registration/registration-view.tsx
+++ b/src/components/registration/registration-view.tsx
@@ -13,7 +13,7 @@ import { useRegistration } from "@/lib/registration/use-registration";
 import { RegistrationForm } from "./registration-form";
 
 type RegistrationViewProps = {
-  userId: string;
+  studentUpn: string;
   studentName: string;
 };
 
@@ -22,8 +22,8 @@ type RegistrationViewProps = {
  * student's to create — so until a teacher has set both up there is no form to show, only the
  * notice US-11 asks for.
  */
-export function RegistrationView({ userId, studentName }: RegistrationViewProps) {
-  const { eventSeries, record, loading, error } = useRegistration(userId);
+export function RegistrationView({ studentUpn, studentName }: RegistrationViewProps) {
+  const { eventSeries, record, loading, error } = useRegistration(studentUpn);
   const classes = useMasterData("classes");
   const skillLevels = useMasterData("skill-levels");
   const busPickupPoints = useMasterData("bus-pickup-points");

--- a/src/components/report/report-view.test.tsx
+++ b/src/components/report/report-view.test.tsx
@@ -47,7 +47,7 @@ function student(
 ): RosterStudent {
   return rosterStudent({
     id: `record-${lastName}`,
-    userId: `${lastName.toLowerCase()}@student.htldornbirn.at`,
+    studentUpn: `${lastName.toLowerCase()}@student.htldornbirn.at`,
     email: `${lastName.toLowerCase()}@student.htldornbirn.at`,
     firstName,
     lastName,

--- a/src/lib/assignment/assignment-service.test.ts
+++ b/src/lib/assignment/assignment-service.test.ts
@@ -12,15 +12,16 @@ const firestore = new FakeFirestore();
 vi.mock("@/lib/firebase/admin", () => ({ adminDb: firestore }));
 
 const { assignStudents } = await import("./assignment-service");
+const { registrationPath } = await import("@/lib/registration/registration");
 const { ServiceError } = await import("@/lib/service-error");
 
-const ANNA = "s1__anna@student.htldornbirn.at";
-const BENE = "s1__bene@student.htldornbirn.at";
+const ANNA = "anna@student.htldornbirn.at";
+const BENE = "bene@student.htldornbirn.at";
+const REGISTRATIONS = registrationPath("s1");
 
-function seedRecord(id: string, fields: Record<string, unknown> = {}) {
-  firestore.seed("registrations", id, {
-    userId: id.split("__")[1],
-    eventSeriesId: "s1",
+function seedRecord(studentUpn: string, fields: Record<string, unknown> = {}) {
+  firestore.seed(REGISTRATIONS, studentUpn, {
+    studentUpn,
     event: null,
     isAttendingSportsWeek: true,
     ...fields,
@@ -54,7 +55,7 @@ beforeEach(() => {
   seedRecord(BENE);
 });
 
-const eventOf = (id: string) => firestore.get("registrations", id)?.event;
+const eventOf = (id: string) => firestore.get(REGISTRATIONS, id)?.event;
 
 describe("assignStudents", () => {
   it("writes the event onto every record it was given", async () => {
@@ -91,9 +92,8 @@ describe("assignStudents", () => {
   it("changes nothing but the assignment", async () => {
     await assignStudents([ANNA], "Woche 1");
 
-    expect(firestore.get("registrations", ANNA)).toMatchObject({
-      userId: "anna@student.htldornbirn.at",
-      eventSeriesId: "s1",
+    expect(firestore.get(REGISTRATIONS, ANNA)).toMatchObject({
+      studentUpn: ANNA,
       isAttendingSportsWeek: true,
     });
   });
@@ -143,17 +143,17 @@ describe("assignStudents", () => {
     await expect(assignStudents(["ghost"], "Woche 1")).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 
-  it("refuses a registration of an event series that is no longer the active one", async () => {
-    firestore.seed("registrations", "s0__anna@student.htldornbirn.at", {
-      userId: "anna@student.htldornbirn.at",
-      eventSeriesId: "s0",
+  /** The path is derived from the active series, so another series' record is out of reach. */
+  it("refuses a student whose only registration is in another event series", async () => {
+    const CLARA = "clara@student.htldornbirn.at";
+    firestore.seed(registrationPath("s0"), CLARA, {
+      studentUpn: CLARA,
       event: null,
       isAttendingSportsWeek: true,
     });
 
-    await expect(
-      assignStudents(["s0__anna@student.htldornbirn.at"], "Woche 1"),
-    ).rejects.toMatchObject({ code: "CONFLICT" });
+    await expect(assignStudents([CLARA], "Woche 1")).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(firestore.get(registrationPath("s0"), CLARA)).toMatchObject({ event: null });
   });
 
   it("writes nothing at all when one of the records is refused", async () => {
@@ -179,7 +179,7 @@ describe("assignStudents", () => {
    * drop once a whole class is moved at once.
    */
   it("reads every record at once rather than one round trip after another", async () => {
-    const CLARA = "s1__clara@student.htldornbirn.at";
+    const CLARA = "clara@student.htldornbirn.at";
     seedRecord(CLARA);
 
     const started: string[] = [];
@@ -189,7 +189,7 @@ describe("assignStudents", () => {
     vi.spyOn(FakeDocumentReference.prototype, "get").mockImplementation(async function (
       this: FakeDocumentReference,
     ) {
-      const isRecord = this.collectionPath === "registrations";
+      const isRecord = this.collectionPath === REGISTRATIONS;
       if (isRecord) started.push(this.id);
 
       const snapshot = await read.call(this);

--- a/src/lib/assignment/assignment-service.ts
+++ b/src/lib/assignment/assignment-service.ts
@@ -10,6 +10,7 @@ import { normalizeName } from "@/lib/firebase/name-key";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
 import { COLLECTIONS } from "@/lib/schemas/collections";
+import { registrationPath } from "@/lib/registration/registration";
 import { eventSeriesSchema, type EventSeries } from "@/lib/schemas/event-series";
 import { registrationSchema } from "@/lib/schemas/registration";
 import {
@@ -17,11 +18,8 @@ import {
   NO_ACTIVE_EVENT_SERIES_HINT,
 } from "@/lib/event-series/event-series-state";
 
-/** The two answers the assignment turns on, derived so a rename cannot pass this by. */
-const assignableSchema = registrationSchema.pick({
-  eventSeriesId: true,
-  isAttendingSportsWeek: true,
-});
+/** The one answer the assignment turns on, derived so a rename cannot pass this by. */
+const assignableSchema = registrationSchema.pick({ isAttendingSportsWeek: true });
 
 async function requireActiveEventSeries(): Promise<EventSeries> {
   const snapshot = await adminDb
@@ -71,14 +69,16 @@ function eventOfEventSeries(eventSeries: EventSeries, event: string): string {
  * cannot get stuck in an event.
  */
 export async function assignStudents(
-  recordIds: readonly string[],
+  studentUpns: readonly string[],
   event: string | null,
 ): Promise<void> {
   const eventSeries = await requireActiveEventSeries();
   const assigned = event === null ? null : eventOfEventSeries(eventSeries, event);
 
-  const references = recordIds.map((recordId) =>
-    adminDb.collection(COLLECTIONS.registrations).doc(recordId),
+  // Beneath the active series by construction, so "is this registration one of ours?" is the
+  // path rather than a field a caller could point elsewhere (US-26).
+  const references = studentUpns.map((studentUpn) =>
+    adminDb.collection(registrationPath(eventSeries.id)).doc(studentUpn),
   );
 
   // All in flight together. Read one after the other, moving a class was as many round trips as
@@ -91,12 +91,6 @@ export async function assignStudents(
     }
 
     const record = assignableSchema.parse(snapshot.data());
-    if (record.eventSeriesId !== eventSeries.id) {
-      throw new ServiceError(
-        ErrorCode.Conflict,
-        "Nur Anmeldungen der aktiven Eventreihe können zugeteilt werden.",
-      );
-    }
     if (assigned !== null && !record.isAttendingSportsWeek) {
       throw new ServiceError(
         ErrorCode.Conflict,

--- a/src/lib/assignment/statistics.test.ts
+++ b/src/lib/assignment/statistics.test.ts
@@ -14,7 +14,7 @@ function student(overrides: Partial<Omit<RosterStudent, "record">> = {}): Roster
   seed += 1;
   return rosterStudent({
     id: `record${seed}`,
-    userId: `student${seed}@student.htldornbirn.at`,
+    studentUpn: `student${seed}@student.htldornbirn.at`,
     firstName: `Vorname${seed}`,
     lastName: `Nachname${seed}`,
     skillLevel: "Fortgeschritten",

--- a/src/lib/auth/provision-user.test.ts
+++ b/src/lib/auth/provision-user.test.ts
@@ -4,6 +4,8 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeFirestore } from "@/test/fake-firestore";
+import { storedEventSeries } from "@/test/event-series";
 
 const docGet = vi.fn();
 const docSet = vi.fn();
@@ -13,8 +15,19 @@ const collection = vi.fn(() => ({ doc }));
 const setCustomUserClaims = vi.fn();
 const fetchEntraName = vi.fn();
 
+/**
+ * The user record stays a mock, so the tests below can stage a login that finds one or does
+ * not. The registrations are a real store: what the refresh has to get right is which documents
+ * a collection group query reaches and which series each of them sits beneath (US-26).
+ */
+const firestore = new FakeFirestore();
+
 vi.mock("@/lib/firebase/admin", () => ({
-  adminDb: { collection },
+  adminDb: {
+    collection,
+    collectionGroup: (id: string) => firestore.collectionGroup(id),
+    batch: () => firestore.batch(),
+  },
   adminAuth: { setCustomUserClaims },
 }));
 
@@ -26,6 +39,7 @@ const refuseSignIn = vi.fn();
 vi.mock("@/lib/auth/sign-in-policy", () => ({ refuseSignIn }));
 
 const { provisionUser } = await import("@/lib/auth/provision-user");
+const { registrationPath } = await import("@/lib/registration/registration");
 
 const teacherClaims = {
   uid: "firebase-uid-1",
@@ -307,5 +321,121 @@ describe("provisionUser", () => {
     await provisionUser({ ...teacherClaims, email: "jane@gmail.com" }, "graph-token");
 
     expect(fetchEntraName).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The name on a registration is a copy (US-26), and this is the repair that makes it safe: it
+ * can never be more than one login out of date.
+ */
+describe("the login refresh of a student's registrations", () => {
+  const STUDENT = studentClaims.email;
+
+  function seedEventSeries(id: string, isArchived = false) {
+    firestore.seed("eventSeries", id, storedEventSeries({ name: `Eventreihe ${id}`, isArchived }));
+  }
+
+  function seedRegistration(eventSeriesId: string, name: Record<string, unknown>) {
+    firestore.seed(registrationPath(eventSeriesId), STUDENT, {
+      studentUpn: STUDENT,
+      email: STUDENT,
+      class: "3AHME",
+      ...name,
+    });
+  }
+
+  const stored = (eventSeriesId: string) => firestore.get(registrationPath(eventSeriesId), STUDENT);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    firestore.reset();
+    refuseSignIn.mockReturnValue(null);
+    docGet.mockResolvedValue({ exists: false, data: () => undefined });
+    fetchEntraName.mockResolvedValue(null);
+  });
+
+  it("corrects a name the directory has since changed", async () => {
+    seedEventSeries("s1");
+    seedRegistration("s1", { firstName: "Maks", lastName: "Mustermann" });
+
+    await provisionUser({ ...studentClaims, ...ENTRA });
+
+    expect(stored("s1")).toMatchObject({ firstName: "Max", lastName: "Mustermann" });
+  });
+
+  it("writes only the field that differs, so a correction is not a rewrite", async () => {
+    seedEventSeries("s1");
+    seedRegistration("s1", { firstName: "Maks", lastName: "Mustermann" });
+
+    await provisionUser({ ...studentClaims, ...ENTRA });
+
+    expect(firestore.batchSizes).toEqual([1]);
+  });
+
+  /** A login that changes nothing must not wake every teacher's subscription to say so. */
+  it("writes nothing at all when the name has not changed", async () => {
+    seedEventSeries("s1");
+    seedRegistration("s1", { firstName: "Max", lastName: "Mustermann" });
+
+    await provisionUser({ ...studentClaims, ...ENTRA });
+
+    expect(firestore.commitCount).toBe(0);
+  });
+
+  /** An archived series is read-only in everything it holds (US-19). */
+  it("leaves a registration in an archived event series as it was", async () => {
+    seedEventSeries("archived", true);
+    seedRegistration("archived", { firstName: "Maks", lastName: "Mustermann" });
+
+    await provisionUser({ ...studentClaims, ...ENTRA });
+
+    expect(stored("archived")).toMatchObject({ firstName: "Maks" });
+    expect(firestore.commitCount).toBe(0);
+  });
+
+  it("reaches every event series the student has registered in", async () => {
+    seedEventSeries("s1");
+    seedEventSeries("s2");
+    seedEventSeries("archived", true);
+    seedRegistration("s1", { firstName: "Maks", lastName: "Mustermann" });
+    seedRegistration("s2", { firstName: "Maks", lastName: "Mustermann" });
+    seedRegistration("archived", { firstName: "Maks", lastName: "Mustermann" });
+
+    await provisionUser({ ...studentClaims, ...ENTRA });
+
+    expect(stored("s1")).toMatchObject({ firstName: "Max" });
+    expect(stored("s2")).toMatchObject({ firstName: "Max" });
+    expect(stored("archived")).toMatchObject({ firstName: "Maks" });
+  });
+
+  it("leaves somebody else's registration alone", async () => {
+    seedEventSeries("s1");
+    firestore.seed(registrationPath("s1"), "other@student.htldornbirn.at", {
+      studentUpn: "other@student.htldornbirn.at",
+      firstName: "Maks",
+      lastName: "Mustermann",
+      email: "other@student.htldornbirn.at",
+    });
+
+    await provisionUser({ ...studentClaims, ...ENTRA });
+
+    expect(firestore.get(registrationPath("s1"), "other@student.htldornbirn.at")).toMatchObject({
+      firstName: "Maks",
+    });
+  });
+
+  /** A teacher keeps no registration of their own (US-15), so there is nothing to look for. */
+  it("asks nothing of the registrations when a teacher signs in", async () => {
+    const read = vi.spyOn(firestore, "runGroupQuery");
+
+    await provisionUser({ ...teacherClaims, ...ENTRA });
+
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing for a student who has not registered anywhere", async () => {
+    await provisionUser({ ...studentClaims, ...ENTRA });
+
+    expect(firestore.commitCount).toBe(0);
   });
 });

--- a/src/lib/auth/provision-user.ts
+++ b/src/lib/auth/provision-user.ts
@@ -4,9 +4,12 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import "server-only";
+import type { DocumentReference } from "firebase-admin/firestore";
 import { adminAuth, adminDb } from "@/lib/firebase/admin";
+import { commitInChunks, type BatchOperation } from "@/lib/firebase/batch";
 import { COLLECTIONS } from "@/lib/schemas/collections";
-import { userSchema, type User } from "@/lib/schemas/user";
+import type { Registration } from "@/lib/schemas/registration";
+import { userRoleSchema, userSchema, type User } from "@/lib/schemas/user";
 import { fetchEntraName } from "./graph";
 import { refuseSignIn } from "./sign-in-policy";
 import { roleFromUpn } from "./upn";
@@ -56,6 +59,54 @@ function resolveName(claims: EntraClaims, localPart: string) {
   };
 }
 
+/** What a registration copies off the user record, derived so a field added there reaches this. */
+type StoredIdentity = Pick<Registration, "firstName" | "lastName" | "email">;
+
+/**
+ * Carries a corrected name into the registrations this student already holds (US-26).
+ *
+ * The copy on a registration is what lets the report, the board and both exports read a name
+ * without joining to `users`. This is the repair that makes the copy safe: it is not a snapshot
+ * that drifts, it is one that can never be more than a login out of date.
+ *
+ * Only a field that actually differs is written, so a login that changes nothing writes nothing
+ * and wakes no teacher's subscription to say so. Registrations in an archived series are left
+ * alone, because an archived series is read-only in everything it holds (US-19) — a name in last
+ * year's report is a record of what was true then.
+ */
+async function refreshRegistrations(upn: string, identity: StoredIdentity): Promise<void> {
+  const held = await adminDb
+    .collectionGroup(COLLECTIONS.registrations)
+    .where("studentUpn", "==", upn)
+    .get();
+  if (held.empty) return;
+
+  const series = new Map<string, DocumentReference>();
+  for (const registration of held.docs) {
+    const owner = registration.ref.parent.parent;
+    if (owner) series.set(owner.id, owner);
+  }
+
+  const archived = new Set(
+    (await Promise.all([...series.values()].map((owner) => owner.get())))
+      .filter((owner) => owner.data()?.isArchived === true)
+      .map((owner) => owner.id),
+  );
+
+  const operations = held.docs.flatMap((registration): BatchOperation[] => {
+    const owner = registration.ref.parent.parent;
+    if (!owner || archived.has(owner.id)) return [];
+
+    const stored = registration.data();
+    const corrections = Object.entries(identity).filter(([field, name]) => stored[field] !== name);
+    if (corrections.length === 0) return [];
+
+    return [(batch) => batch.update(registration.ref, Object.fromEntries(corrections))];
+  });
+
+  await commitInChunks(operations);
+}
+
 /**
  * Creates the user record on first login and keeps the role custom claim in sync (US-1, US-3).
  * Runs server-side only — the Admin SDK bypasses Security Rules, which deny client writes to `users`.
@@ -99,6 +150,11 @@ export async function provisionUser(
   }
 
   const user = userSchema.parse({ id: upn, firstName, lastName, email: upn, role });
+
+  // Only a student holds registrations: a teacher keeps none of their own (US-15).
+  if (role === userRoleSchema.enum.student) {
+    await refreshRegistrations(upn, { firstName, lastName, email: upn });
+  }
 
   if (claims.role !== role) {
     await adminAuth.setCustomUserClaims(claims.uid, { role });

--- a/src/lib/event-series/event-series-service.test.ts
+++ b/src/lib/event-series/event-series-service.test.ts
@@ -6,6 +6,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeFirestore } from "@/test/fake-firestore";
 import { storedEventSeries } from "@/test/event-series";
+import { registrationPath } from "@/lib/registration/registration";
 
 const firestore = new FakeFirestore();
 
@@ -230,7 +231,7 @@ describe("updateEventSeries — exactly one active event series", () => {
 describe("updateEventSeries — archiving", () => {
   it("archives an event series with registrations", async () => {
     seedEventSeries("s1");
-    firestore.seed("registrations", "m1", { eventSeriesId: "s1", studentId: "u1" });
+    firestore.seed(registrationPath("s1"), "m1", { studentUpn: "u1" });
 
     await updateEventSeries("s1", { isArchived: true });
 
@@ -239,7 +240,7 @@ describe("updateEventSeries — archiving", () => {
 
   it("self-heals a stale hasRegistrations flag while archiving, since the client relies on it", async () => {
     seedEventSeries("s1", { hasRegistrations: false });
-    firestore.seed("registrations", "m1", { eventSeriesId: "s1", studentId: "u1" });
+    firestore.seed(registrationPath("s1"), "m1", { studentUpn: "u1" });
 
     await updateEventSeries("s1", { isArchived: true });
 
@@ -269,7 +270,7 @@ describe("updateEventSeries — archiving", () => {
 
   it("archives an event series deactivated in the same call", async () => {
     seedEventSeries("s1", { isActive: true });
-    firestore.seed("registrations", "m1", { eventSeriesId: "s1", studentId: "u1" });
+    firestore.seed(registrationPath("s1"), "m1", { studentUpn: "u1" });
 
     await updateEventSeries("s1", { isActive: false, isArchived: true });
 
@@ -304,7 +305,7 @@ describe("updateEventSeries — archiving", () => {
 describe("deleteEventSeries", () => {
   it("refuses to delete an unarchived event series that still has registrations", async () => {
     seedEventSeries("s1");
-    firestore.seed("registrations", "m1", { eventSeriesId: "s1", studentId: "u1" });
+    firestore.seed(registrationPath("s1"), "m1", { studentUpn: "u1" });
 
     await expect(deleteEventSeries("s1")).rejects.toMatchObject({ code: "CONFLICT" });
     expect(firestore.get("eventSeries", "s1")).toBeDefined();
@@ -312,7 +313,7 @@ describe("deleteEventSeries", () => {
 
   it("refuses to delete an active event series that still has registrations", async () => {
     seedEventSeries("s1", { isActive: true });
-    firestore.seed("registrations", "m1", { eventSeriesId: "s1", studentId: "u1" });
+    firestore.seed(registrationPath("s1"), "m1", { studentUpn: "u1" });
 
     await expect(deleteEventSeries("s1")).rejects.toMatchObject({ code: "CONFLICT" });
   });
@@ -347,12 +348,12 @@ describe("deleteEventSeries", () => {
 
   it("deletes an archived event series that still has registrations", async () => {
     seedEventSeries("s1", { isArchived: true });
-    firestore.seed("registrations", "m1", { eventSeriesId: "s1", studentId: "u1" });
+    firestore.seed(registrationPath("s1"), "m1", { studentUpn: "u1" });
 
     await deleteEventSeries("s1");
 
     expect(firestore.get("eventSeries", "s1")).toBeUndefined();
-    expect(firestore.count("registrations")).toBe(0);
+    expect(firestore.count(registrationPath("s1"))).toBe(0);
   });
 
   it("takes the events of the event series with it, since they are fields of its document", async () => {
@@ -365,63 +366,62 @@ describe("deleteEventSeries", () => {
 
   it("deletes every registration of the event series", async () => {
     seedEventSeries("s1", { isArchived: true });
-    firestore.seed("registrations", "m1", {
-      eventSeriesId: "s1",
-      studentId: "u1",
+    firestore.seed(registrationPath("s1"), "m1", {
+      studentUpn: "u1",
       emergencyContact: { firstName: "Maria", lastName: "Muster" },
       rentedEquipment: ["Ski"],
     });
 
     await deleteEventSeries("s1");
 
-    expect(firestore.count("registrations")).toBe(0);
+    expect(firestore.count(registrationPath("s1"))).toBe(0);
   });
 
   it("leaves documents of other event series untouched", async () => {
     seedEventSeries("s1", { isArchived: true, events: ["Montafon"] });
     seedEventSeries("s2", { events: ["Behalten"] });
-    firestore.seed("registrations", "m1", { eventSeriesId: "s1", studentId: "u1" });
-    firestore.seed("registrations", "keep", { eventSeriesId: "s2", studentId: "u2" });
+    firestore.seed(registrationPath("s1"), "m1", { studentUpn: "u1" });
+    firestore.seed(registrationPath("s2"), "keep", { studentUpn: "u2" });
 
     await deleteEventSeries("s1");
 
     expect(firestore.get("eventSeries", "s2")).toMatchObject({ events: ["Behalten"] });
-    expect(Object.keys(firestore.docs("registrations"))).toEqual(["keep"]);
+    expect(Object.keys(firestore.docs(registrationPath("s2")))).toEqual(["keep"]);
   });
 
   it("chunks the cascade into batches no larger than the Firestore limit", async () => {
     seedEventSeries("s1", { isArchived: true });
     for (let index = 0; index < 1200; index += 1) {
-      firestore.seed("registrations", `m${index}`, { eventSeriesId: "s1", studentId: `u${index}` });
+      firestore.seed(registrationPath("s1"), `m${index}`, { studentUpn: `u${index}` });
     }
 
     await deleteEventSeries("s1");
 
-    expect(firestore.count("registrations")).toBe(0);
+    expect(firestore.count(registrationPath("s1"))).toBe(0);
     expect(Math.max(...firestore.batchSizes)).toBeLessThanOrEqual(500);
     expect(firestore.commitCount).toBeGreaterThan(2);
   });
 
   it("is retry-safe: deleting the leftovers of a half-finished cascade still succeeds", async () => {
     seedEventSeries("s1", { isArchived: true });
-    firestore.seed("registrations", "orphan", { eventSeriesId: "s1", studentId: "u1" });
+    firestore.seed(registrationPath("s1"), "orphan", { studentUpn: "u1" });
 
     await deleteEventSeries("s1");
     seedEventSeries("s1", { isArchived: true });
-    firestore.seed("registrations", "orphan", { eventSeriesId: "s1", studentId: "u1" });
+    firestore.seed(registrationPath("s1"), "orphan", { studentUpn: "u1" });
 
     await expect(deleteEventSeries("s1")).resolves.toBeUndefined();
-    expect(firestore.count("registrations")).toBe(0);
+    expect(firestore.count(registrationPath("s1"))).toBe(0);
   });
 
   it("removes the event series only after its dependants are gone", async () => {
     seedEventSeries("s1", { isArchived: true });
-    firestore.seed("registrations", "m1", { eventSeriesId: "s1", studentId: "u1" });
+    firestore.seed(registrationPath("s1"), "m1", { studentUpn: "u1" });
 
     await deleteEventSeries("s1");
 
     expect(firestore.get("eventSeries", "s1")).toBeUndefined();
-    expect(firestore.count("registrations")).toBe(0);
+    expect(firestore.count(registrationPath("s1"))).toBe(0);
   });
 });
 
@@ -463,7 +463,7 @@ describe("event series names are unique", () => {
 
   it("lets an event series keep its own name while another field changes", async () => {
     seedEventSeries("s1", { name: "Winter 2026" });
-    firestore.seed("registrations", "m1", { eventSeriesId: "s1", studentId: "u1" });
+    firestore.seed(registrationPath("s1"), "m1", { studentUpn: "u1" });
 
     await expect(
       updateEventSeries("s1", { name: "Winter 2026", isArchived: true }),

--- a/src/lib/event-series/event-series-service.ts
+++ b/src/lib/event-series/event-series-service.ts
@@ -13,6 +13,7 @@ import { normalizeName } from "@/lib/firebase/name-key";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
 import { COLLECTIONS } from "@/lib/schemas/collections";
+import { registrationPath } from "@/lib/registration/registration";
 import { eventSeriesSchema, type EventSeries } from "@/lib/schemas/event-series";
 
 const nameSchema = eventSeriesSchema.shape.name;
@@ -168,10 +169,10 @@ export async function updateEventSeries(
     // registration themselves (see firestore.rules).
     let hasRegistrations = current.hasRegistrations;
     if (wantsArchival) {
-      const masterData = await transaction.get(
-        adminDb.collection(COLLECTIONS.registrations).where("eventSeriesId", "==", id).limit(1),
+      const registrations = await transaction.get(
+        adminDb.collection(registrationPath(id)).limit(1),
       );
-      if (masterData.empty) {
+      if (registrations.empty) {
         throw new ServiceError(
           ErrorCode.Conflict,
           "Eine Eventreihe ohne Anmeldungen kann nicht archiviert werden.",
@@ -216,12 +217,9 @@ export async function deleteEventSeries(id: string): Promise<void> {
 
   const eventSeries = eventSeriesSchema.parse({ id, ...snapshot.data() });
 
-  const masterDataSnapshot = await adminDb
-    .collection(COLLECTIONS.registrations)
-    .where("eventSeriesId", "==", id)
-    .get();
+  const registrationsSnapshot = await adminDb.collection(registrationPath(id)).get();
 
-  if (!eventSeries.isArchived && !masterDataSnapshot.empty) {
+  if (!eventSeries.isArchived && !registrationsSnapshot.empty) {
     throw new ServiceError(
       ErrorCode.Conflict,
       "Eine Eventreihe mit Anmeldungen kann nur gelöscht werden, wenn sie archiviert ist.",
@@ -232,7 +230,7 @@ export async function deleteEventSeries(id: string): Promise<void> {
   // deleting it takes them along — there is nothing hanging off it to clean up separately.
   // The lists the series maintained, its events among them, are fields of the document itself
   // and go with it (US-21).
-  const operations: BatchOperation[] = masterDataSnapshot.docs.map(
+  const operations: BatchOperation[] = registrationsSnapshot.docs.map(
     (record) => (batch) => batch.delete(record.ref),
   );
   await commitInChunks(operations);

--- a/src/lib/event-series/event-series-state.test.ts
+++ b/src/lib/event-series/event-series-state.test.ts
@@ -6,7 +6,6 @@
 import { describe, expect, it } from "vitest";
 import {
   activeEventSeriesOf,
-  isRecordArchived,
   EVENT_SERIES_STATE_LABELS,
   eventSeriesState,
   visibleEventSeries,
@@ -68,26 +67,6 @@ describe("visibleEventSeries", () => {
     const list = [eventSeries("a", { isActive: true })];
 
     expect(visibleEventSeries(list, false)).toHaveLength(1);
-  });
-});
-
-describe("isRecordArchived", () => {
-  it("reports a record of an archived event series as archived", () => {
-    const list = [eventSeries("s1", { isArchived: true })];
-
-    expect(isRecordArchived({ eventSeriesId: "s1" }, list)).toBe(true);
-  });
-
-  it("reports a record of a live event series as not archived", () => {
-    const list = [eventSeries("s1")];
-
-    expect(isRecordArchived({ eventSeriesId: "s1" }, list)).toBe(false);
-  });
-
-  it("treats a record whose event series is unknown as not archived", () => {
-    expect(
-      isRecordArchived({ eventSeriesId: "ghost" }, [eventSeries("s1", { isArchived: true })]),
-    ).toBe(false);
   });
 });
 

--- a/src/lib/event-series/event-series-state.ts
+++ b/src/lib/event-series/event-series-state.ts
@@ -42,18 +42,6 @@ export function visibleEventSeries<T extends Pick<EventSeries, "isArchived">>(
 }
 
 /**
- * A registration carries no archived flag of its own — its state is derived from the
- * event series it belongs to (US-4, US-11), so archiving an event series locks its records in one write.
- */
-export function isRecordArchived(
-  record: { eventSeriesId: string },
-  allEventSeries: Pick<EventSeries, "id" | "isArchived">[],
-): boolean {
-  const eventSeries = allEventSeries.find((candidate) => candidate.id === record.eventSeriesId);
-  return eventSeries?.isArchived ?? false;
-}
-
-/**
  * Registration, the assignment dialog and the report all bind to the active event series.
  * Having none is a legitimate state a teacher creates by deactivating (US-4) — callers then
  * lock their view instead — whereas an ambiguous result is a data defect and must surface loudly.

--- a/src/lib/events/event-service.test.ts
+++ b/src/lib/events/event-service.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeFirestore } from "@/test/fake-firestore";
 import { storedEventSeries } from "@/test/event-series";
 import type { EventSeries } from "@/lib/schemas/event-series";
+import { registrationPath } from "@/lib/registration/registration";
 
 const firestore = new FakeFirestore();
 
@@ -28,7 +29,7 @@ const storedEvents = (id: string) => firestore.get("eventSeries", id)?.events;
 
 /** A registration names the event it is assigned to, exactly as it names its class (US-11). */
 function seedRegistration(id: string, eventSeriesId: string, answers: Record<string, unknown>) {
-  firestore.seed("registrations", id, { userId: `u-${id}`, eventSeriesId, ...answers });
+  firestore.seed(registrationPath(eventSeriesId), id, { studentUpn: id, ...answers });
 }
 
 describe("createEvent", () => {
@@ -192,8 +193,8 @@ describe("updateEvent", () => {
 
     await updateEvent("s1", "Woche 1", { name: "Semesterwoche" });
 
-    expect(firestore.get("registrations", "m1")).toMatchObject({ event: "Semesterwoche" });
-    expect(firestore.get("registrations", "m2")).toMatchObject({ event: null });
+    expect(firestore.get(registrationPath("s1"), "m1")).toMatchObject({ event: "Semesterwoche" });
+    expect(firestore.get(registrationPath("s1"), "m2")).toMatchObject({ event: null });
   });
 
   it("leaves the registrations of another event series alone", async () => {
@@ -203,7 +204,7 @@ describe("updateEvent", () => {
 
     await updateEvent("s1", "Woche 1", { name: "Semesterwoche" });
 
-    expect(firestore.get("registrations", "other")).toMatchObject({ event: "Woche 1" });
+    expect(firestore.get(registrationPath("s2"), "other")).toMatchObject({ event: "Woche 1" });
   });
 });
 
@@ -265,8 +266,8 @@ describe("deleteEvent", () => {
 
     await deleteEvent("s1", "Woche 1");
 
-    expect(firestore.get("registrations", "m1")).toMatchObject({ event: null });
-    expect(firestore.get("registrations", "m2")).toMatchObject({ event: null });
+    expect(firestore.get(registrationPath("s1"), "m1")).toMatchObject({ event: null });
+    expect(firestore.get(registrationPath("s1"), "m2")).toMatchObject({ event: null });
   });
 
   it("keeps the registration records themselves", async () => {
@@ -275,7 +276,7 @@ describe("deleteEvent", () => {
 
     await deleteEvent("s1", "Woche 1");
 
-    expect(firestore.count("registrations")).toBe(1);
+    expect(firestore.count(registrationPath("s1"))).toBe(1);
   });
 
   it("changes no answer other than the assignment", async () => {
@@ -288,9 +289,8 @@ describe("deleteEvent", () => {
 
     await deleteEvent("s1", "Woche 1");
 
-    expect(firestore.get("registrations", "m1")).toEqual({
-      userId: "u-m1",
-      eventSeriesId: "s1",
+    expect(firestore.get(registrationPath("s1"), "m1")).toEqual({
+      studentUpn: "m1",
       event: null,
       skillLevel: "Fortgeschritten",
       isAttendingSportsWeek: true,
@@ -304,7 +304,7 @@ describe("deleteEvent", () => {
 
     await deleteEvent("s1", "Woche 1");
 
-    expect(firestore.get("registrations", "keep")).toMatchObject({ event: "Woche 2" });
+    expect(firestore.get(registrationPath("s1"), "keep")).toMatchObject({ event: "Woche 2" });
   });
 
   it("leaves the same name in another event series assigned", async () => {
@@ -314,7 +314,7 @@ describe("deleteEvent", () => {
 
     await deleteEvent("s1", "Woche 1");
 
-    expect(firestore.get("registrations", "other")).toMatchObject({ event: "Woche 1" });
+    expect(firestore.get(registrationPath("s2"), "other")).toMatchObject({ event: "Woche 1" });
     expect(storedEvents("s2")).toEqual(["Woche 1"]);
   });
 
@@ -327,7 +327,7 @@ describe("deleteEvent", () => {
     await deleteEvent("s1", "Woche 1");
 
     expect(Math.max(...firestore.batchSizes)).toBeLessThanOrEqual(500);
-    const stillAssigned = Object.values(firestore.docs("registrations")).filter(
+    const stillAssigned = Object.values(firestore.docs(registrationPath("s1"))).filter(
       (record) => record.event === "Woche 1",
     );
     expect(stillAssigned).toHaveLength(0);

--- a/src/lib/events/event-service.ts
+++ b/src/lib/events/event-service.ts
@@ -10,6 +10,7 @@ import { normalizeName } from "@/lib/firebase/name-key";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
 import { COLLECTIONS } from "@/lib/schemas/collections";
+import { registrationPath } from "@/lib/registration/registration";
 import { eventSeriesSchema, type EventSeries } from "@/lib/schemas/event-series";
 import { listItemNameSchema, namedListSchema } from "@/lib/schemas/master-data";
 
@@ -119,15 +120,12 @@ async function readEvent(eventSeriesId: string, event: string): Promise<string> 
  * nothing at all. An assignment used to be a reference, so it survived a rename and had to be
  * cleared on a delete; now that it is the name itself, both are the same write (US-4, US-12).
  *
- * Only the event series is queried for. The event is compared here, so that reaching the
- * registrations of one series needs no index beyond the one Firestore keeps by itself.
+ * The whole subcollection is read and the event compared here, so reaching the registrations of
+ * one series needs no index beyond the one Firestore keeps by itself.
  */
 async function reassign(eventSeriesId: string, event: string, next: string | null): Promise<void> {
   const wanted = normalizeName(event);
-  const found = await adminDb
-    .collection(COLLECTIONS.registrations)
-    .where("eventSeriesId", "==", eventSeriesId)
-    .get();
+  const found = await adminDb.collection(registrationPath(eventSeriesId)).get();
 
   const operations: BatchOperation[] = found.docs
     .filter((record) => {

--- a/src/lib/firebase/live-query.ts
+++ b/src/lib/firebase/live-query.ts
@@ -6,7 +6,14 @@
 "use client";
 
 import { onAuthStateChanged } from "firebase/auth";
-import { onSnapshot, type DocumentData, type Query } from "firebase/firestore";
+import {
+  onSnapshot,
+  type DocumentData,
+  type DocumentReference,
+  type DocumentSnapshot,
+  type Query,
+  type QuerySnapshot,
+} from "firebase/firestore";
 import { auth } from "@/lib/firebase/client";
 
 /** Long enough not to hammer Firestore while a rules deploy or a token refresh settles. */
@@ -22,25 +29,44 @@ type Params<T> = {
   onError: (message: string | null) => void;
 };
 
+type DocumentParams<T> = {
+  /** Names the document in console diagnostics. */
+  label: string;
+  buildReference: () => DocumentReference;
+  /** Returns null for a document that fails its schema, so half of one is never shown. */
+  parse: (id: string, data: DocumentData) => T | null;
+  onData: (item: T | null) => void;
+  onError: (message: string | null) => void;
+};
+
+type Recovery<S> = {
+  label: string;
+  subscribe: (onNext: (snapshot: S) => void, onFailure: (error: Error) => void) => () => void;
+  deliver: (snapshot: S) => void;
+  /** What a signed-out visitor is told, since there is nothing they may read. */
+  onSignedOut: () => void;
+  onError: (message: string | null) => void;
+};
+
 /**
- * A real-time subscription that survives the two things a bare `onSnapshot` does not.
+ * The two things a bare `onSnapshot` does not survive, in one place for both shapes of read.
  *
  * Firestore tears a listener down for good when it errors — a single permission denial
  * during a rules deploy or a token refresh leaves the UI stale until a full page reload,
  * which looks exactly like "writes succeed but the list never changes". So failures are
  * retried here instead of being terminal.
  *
- * It also waits for Firebase Auth before querying: subscribing while the SDK is still
+ * It also waits for Firebase Auth before reading: subscribing while the SDK is still
  * restoring the session from IndexedDB produces an unauthenticated read, and that failure
  * is what kills the listener in the first place.
  */
-export function subscribeWithRecovery<T>({
+function withRecovery<S>({
   label,
-  buildQuery,
-  parse,
-  onData,
+  subscribe,
+  deliver,
+  onSignedOut,
   onError,
-}: Params<T>): () => void {
+}: Recovery<S>): () => void {
   let unsubscribeSnapshot: (() => void) | null = null;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
@@ -54,19 +80,13 @@ export function subscribeWithRecovery<T>({
     }
   }
 
-  function subscribe() {
+  function start() {
     if (stopped) return;
 
-    unsubscribeSnapshot = onSnapshot(
-      buildQuery(),
+    unsubscribeSnapshot = subscribe(
       (snapshot) => {
         if (stopped) return;
-        onData(
-          snapshot.docs.flatMap((document) => {
-            const parsed = parse(document.id, document.data());
-            return parsed === null ? [] : [parsed];
-          }),
-        );
+        deliver(snapshot);
         onError(null);
       },
       (error) => {
@@ -77,7 +97,7 @@ export function subscribeWithRecovery<T>({
         unsubscribeSnapshot = null;
         retryTimer = setTimeout(() => {
           retryTimer = null;
-          subscribe();
+          start();
         }, RESUBSCRIBE_DELAY_MS);
       },
     );
@@ -88,11 +108,11 @@ export function subscribeWithRecovery<T>({
     dropSubscription();
 
     if (!user) {
-      onData([]);
+      onSignedOut();
       return;
     }
 
-    subscribe();
+    start();
   });
 
   return () => {
@@ -100,4 +120,51 @@ export function subscribeWithRecovery<T>({
     dropSubscription();
     unsubscribeAuth();
   };
+}
+
+/** A real-time query, retried past the failures that would otherwise end it for good. */
+export function subscribeWithRecovery<T>({
+  label,
+  buildQuery,
+  parse,
+  onData,
+  onError,
+}: Params<T>): () => void {
+  return withRecovery<QuerySnapshot>({
+    label,
+    subscribe: (onNext, onFailure) => onSnapshot(buildQuery(), onNext, onFailure),
+    deliver: (snapshot) =>
+      onData(
+        snapshot.docs.flatMap((document) => {
+          const parsed = parse(document.id, document.data());
+          return parsed === null ? [] : [parsed];
+        }),
+      ),
+    onSignedOut: () => onData([]),
+    onError,
+  });
+}
+
+/**
+ * The same, for a document read by its own id rather than found by a query. A document that
+ * does not exist reads as null: it is a legitimate answer wherever the id is derived rather
+ * than discovered, and the reader has to tell it apart from not having read yet.
+ */
+export function subscribeToDocument<T>({
+  label,
+  buildReference,
+  parse,
+  onData,
+  onError,
+}: DocumentParams<T>): () => void {
+  return withRecovery<DocumentSnapshot>({
+    label,
+    subscribe: (onNext, onFailure) => onSnapshot(buildReference(), onNext, onFailure),
+    deliver: (snapshot) => {
+      const data = snapshot.data();
+      onData(data === undefined ? null : parse(snapshot.id, data));
+    },
+    onSignedOut: () => onData(null),
+    onError,
+  });
 }

--- a/src/lib/master-data/master-data-service.test.ts
+++ b/src/lib/master-data/master-data-service.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeFirestore } from "@/test/fake-firestore";
 import { storedEventSeries } from "@/test/event-series";
 import type { EventSeries } from "@/lib/schemas/event-series";
+import { registrationPath } from "@/lib/registration/registration";
 
 const firestore = new FakeFirestore();
 
@@ -41,7 +42,7 @@ function storedList(field: keyof Omit<EventSeries, "id">) {
 
 /** A registration holds the plain text it selected (US-11), which is what the in-use rule reads. */
 function seedRegistration(id: string, answers: Record<string, unknown>) {
-  firestore.seed("registrations", id, { userId: `u-${id}`, eventSeriesId: ACTIVE, ...answers });
+  firestore.seed(registrationPath(ACTIVE), id, { studentUpn: id, ...answers });
 }
 
 describe("createMasterDataItem", () => {
@@ -316,11 +317,7 @@ describe("updateMasterDataItem", () => {
 
   it("leaves an item alone that only another event series' registrations select", async () => {
     seedActiveEventSeries({ classOptions: ["3AHIT"] });
-    firestore.seed("registrations", "other", {
-      userId: "u9",
-      eventSeriesId: "s2",
-      class: "3AHIT",
-    });
+    firestore.seed(registrationPath("s2"), "other", { studentUpn: "other", class: "3AHIT" });
 
     await updateMasterDataItem("classes", "3AHIT", { name: "3BHIT" });
 
@@ -454,7 +451,11 @@ describe("the transaction a list edit runs in", () => {
 
     await updateMasterDataItem("classes", "3AHIT", { name: "3BHIT" });
 
-    expect(order).toEqual(["read eventSeries", "read registrations", "write eventSeries"]);
+    expect(order).toEqual([
+      "read eventSeries",
+      `read ${registrationPath(ACTIVE)}`,
+      "write eventSeries",
+    ]);
   });
 
   it("asks again before deleting, so a hold taken since the list was read still counts", async () => {
@@ -464,7 +465,11 @@ describe("the transaction a list edit runs in", () => {
 
     await deleteMasterDataItem("classes", "3AHIT");
 
-    expect(order).toEqual(["read eventSeries", "read registrations", "write eventSeries"]);
+    expect(order).toEqual([
+      "read eventSeries",
+      `read ${registrationPath(ACTIVE)}`,
+      "write eventSeries",
+    ]);
   });
 
   /** One transaction, so the list the guard was asked about is the list that gets written. */

--- a/src/lib/master-data/usage-guard.test.ts
+++ b/src/lib/master-data/usage-guard.test.ts
@@ -15,6 +15,7 @@ vi.mock("@/lib/firebase/admin", () => ({
 }));
 
 const { assertEquipmentNotInUse, assertNotInUse, usageReport } = await import("./usage-guard");
+const { registrationPath } = await import("@/lib/registration/registration");
 const { adminDb } = await import("@/lib/firebase/admin");
 const { ServiceError } = await import("@/lib/service-error");
 
@@ -24,7 +25,7 @@ const SERIES = "s1";
 beforeEach(() => firestore.reset());
 
 function seedRegistration(id: string, eventSeriesId: string, answers: Record<string, unknown>) {
-  firestore.seed("registrations", id, { userId: `u-${id}`, eventSeriesId, ...answers });
+  firestore.seed(registrationPath(eventSeriesId), id, { studentUpn: id, ...answers });
 }
 
 /**

--- a/src/lib/master-data/usage-guard.ts
+++ b/src/lib/master-data/usage-guard.ts
@@ -9,11 +9,15 @@ import { adminDb } from "@/lib/firebase/admin";
 import { normalizeName } from "@/lib/firebase/name-key";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
-import { COLLECTIONS } from "@/lib/schemas/collections";
+import { registrationPath } from "@/lib/registration/registration";
 import { IN_USE_HINT, type MasterDataCategory } from "./categories";
 
 /**
  * A registration of this event series holding this exact value, if there is one.
+ *
+ * Scoped by path rather than by a filter, since a registration lives beneath the series it
+ * belongs to (US-26) — so this is one equality on one field, which Firestore's automatic
+ * single-field index serves, and the range it locks cannot reach another series at all.
  *
  * The equality is exact where names elsewhere compare normalized, and that is deliberate: a
  * student picks from the list, so what they store is the list's own spelling, and a list holds
@@ -21,11 +25,7 @@ import { IN_USE_HINT, type MasterDataCategory } from "./categories";
  * spelling could only arrive through a rename — which is what this guard refuses.
  */
 function holdersOf(eventSeriesId: string, field: string, name: string): Query {
-  return adminDb
-    .collection(COLLECTIONS.registrations)
-    .where("eventSeriesId", "==", eventSeriesId)
-    .where(field, "==", name)
-    .limit(1);
+  return adminDb.collection(registrationPath(eventSeriesId)).where(field, "==", name).limit(1);
 }
 
 /**
@@ -34,8 +34,7 @@ function holdersOf(eventSeriesId: string, field: string, name: string): Query {
  */
 function rentersOf(eventSeriesId: string, name: string): Query {
   return adminDb
-    .collection(COLLECTIONS.registrations)
-    .where("eventSeriesId", "==", eventSeriesId)
+    .collection(registrationPath(eventSeriesId))
     .where("rentedEquipment", "array-contains", name)
     .limit(1);
 }
@@ -106,12 +105,7 @@ export async function usageReport(
   category: MasterDataCategory,
   items: readonly { name: string; requiredEquipment?: readonly string[] }[],
 ): Promise<MasterDataUsageReport> {
-  const registrations = (
-    await adminDb
-      .collection(COLLECTIONS.registrations)
-      .where("eventSeriesId", "==", eventSeriesId)
-      .get()
-  ).docs;
+  const registrations = (await adminDb.collection(registrationPath(eventSeriesId)).get()).docs;
 
   const held = new Set(
     normalizedNames(registrations.map((record) => record.data()?.[category.usage.field])),

--- a/src/lib/registration/registration-service.test.ts
+++ b/src/lib/registration/registration-service.test.ts
@@ -15,16 +15,27 @@ vi.mock("@/lib/firebase/admin", () => ({
 }));
 
 const { saveRegistration } = await import("./registration-service");
-const { ANSWER_NO_LONGER_OFFERED_HINT, REGISTRATION_NOT_OPEN_HINT, recordIdFor } =
+const { ANSWER_NO_LONGER_OFFERED_HINT, REGISTRATION_NOT_OPEN_HINT, registrationPath } =
   await import("./registration");
 const { FOOD_OPTION_OTHER } = await import("@/lib/schemas/master-data");
 const { ServiceError } = await import("@/lib/service-error");
 
 const STUDENT = "jane.doe@student.htldornbirn.at";
-const RECORD_ID = recordIdFor("s1", STUDENT);
+const REGISTRATIONS = registrationPath("s1");
 
-beforeEach(() => firestore.reset());
+beforeEach(() => {
+  firestore.reset();
+  seedStudent(STUDENT, { firstName: "Jane", lastName: "Doe" });
+});
 afterEach(() => vi.restoreAllMocks());
+
+/**
+ * The name a registration carries is read from the user record rather than sent (US-26), so a
+ * student who can save is one the directory has already provisioned (US-1).
+ */
+function seedStudent(upn: string, name: { firstName: string; lastName: string }) {
+  firestore.seed("users", upn, { ...name, email: upn, role: "student" });
+}
 
 /**
  * Registering needs a class to pick from as much as it needs an event series (US-6, US-11), and
@@ -82,12 +93,34 @@ describe("saveRegistration", () => {
 
     await saveRegistration(STUDENT, attending);
 
-    expect(firestore.get("registrations", RECORD_ID)).toMatchObject({
-      userId: STUDENT,
-      eventSeriesId: "s1",
+    expect(firestore.get(REGISTRATIONS, STUDENT)).toMatchObject({
+      studentUpn: STUDENT,
       class: "3AHME",
       program: "Ski",
     });
+  });
+
+  /** A reader takes the name from the registration and never joins to `users` (US-26). */
+  it("copies the student's name and e-mail address off the user record", async () => {
+    seedEventSeries("s1", { isActive: true });
+
+    const record = await saveRegistration(STUDENT, attending);
+
+    expect(record).toMatchObject({ firstName: "Jane", lastName: "Doe", email: STUDENT });
+    expect(firestore.get(REGISTRATIONS, STUDENT)).toMatchObject({
+      firstName: "Jane",
+      lastName: "Doe",
+      email: STUDENT,
+    });
+  });
+
+  it("refuses to save for somebody the directory has never provisioned", async () => {
+    seedEventSeries("s1", { isActive: true });
+
+    await expect(saveRegistration("ghost@student.htldornbirn.at", attending)).rejects.toMatchObject(
+      { code: "NOT_FOUND" },
+    );
+    expect(firestore.count(REGISTRATIONS)).toBe(0);
   });
 
   it("returns the stored record, id and all", async () => {
@@ -95,16 +128,18 @@ describe("saveRegistration", () => {
 
     const record = await saveRegistration(STUDENT, attending);
 
-    expect(record).toMatchObject({ id: RECORD_ID, userId: STUDENT, eventSeriesId: "s1" });
+    expect(record).toMatchObject({ id: STUDENT, studentUpn: STUDENT });
   });
 
-  it("binds the record to the active event series, not to one the student names", async () => {
+  /** Which series a registration is in is where it is stored, not a field it carries (US-26). */
+  it("stores the record beneath the active event series, not one the student names", async () => {
     seedEventSeries("old");
     seedEventSeries("current", { isActive: true });
 
-    const record = await saveRegistration(STUDENT, attending);
+    await saveRegistration(STUDENT, attending);
 
-    expect(record.eventSeriesId).toBe("current");
+    expect(firestore.count(registrationPath("current"))).toBe(1);
+    expect(firestore.count(registrationPath("old"))).toBe(0);
   });
 
   it("updates the record a second save produces instead of adding another one", async () => {
@@ -113,17 +148,18 @@ describe("saveRegistration", () => {
     await saveRegistration(STUDENT, attending);
     await saveRegistration(STUDENT, { ...attending, class: "4AHME" });
 
-    expect(firestore.count("registrations")).toBe(1);
-    expect(firestore.get("registrations", RECORD_ID)).toMatchObject({ class: "4AHME" });
+    expect(firestore.count(REGISTRATIONS)).toBe(1);
+    expect(firestore.get(REGISTRATIONS, STUDENT)).toMatchObject({ class: "4AHME" });
   });
 
   it("keeps one record per student per event series", async () => {
     seedEventSeries("s1", { isActive: true });
+    seedStudent("john@student.htldornbirn.at", { firstName: "John", lastName: "Doe" });
 
     await saveRegistration(STUDENT, attending);
     await saveRegistration("john@student.htldornbirn.at", attending);
 
-    expect(firestore.count("registrations")).toBe(2);
+    expect(firestore.count(REGISTRATIONS)).toBe(2);
   });
 
   it("refuses to save while no event series is active", async () => {
@@ -133,7 +169,7 @@ describe("saveRegistration", () => {
       code: "CONFLICT",
       message: REGISTRATION_NOT_OPEN_HINT,
     });
-    expect(firestore.count("registrations")).toBe(0);
+    expect(firestore.count(REGISTRATIONS)).toBe(0);
   });
 
   /** The class is asked of every student, attending or not, so a list without one is unusable. */
@@ -144,7 +180,7 @@ describe("saveRegistration", () => {
       code: "CONFLICT",
       message: REGISTRATION_NOT_OPEN_HINT,
     });
-    expect(firestore.count("registrations")).toBe(0);
+    expect(firestore.count(REGISTRATIONS)).toBe(0);
   });
 
   /**
@@ -162,7 +198,7 @@ describe("saveRegistration", () => {
       code: "CONFLICT",
       message: ANSWER_NO_LONGER_OFFERED_HINT,
     });
-    expect(firestore.count("registrations")).toBe(0);
+    expect(firestore.count(REGISTRATIONS)).toBe(0);
   });
 
   it("asks the student to reload rather than storing an answer nothing offers", async () => {
@@ -214,7 +250,7 @@ describe("saveRegistration", () => {
         foodOtherText: "Laktosefrei",
       }),
     ).rejects.toMatchObject({ code: "CONFLICT", message: ANSWER_NO_LONGER_OFFERED_HINT });
-    expect(firestore.count("registrations")).toBe(0);
+    expect(firestore.count(REGISTRATIONS)).toBe(0);
   });
 
   it("stores nothing when an answer is malformed", async () => {
@@ -223,7 +259,7 @@ describe("saveRegistration", () => {
     await expect(
       saveRegistration(STUDENT, { ...attending, phoneNumber: "06601234567" }),
     ).rejects.toBeInstanceOf(ServiceError);
-    expect(firestore.count("registrations")).toBe(0);
+    expect(firestore.count(REGISTRATIONS)).toBe(0);
   });
 
   /** A registration is filled in over time, so an unanswered question is not a failed save. */
@@ -241,7 +277,7 @@ describe("saveRegistration", () => {
     const record = await saveRegistration(STUDENT, { ...attending, gender: null });
 
     expect(record.isIncomplete).toBe(true);
-    expect(firestore.get("registrations", RECORD_ID)).toMatchObject({ isIncomplete: true });
+    expect(firestore.get(REGISTRATIONS, STUDENT)).toMatchObject({ isIncomplete: true });
   });
 
   it("clears the mark once nothing is missing", async () => {
@@ -270,12 +306,12 @@ describe("saveRegistration", () => {
     ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
   });
 
-  it("refuses a record that names an event series or a student of its own", async () => {
+  it("refuses a record that names a student or a name of its own", async () => {
     seedEventSeries("s1", { isActive: true });
     const smuggled = {
       ...attending,
-      eventSeriesId: "other",
-      userId: "someone.else@htldornbirn.at",
+      studentUpn: "someone.else@htldornbirn.at",
+      firstName: "Someone",
     };
 
     await expect(saveRegistration(STUDENT, smuggled as RegistrationInput)).rejects.toMatchObject({
@@ -302,8 +338,8 @@ describe("saveRegistration", () => {
   it("leaves an existing event assignment alone while the student is attending", async () => {
     seedEventSeries("s1", { isActive: true });
     await saveRegistration(STUDENT, attending);
-    firestore.seed("registrations", RECORD_ID, {
-      ...firestore.get("registrations", RECORD_ID),
+    firestore.seed(REGISTRATIONS, STUDENT, {
+      ...firestore.get(REGISTRATIONS, STUDENT),
       event: "Woche 1",
     });
 
@@ -315,8 +351,8 @@ describe("saveRegistration", () => {
   it("gives up the event assignment when the student answers 'no' (US-11)", async () => {
     seedEventSeries("s1", { isActive: true });
     await saveRegistration(STUDENT, attending);
-    firestore.seed("registrations", RECORD_ID, {
-      ...firestore.get("registrations", RECORD_ID),
+    firestore.seed(REGISTRATIONS, STUDENT, {
+      ...firestore.get(REGISTRATIONS, STUDENT),
       event: "Woche 1",
     });
 
@@ -355,7 +391,7 @@ describe("saveRegistration", () => {
 
     expect(firestore.transactionCount).toBe(1);
     expect(writes.mock.calls.map(([write]) => write.ref.path)).toEqual([
-      `registrations/${RECORD_ID}`,
+      `${REGISTRATIONS}/${STUDENT}`,
       "eventSeries/s1",
     ]);
   });
@@ -367,7 +403,7 @@ describe("saveRegistration", () => {
     await saveRegistration(STUDENT, attending);
 
     expect(writes.mock.calls.map(([write]) => write.ref.path)).toEqual([
-      `registrations/${RECORD_ID}`,
+      `${REGISTRATIONS}/${STUDENT}`,
     ]);
   });
 });

--- a/src/lib/registration/registration-service.ts
+++ b/src/lib/registration/registration-service.ts
@@ -19,10 +19,11 @@ import {
   type RegistrationInput,
 } from "@/lib/schemas/registration";
 import { activeEventSeriesOf } from "@/lib/event-series/event-series-state";
+import { userSchema } from "@/lib/schemas/user";
 import { isRegistrationIncomplete } from "./completeness";
 import {
   ANSWER_NO_LONGER_OFFERED_HINT,
-  recordIdFor,
+  registrationPath,
   REGISTRATION_NOT_OPEN_HINT,
 } from "./registration";
 
@@ -94,28 +95,51 @@ function assertAnswersAreOffered(eventSeries: EventSeries, fields: RegistrationI
 }
 
 /**
+ * The three fields a reader needs and a student may not give (US-26). They are read from the
+ * user record rather than sent, and that record is corrected from the directory at every login
+ * (US-1) — which is what keeps this copy from being a snapshot that drifts.
+ */
+async function identityOf(studentUpn: string) {
+  const stored = await adminDb.collection(COLLECTIONS.users).doc(studentUpn).get();
+  const user = userSchema.safeParse({ id: studentUpn, ...stored.data() });
+
+  if (!user.success) {
+    throw new ServiceError(ErrorCode.NotFound, "Dieses Benutzerkonto gibt es nicht.");
+  }
+  return {
+    studentUpn,
+    firstName: user.data.firstName,
+    lastName: user.data.lastName,
+    email: user.data.email,
+  };
+}
+
+/**
  * Writes the student's registration for the active event series, whole.
  *
  * A student cannot write this collection at all (see firestore.rules), and this is why: the
- * event series is resolved here rather than sent, answering "no" gives up the event assignment a
- * teacher made (US-11, US-12), and the event series' `hasRegistrations` mirror has to follow along so
- * the teacher's list can decide about archiving without reading records it may not read (US-4).
+ * event series is resolved here rather than sent, the name is copied here rather than typed,
+ * answering "no" gives up the event assignment a teacher made (US-11, US-12), and the event
+ * series' `hasRegistrations` mirror has to follow along so the teacher's list can decide about
+ * archiving without reading records it may not read (US-4).
  *
  * It is one transaction rather than a batch because the answers are validated against the series
  * as it stands: reading that document inside the transaction is what makes a teacher's
- * concurrent list edit conflict rather than slip past.
+ * concurrent list edit conflict rather than slip past (US-27).
  */
 export async function saveRegistration(
-  userId: string,
+  studentUpn: string,
   input: RegistrationInput,
 ): Promise<Registration> {
   const fields = parseInput(input);
+  const identity = await identityOf(studentUpn);
 
   return adminDb.runTransaction(async (transaction) => {
     const eventSeries = await requireOpenRegistration(transaction);
 
-    const id = recordIdFor(eventSeries.id, userId);
-    const reference = adminDb.collection(COLLECTIONS.registrations).doc(id);
+    // The series is the path and the UPN is the id, so one registration per student per series
+    // holds by construction rather than by a check (US-26).
+    const reference = adminDb.collection(registrationPath(eventSeries.id)).doc(identity.studentUpn);
     const stored = await transaction.get(reference);
 
     assertAnswersAreOffered(eventSeries, fields);
@@ -125,15 +149,14 @@ export async function saveRegistration(
     const event = fields.isAttendingSportsWeek ? ((stored.data()?.event as string) ?? null) : null;
 
     const data = {
-      userId,
-      eventSeriesId: eventSeries.id,
+      ...identity,
       event,
       // Recomputed here rather than trusted from the client: it is what the report marks a
       // student by (US-13), so it has to follow the answers actually stored.
       isIncomplete: isRegistrationIncomplete(fields),
       ...fields,
     };
-    const record = registrationSchema.parse({ id, ...data });
+    const record = registrationSchema.parse({ id: identity.studentUpn, ...data });
 
     transaction.set(reference, data);
     if (!eventSeries.hasRegistrations) {

--- a/src/lib/registration/registration.test.ts
+++ b/src/lib/registration/registration.test.ts
@@ -6,32 +6,22 @@
 import { describe, expect, it } from "vitest";
 import {
   EMPTY_REGISTRATION,
-  recordIdFor,
+  registrationPath,
   REGISTRATION_NOT_OPEN_HINT,
   scopeRentalToProgram,
 } from "./registration";
 
-describe("recordIdFor", () => {
-  it("derives the id from the event series and the student", () => {
-    expect(recordIdFor("eventSeries1", "jane.doe@student.htldornbirn.at")).toBe(
-      "eventSeries1__jane.doe@student.htldornbirn.at",
-    );
+describe("registrationPath", () => {
+  it("puts a registration beneath the event series it belongs to (US-26)", () => {
+    expect(registrationPath("eventSeries1")).toBe("eventSeries/eventSeries1/registrations");
   });
 
   /**
-   * The point of deriving it: one student can hold exactly one record per event series without
-   * anyone having to query for it, because document ids are unique by construction.
+   * The point of deriving it: which series a registration is in is where it is stored rather
+   * than a field, so one student holds exactly one per series without anyone querying for it.
    */
-  it("gives the same student the same id for the same event series", () => {
-    expect(recordIdFor("eventSeries1", "jane@student.htldornbirn.at")).toBe(
-      recordIdFor("eventSeries1", "jane@student.htldornbirn.at"),
-    );
-  });
-
-  it("gives the same student a separate id per event series", () => {
-    expect(recordIdFor("eventSeries1", "jane@student.htldornbirn.at")).not.toBe(
-      recordIdFor("eventSeries2", "jane@student.htldornbirn.at"),
-    );
+  it("gives each event series its own collection", () => {
+    expect(registrationPath("eventSeries1")).not.toBe(registrationPath("eventSeries2"));
   });
 
   it("states the message US-11 asks for while registering is not open", () => {

--- a/src/lib/registration/registration.ts
+++ b/src/lib/registration/registration.ts
@@ -5,14 +5,15 @@
  */
 import type { Registration, RegistrationInput } from "@/lib/schemas/registration";
 import { EMPTY_EMERGENCY_CONTACT } from "@/lib/schemas/registration";
+import { COLLECTIONS } from "@/lib/schemas/collections";
 
 /**
- * A student holds exactly one record per event series, so the id is derived from both rather than
- * generated: document ids are unique by construction, which turns "does one exist yet?" into a
- * single-document read on the client and on the server alike (US-11).
+ * Where a student's registration for one event series lives. The series is the path and the UPN
+ * is the document id, so "does one exist yet?" is a single-document read rather than a query,
+ * and a student can hold exactly one per series by construction (US-11, US-26).
  */
-export function recordIdFor(eventSeriesId: string, userId: string): string {
-  return `${eventSeriesId}__${userId}`;
+export function registrationPath(eventSeriesId: string): string {
+  return `${COLLECTIONS.eventSeries}/${eventSeriesId}/${COLLECTIONS.registrations}`;
 }
 
 /**

--- a/src/lib/registration/use-registration.test.ts
+++ b/src/lib/registration/use-registration.test.ts
@@ -8,19 +8,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EventSeries } from "@/lib/schemas/event-series";
 import { storedEventSeries } from "@/test/event-series";
 
-type SnapshotHandler = (snapshot: { docs: { id: string; data: () => unknown }[] }) => void;
+type Snapshot = { id: string; data: () => unknown };
+type SnapshotHandler = (snapshot: Snapshot) => void;
 
 const onSnapshot = vi.fn();
 const onAuthStateChanged = vi.fn();
-const collection = vi.fn((_db: unknown, path: string) => path);
-const where = vi.fn((field: string, _op: string, value: unknown) => `where:${field}=${value}`);
+const doc = vi.fn((_db: unknown, path: string, id: string) => `${path}/${id}`);
 const useEventSeries = vi.fn();
 
 vi.mock("firebase/firestore", () => ({
-  collection: (...args: unknown[]) => collection(args[0], args[1] as string),
+  doc: (...args: unknown[]) => doc(args[0], args[1] as string, args[2] as string),
   onSnapshot,
-  query: vi.fn((...args: unknown[]) => args),
-  where: (...args: unknown[]) => where(args[0] as string, args[1] as string, args[2]),
 }));
 
 vi.mock("firebase/auth", () => ({ onAuthStateChanged }));
@@ -40,41 +38,47 @@ function signIn() {
   act(() => (onAuthStateChanged.mock.calls.at(-1)![1] as (user: unknown) => void)({ uid: "u1" }));
 }
 
-function emit(docs: { id: string; data: () => unknown }[]) {
-  act(() => (onSnapshot.mock.calls.at(-1)![1] as SnapshotHandler)({ docs }));
+/** What Firestore hands back for a document that is not there — how every student starts. */
+const MISSING: Snapshot = { id: STUDENT, data: () => undefined };
+
+function emit(snapshot: Snapshot) {
+  act(() => (onSnapshot.mock.calls.at(-1)![1] as SnapshotHandler)(snapshot));
 }
 
 function fail(message: string) {
   act(() => (onSnapshot.mock.calls.at(-1)![2] as (error: Error) => void)(new Error(message)));
 }
 
-function storedRecord(eventSeriesId: string, className: string) {
+function storedRecord(className: string): Snapshot {
   return {
-    userId: STUDENT,
-    eventSeriesId,
-    event: null,
-    isAttendingSportsWeek: true,
-    class: className,
-    program: null,
-    skillLevel: null,
-    busPickupPoint: null,
-    foodOption: null,
-    foodOtherText: null,
-    seasonPassOption: null,
-    dateOfBirth: null,
-    gender: null,
-    phoneNumber: null,
-    healthNotes: null,
-    hasMedication: null,
-    equipmentRentalNeeded: null,
-    rentedEquipment: [],
-    shoeSize: null,
-    heightCm: null,
-    weightKg: null,
+    id: STUDENT,
+    data: () => ({
+      studentUpn: STUDENT,
+      firstName: "Jane",
+      lastName: "Doe",
+      email: STUDENT,
+      event: null,
+      isAttendingSportsWeek: true,
+      class: className,
+      program: null,
+      skillLevel: null,
+      busPickupPoint: null,
+      foodOption: null,
+      foodOtherText: null,
+      seasonPassOption: null,
+      dateOfBirth: null,
+      gender: null,
+      phoneNumber: null,
+      healthNotes: null,
+      hasMedication: null,
+      equipmentRentalNeeded: null,
+      rentedEquipment: [],
+      shoeSize: null,
+      heightCm: null,
+      weightKg: null,
+    }),
   };
 }
-
-const doc = (id: string, data: unknown) => ({ id, data: () => data });
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -103,7 +107,7 @@ describe("useRegistration", () => {
     await waitFor(() => expect(result.current.eventSeries?.id).toBe("s1"));
   });
 
-  it("reports no event series while none is active", async () => {
+  it("reports no event series while none is active, and reads nothing", async () => {
     useEventSeries.mockReturnValue({
       eventSeries: [eventSeries("s1", false)],
       loading: false,
@@ -111,25 +115,24 @@ describe("useRegistration", () => {
     });
 
     const { result } = renderHook(() => useRegistration(STUDENT));
-    signIn();
-    emit([]);
 
     await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(onAuthStateChanged).not.toHaveBeenCalled();
+    expect(onSnapshot).not.toHaveBeenCalled();
     expect(result.current.eventSeries).toBeNull();
     expect(result.current.record).toBeNull();
   });
 
   /**
-   * Rules deny a read of a document that does not exist — there is no `resource` to check
-   * ownership against — and not having registered yet is where every student starts. Asking for
-   * the student's records rather than for the one id they could derive answers "none" instead.
+   * Both halves of "which one is mine?" are known before the read: the series is the path and
+   * the UPN is the document's own name (US-26), which is also what the rule owns it by — so a
+   * student may read one that does not exist yet.
    */
-  it("asks for the records belonging to this student", () => {
+  it("reads its own document beneath the active event series", () => {
     renderHook(() => useRegistration(STUDENT));
     signIn();
 
-    expect(collection).toHaveBeenCalledWith(expect.anything(), "registrations");
-    expect(where).toHaveBeenCalledWith("userId", "==", STUDENT);
+    expect(doc).toHaveBeenCalledWith(expect.anything(), "eventSeries/s1/registrations", STUDENT);
   });
 
   it("waits for Firebase Auth before reading, so the session is restored first", () => {
@@ -142,26 +145,16 @@ describe("useRegistration", () => {
     const { result } = renderHook(() => useRegistration(STUDENT));
     signIn();
 
-    emit([doc(`s1__${STUDENT}`, storedRecord("s1", "3AHME"))]);
+    emit(storedRecord("3AHME"));
 
     await waitFor(() => expect(result.current.record?.class).toBe("3AHME"));
-  });
-
-  it("ignores what the student registered for in another event series", async () => {
-    const { result } = renderHook(() => useRegistration(STUDENT));
-    signIn();
-
-    emit([doc(`s0__${STUDENT}`, storedRecord("s0", "2AHME"))]);
-
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.record).toBeNull();
   });
 
   it("returns no record for a student who has not registered yet", async () => {
     const { result } = renderHook(() => useRegistration(STUDENT));
     signIn();
 
-    emit([]);
+    emit(MISSING);
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.record).toBeNull();
@@ -172,7 +165,7 @@ describe("useRegistration", () => {
     const { result } = renderHook(() => useRegistration(STUDENT));
     signIn();
 
-    emit([doc(`s1__${STUDENT}`, { eventSeriesId: "s1", class: 42 })]);
+    emit({ id: STUDENT, data: () => ({ studentUpn: STUDENT, class: 42 }) });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.record).toBeNull();

--- a/src/lib/registration/use-registration.ts
+++ b/src/lib/registration/use-registration.ts
@@ -6,14 +6,14 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { collection, query, where } from "firebase/firestore";
+import { doc } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
-import { subscribeWithRecovery } from "@/lib/firebase/live-query";
-import { COLLECTIONS } from "@/lib/schemas/collections";
+import { subscribeToDocument } from "@/lib/firebase/live-query";
 import { registrationSchema, type Registration } from "@/lib/schemas/registration";
 import type { EventSeries } from "@/lib/schemas/event-series";
 import { activeEventSeriesOf } from "@/lib/event-series/event-series-state";
 import { useEventSeries } from "@/lib/event-series/use-event-series";
+import { registrationPath } from "./registration";
 
 type RegistrationState = {
   /** The event series the student registers for, or null while a teacher has activated none (US-4). */
@@ -27,14 +27,17 @@ type RegistrationState = {
 /**
  * The student's own registration, read live through the client SDK (see firestore.rules).
  *
- * A query rather than a read of the derived id, even though the id is known: rules deny a read
- * of a document that does not exist, because there is no `resource` to check ownership against
- * — and not having registered yet is where every student starts. A query is evaluated per
- * document returned, so the same rule answers "none of them" instead of "no permission".
+ * The document is read by its own id rather than found by a query: it lives beneath the series
+ * it belongs to and is named after the student, so both halves of "which one is mine?" are
+ * known before the read (US-26). That is also what lets a student read one that does not exist
+ * yet — where every student starts — since the rule owns them by the document's name rather
+ * than by a field only an existing document would have.
  */
-export function useRegistration(userId: string): RegistrationState {
+export function useRegistration(studentUpn: string): RegistrationState {
   const { eventSeries, loading: eventSeriesLoading, error: eventSeriesError } = useEventSeries();
-  const [records, setRecords] = useState<Registration[] | null>(null);
+  // Undefined while the read is still outstanding, which is what null cannot say: null is the
+  // answer for a student who has not registered yet.
+  const [record, setRecord] = useState<Registration | null | undefined>(undefined);
   const [recordError, setRecordError] = useState<string | null>(null);
 
   // Two active event series is a data defect the student cannot act on, so it is reported rather
@@ -52,34 +55,30 @@ export function useRegistration(userId: string): RegistrationState {
 
   const eventSeriesId = active.eventSeries?.id ?? null;
 
-  useEffect(
-    () =>
-      subscribeWithRecovery<Registration>({
-        label: COLLECTIONS.registrations,
-        buildQuery: () =>
-          query(collection(db, COLLECTIONS.registrations), where("userId", "==", userId)),
-        parse: (id, data) => {
-          const parsed = registrationSchema.safeParse({ id, ...data });
-          if (!parsed.success) {
-            console.error(
-              `${COLLECTIONS.registrations}/${id} does not match the schema`,
-              parsed.error,
-            );
-            return null;
-          }
-          return parsed.data;
-        },
-        onData: setRecords,
-        onError: setRecordError,
-      }),
-    [userId],
-  );
+  useEffect(() => {
+    if (eventSeriesId === null) return;
+    const path = registrationPath(eventSeriesId);
+
+    return subscribeToDocument<Registration>({
+      label: `${path}/${studentUpn}`,
+      buildReference: () => doc(db, path, studentUpn),
+      parse: (id, data) => {
+        const parsed = registrationSchema.safeParse({ id, ...data });
+        if (!parsed.success) {
+          console.error(`${path}/${id} does not match the schema`, parsed.error);
+          return null;
+        }
+        return parsed.data;
+      },
+      onData: setRecord,
+      onError: setRecordError,
+    });
+  }, [eventSeriesId, studentUpn]);
 
   return {
     eventSeries: active.eventSeries,
-    // A student keeps one record per event series they have registered for; this is the current one.
-    record: records?.find((candidate) => candidate.eventSeriesId === eventSeriesId) ?? null,
-    loading: eventSeriesLoading || records === null,
+    record: record ?? null,
+    loading: eventSeriesLoading || (eventSeriesId !== null && record === undefined),
     error: eventSeriesError ?? active.error ?? recordError,
   };
 }

--- a/src/lib/schemas/registration.test.ts
+++ b/src/lib/schemas/registration.test.ts
@@ -21,9 +21,11 @@ const validContact = {
 };
 
 const validRecord = {
-  id: "smd-1",
-  userId: "jane.doe@student.htldornbirn.at",
-  eventSeriesId: "event series-1",
+  id: "jane.doe@student.htldornbirn.at",
+  studentUpn: "jane.doe@student.htldornbirn.at",
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane.doe@student.htldornbirn.at",
   event: null,
   isIncomplete: false,
   isAttendingSportsWeek: true,
@@ -52,8 +54,14 @@ describe("registrationSchema", () => {
     expect(registrationSchema.parse(validRecord)).toEqual(validRecord);
   });
 
-  it("binds the record to its event series through a genuine foreign key", () => {
-    expect(registrationSchema.safeParse({ ...validRecord, eventSeriesId: "" }).success).toBe(false);
+  /** The one identifying field it keeps, because a record naming nobody is owned by nobody. */
+  it("names the student it belongs to", () => {
+    expect(registrationSchema.safeParse({ ...validRecord, studentUpn: "" }).success).toBe(false);
+  });
+
+  /** The report, the board and both exports read the name from here rather than join (US-26). */
+  it.each(["firstName", "lastName", "email"])("carries the student's %s", (field) => {
+    expect(registrationSchema.safeParse({ ...validRecord, [field]: "" }).success).toBe(false);
   });
 
   it("stores a registration whose class has not been picked yet", () => {
@@ -175,10 +183,12 @@ describe("registrationSchema", () => {
 describe("registrationLockedFields", () => {
   it("locks the fields students must never write, so firestore.rules can deny them", () => {
     expect(Object.keys(registrationLockedFields.shape).sort()).toEqual([
+      "email",
       "event",
-      "eventSeriesId",
+      "firstName",
       "isIncomplete",
-      "userId",
+      "lastName",
+      "studentUpn",
     ]);
   });
 });
@@ -212,7 +222,7 @@ describe("registrationInputSchema", () => {
     expect(parse(attending).success).toBe(true);
   });
 
-  it.each(["id", "userId", "eventSeriesId", "event", "isIncomplete"])(
+  it.each(["id", "studentUpn", "firstName", "lastName", "email", "event", "isIncomplete"])(
     "refuses to take %s from the student, since the server owns it",
     (field) => {
       expect(parse({ ...attending, [field]: "smuggled" }).success).toBe(false);

--- a/src/lib/schemas/registration.ts
+++ b/src/lib/schemas/registration.ts
@@ -56,9 +56,21 @@ export const rentedEquipmentSchema = z
 
 const registrationFields = z.object({
   id: documentIdSchema,
-  userId: documentIdSchema,
-  // The only genuine reference on this record: it makes the archived state derivable (US-4, US-11).
-  eventSeriesId: documentIdSchema,
+  /**
+   * The one reference this record keeps, and the reason it keeps it: the access rules have to be
+   * able to say "yours" about a registration, and a record naming nobody could be owned by
+   * nobody (US-26). It is also the document's own id, so a student's registration in a series is
+   * reached without a query.
+   */
+  studentUpn: documentIdSchema,
+  /**
+   * Copied from the session on every save and refreshed at every login (US-1, US-26), so a
+   * reader needs no join: the report, the board, the overview and both exports read the name
+   * from here. Which event series a registration belongs to is where it is stored, not a field.
+   */
+  firstName: requiredText(100),
+  lastName: requiredText(100),
+  email: requiredText(320),
   /**
    * Teacher-managed assignment (US-12); null means unassigned. The event is named rather than
    * pointed at, like every other value chosen from one of the series' lists (US-11, US-21).
@@ -105,8 +117,10 @@ export type Registration = z.infer<typeof registrationSchema>;
 
 /** Set by the server on every save, so a student naming one of them is refused outright. */
 const SERVER_OWNED = {
-  userId: true,
-  eventSeriesId: true,
+  studentUpn: true,
+  firstName: true,
+  lastName: true,
+  email: true,
   event: true,
   isIncomplete: true,
 } as const;
@@ -117,7 +131,7 @@ export const registrationLockedFields = registrationFields.pick(SERVER_OWNED);
 /**
  * What a student may send. Derived from the record so a field added there cannot be forgotten
  * here, minus the id and everything the server owns — which is why the object is strict: a
- * smuggled `eventSeriesId` is a mistake worth reporting, not one worth silently dropping.
+ * smuggled name is a mistake worth reporting, not one worth silently dropping.
  */
 export const registrationInputSchema = registrationFields
   .omit({ id: true, ...SERVER_OWNED })

--- a/src/lib/students/roster.test.ts
+++ b/src/lib/students/roster.test.ts
@@ -3,87 +3,63 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { Registration } from "@/lib/schemas/registration";
-import type { User } from "@/lib/schemas/user";
-import { joinRoster } from "./roster";
+import { studentRecord } from "@/test/roster-student";
+import { toRoster } from "./roster";
 
-function user(id: string, firstName: string, lastName: string): User {
-  return { id, firstName, lastName, email: id, role: "student" };
-}
+function record(
+  firstName: string,
+  lastName: string,
+  overrides: Partial<Registration> = {},
+): Registration {
+  const upn = `${firstName}.${lastName}@student.htldornbirn.at`.toLowerCase();
 
-function record(userId: string, overrides: Partial<Registration> = {}): Registration {
-  return {
-    id: `s1__${userId}`,
-    userId,
-    eventSeriesId: "s1",
-    event: null,
-    isIncomplete: false,
-    isAttendingSportsWeek: true,
-    class: "5AHIF",
-    program: "Ski",
-    skillLevel: "Fortgeschritten",
-    busPickupPoint: null,
-    foodOption: null,
-    foodOtherText: null,
-    seasonPassOption: null,
-    dateOfBirth: null,
-    gender: "female",
-    phoneNumber: null,
-    emergencyContact: {
-      firstName: null,
-      lastName: null,
-      relationship: null,
-      relationshipOtherText: null,
-      phoneNumber: null,
-    },
-    healthNotes: null,
-    hasMedication: null,
-    equipmentRentalNeeded: null,
-    rentedEquipment: [],
-    shoeSize: null,
-    heightCm: null,
-    weightKg: null,
+  return studentRecord({
+    id: upn,
+    studentUpn: upn,
+    firstName,
+    lastName,
+    email: upn,
     ...overrides,
-  };
+  });
 }
 
-const ANNA = user("anna@student.htldornbirn.at", "Anna", "Muster");
-const BENE = user("bene@student.htldornbirn.at", "Bene", "Berger");
+const ANNA = record("Anna", "Muster");
 
-describe("joinRoster", () => {
-  it("takes the name from the user record, which is where it is kept (US-1, US-11)", () => {
-    const [student] = joinRoster([record(ANNA.id)], [ANNA]);
+describe("toRoster", () => {
+  it("takes the name from the registration, which is what carries it now (US-26)", () => {
+    const [student] = toRoster([ANNA]);
 
     expect(student).toMatchObject({
-      id: `s1__${ANNA.id}`,
-      userId: ANNA.id,
+      id: ANNA.id,
+      studentUpn: ANNA.studentUpn,
       firstName: "Anna",
       lastName: "Muster",
       class: "5AHIF",
       gender: "female",
       program: "Ski",
-      skillLevel: "Fortgeschritten",
+      skillLevel: "Profi",
       isAttending: true,
       event: null,
     });
   });
 
   it("carries the answer to the attendance question, whichever it is", () => {
-    const roster = joinRoster([record(ANNA.id, { isAttendingSportsWeek: false })], [ANNA]);
+    const roster = toRoster([record("Anna", "Muster", { isAttendingSportsWeek: false })]);
 
     expect(roster[0].isAttending).toBe(false);
   });
 
   it("carries the event a teacher has assigned", () => {
-    const roster = joinRoster([record(ANNA.id, { event: "Woche 1" })], [ANNA]);
+    const roster = toRoster([record("Anna", "Muster", { event: "Woche 1" })]);
 
     expect(roster[0].event).toBe("Woche 1");
   });
 
   it("carries whether equipment is rented, which the report filters by (US-11, US-13)", () => {
-    const renting = joinRoster([record(ANNA.id, { equipmentRentalNeeded: true })], [ANNA]);
-    const unasked = joinRoster([record(ANNA.id, { equipmentRentalNeeded: null })], [ANNA]);
+    const renting = toRoster([record("Anna", "Muster", { equipmentRentalNeeded: true })]);
+    const unasked = toRoster([record("Anna", "Muster", { equipmentRentalNeeded: null })]);
 
     expect(renting[0].equipmentRentalNeeded).toBe(true);
     expect(unasked[0].equipmentRentalNeeded).toBeNull();
@@ -92,48 +68,33 @@ describe("joinRoster", () => {
   it("carries both health answers, which the report filters on together (US-11, US-13)", () => {
     const stored = { healthNotes: "Asthma", hasMedication: true };
 
-    expect(joinRoster([record(ANNA.id, stored)], [ANNA])[0]).toMatchObject(stored);
+    expect(toRoster([record("Anna", "Muster", stored)])[0]).toMatchObject(stored);
   });
 
   it("carries the e-mail address, which the report's master line shows (US-13)", () => {
-    const roster = joinRoster([record(ANNA.id)], [ANNA]);
-
-    expect(roster[0].email).toBe(ANNA.email);
+    expect(toRoster([ANNA])[0].email).toBe(ANNA.email);
   });
 
   it("keeps the whole registration, which is what the report's detail lines read (US-13)", () => {
-    const stored = record(ANNA.id, { healthNotes: "Asthma", isIncomplete: true });
+    const stored = record("Anna", "Muster", { healthNotes: "Asthma", isIncomplete: true });
 
-    expect(joinRoster([stored], [ANNA])[0].record).toEqual(stored);
+    expect(toRoster([stored])[0].record).toEqual(stored);
   });
 
   it("sorts by last name, then first name, so a list can be read down", () => {
-    const clara = user("clara@student.htldornbirn.at", "Clara", "Berger");
-    const roster = joinRoster(
-      [record(ANNA.id), record(BENE.id), record(clara.id)],
-      [ANNA, BENE, clara],
-    );
+    const roster = toRoster([ANNA, record("Bene", "Berger"), record("Clara", "Berger")]);
 
     expect(roster.map((student) => student.firstName)).toEqual(["Bene", "Clara", "Anna"]);
   });
 
   it("sorts the way German does, so an umlaut does not fall off the end", () => {
-    const oesterle = user("o@student.htldornbirn.at", "Ida", "Österle");
-    const zerbst = user("z@student.htldornbirn.at", "Jan", "Zerbst");
-
-    const roster = joinRoster([record(zerbst.id), record(oesterle.id)], [zerbst, oesterle]);
+    const roster = toRoster([record("Jan", "Zerbst"), record("Ida", "Österle")]);
 
     expect(roster.map((student) => student.lastName)).toEqual(["Österle", "Zerbst"]);
   });
 
-  it("drops a record whose user is gone rather than showing a nameless row", () => {
-    const complain = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    expect(
-      joinRoster([record("ghost@student.htldornbirn.at"), record(ANNA.id)], [ANNA]),
-    ).toHaveLength(1);
-    expect(complain).toHaveBeenCalled();
-
-    complain.mockRestore();
+  /** The join could drop a row for want of a user record; a projection has nothing to miss. */
+  it("keeps every registration it is given", () => {
+    expect(toRoster([ANNA, record("Bene", "Berger")])).toHaveLength(2);
   });
 });

--- a/src/lib/students/roster.ts
+++ b/src/lib/students/roster.ts
@@ -5,12 +5,11 @@
  */
 import type { FilterableStudent } from "@/lib/filters/student-filter";
 import type { Registration } from "@/lib/schemas/registration";
-import type { User } from "@/lib/schemas/user";
 
 export type RosterStudent = FilterableStudent & {
   /** The registration, which is what an assignment is written to (US-12). */
   id: string;
-  userId: string;
+  studentUpn: string;
   /** On the report's master line, where it is the one contact detail always shown (US-13). */
   email: string;
   /**
@@ -24,50 +23,36 @@ export type RosterStudent = FilterableStudent & {
 const byName = new Intl.Collator("de-AT").compare;
 
 /**
- * One row per registration, named from the user record — the registration itself holds no name,
- * because a student never types theirs (US-1, US-11).
+ * One row per registration, named from the registration itself: it carries the student's name
+ * and e-mail address, written from the session on every save and corrected at every login
+ * (US-26), so a roster is a projection of one collection rather than a join to `users`.
  *
  * Sorted alphabetically rather than by a stored position: a teacher orders the lists they
  * maintain (see Ordering), but the students in them are looked up by name.
  */
-export function joinRoster(
-  records: readonly Registration[],
-  users: readonly User[],
-): RosterStudent[] {
-  const byId = new Map(users.map((user) => [user.id, user]));
-
+export function toRoster(records: readonly Registration[]): RosterStudent[] {
   return records
-    .flatMap((record) => {
-      const user = byId.get(record.userId);
-      if (!user) {
-        console.error(`No user record for ${record.userId}; leaving them out of the roster`);
-        return [];
-      }
-
-      return [
-        {
-          id: record.id,
-          userId: record.userId,
-          email: user.email,
-          record,
-          firstName: user.firstName,
-          lastName: user.lastName,
-          class: record.class,
-          gender: record.gender,
-          program: record.program,
-          skillLevel: record.skillLevel,
-          isAttending: record.isAttendingSportsWeek,
-          isIncomplete: record.isIncomplete,
-          event: record.event,
-          equipmentRentalNeeded: record.equipmentRentalNeeded,
-          healthNotes: record.healthNotes,
-          hasMedication: record.hasMedication,
-          busPickupPoint: record.busPickupPoint,
-          seasonPassOption: record.seasonPassOption,
-          foodOption: record.foodOption,
-        },
-      ];
-    })
+    .map((record) => ({
+      id: record.id,
+      studentUpn: record.studentUpn,
+      email: record.email,
+      record,
+      firstName: record.firstName,
+      lastName: record.lastName,
+      class: record.class,
+      gender: record.gender,
+      program: record.program,
+      skillLevel: record.skillLevel,
+      isAttending: record.isAttendingSportsWeek,
+      isIncomplete: record.isIncomplete,
+      event: record.event,
+      equipmentRentalNeeded: record.equipmentRentalNeeded,
+      healthNotes: record.healthNotes,
+      hasMedication: record.hasMedication,
+      busPickupPoint: record.busPickupPoint,
+      seasonPassOption: record.seasonPassOption,
+      foodOption: record.foodOption,
+    }))
     .sort(
       (left, right) =>
         byName(left.lastName, right.lastName) || byName(left.firstName, right.firstName),

--- a/src/lib/students/use-roster.test.ts
+++ b/src/lib/students/use-roster.test.ts
@@ -10,12 +10,12 @@ type Doc = { id: string; data: () => unknown };
 
 const onSnapshot = vi.fn();
 const onAuthStateChanged = vi.fn();
+const collection = vi.fn((_db: unknown, path: string) => path);
 
 vi.mock("firebase/firestore", () => ({
-  collection: (_db: unknown, path: string) => path,
+  collection: (...args: unknown[]) => collection(args[0], args[1] as string),
   onSnapshot,
   query: (...args: unknown[]) => args,
-  where: (field: string, _operator: string, value: unknown) => `where:${field}=${value}`,
 }));
 
 vi.mock("firebase/auth", () => ({ onAuthStateChanged }));
@@ -24,23 +24,18 @@ vi.mock("@/lib/firebase/client", () => ({ auth: {}, db: {} }));
 const { useRoster } = await import("./use-roster");
 
 const ANNA = "anna@student.htldornbirn.at";
+const REGISTRATIONS = "eventSeries/s1/registrations";
 
-function subscription(collectionPath: string) {
-  const call = onSnapshot.mock.calls.find(
-    ([builtQuery]) => (builtQuery as string[])[0] === collectionPath,
-  );
-  if (!call) throw new Error(`Nothing subscribed to ${collectionPath}`);
-  return call;
-}
-
-const emit = (collectionPath: string, docs: Doc[]) =>
-  act(() => (subscription(collectionPath)[1] as (snapshot: { docs: Doc[] }) => void)({ docs }));
+const emit = (docs: Doc[]) =>
+  act(() => (onSnapshot.mock.calls.at(-1)![1] as (snapshot: { docs: Doc[] }) => void)({ docs }));
 
 const doc = (id: string, data: unknown): Doc => ({ id, data: () => data });
 
 const storedRecord = (overrides: Record<string, unknown> = {}) => ({
-  userId: ANNA,
-  eventSeriesId: "s1",
+  studentUpn: ANNA,
+  firstName: "Anna",
+  lastName: "Muster",
+  email: ANNA,
   event: null,
   isIncomplete: false,
   isAttendingSportsWeek: true,
@@ -64,8 +59,6 @@ const storedRecord = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-const storedUser = { firstName: "Anna", lastName: "Muster", email: ANNA, role: "student" };
-
 /** The subscription waits for Firebase Auth, so a signed-in user has to be announced first. */
 function signIn() {
   for (const [, callback] of onAuthStateChanged.mock.calls) {
@@ -80,40 +73,38 @@ beforeEach(() => {
 });
 
 describe("useRoster", () => {
-  it("reads the registrations of the event series it was given", () => {
+  /** Which series a registration belongs to is its path, so the read needs no filter (US-26). */
+  it("reads the registrations beneath the event series it was given", () => {
     renderHook(() => useRoster("s1"));
     signIn();
 
-    expect(subscription("registrations")[0]).toEqual(["registrations", "where:eventSeriesId=s1"]);
+    expect(collection).toHaveBeenCalledWith(expect.anything(), REGISTRATIONS);
   });
 
-  it("reads the users it needs the names from, and only the students among them", () => {
+  it("reads nothing else, because the registration carries the name itself", () => {
     renderHook(() => useRoster("s1"));
     signIn();
 
-    expect(subscription("users")[0]).toEqual(["users", "where:role=student"]);
+    expect(onSnapshot).toHaveBeenCalledTimes(1);
   });
 
-  it("joins a registration to its name once both have arrived", async () => {
+  it("names a student from their own registration", async () => {
     const { result } = renderHook(() => useRoster("s1"));
     signIn();
 
-    emit("registrations", [doc(`s1__${ANNA}`, storedRecord())]);
-    emit("users", [doc(ANNA, storedUser)]);
+    emit([doc(ANNA, storedRecord())]);
 
     await waitFor(() =>
       expect(result.current.students).toEqual([
-        expect.objectContaining({ id: `s1__${ANNA}`, firstName: "Anna", lastName: "Muster" }),
+        expect.objectContaining({ id: ANNA, firstName: "Anna", lastName: "Muster" }),
       ]),
     );
     expect(result.current.loading).toBe(false);
   });
 
-  it("keeps loading until the names are there, so no row appears without one", () => {
+  it("is loading until the registrations have arrived", () => {
     const { result } = renderHook(() => useRoster("s1"));
     signIn();
-
-    emit("registrations", [doc(`s1__${ANNA}`, storedRecord())]);
 
     expect(result.current.loading).toBe(true);
     expect(result.current.students).toEqual([]);
@@ -123,7 +114,7 @@ describe("useRoster", () => {
     const { result } = renderHook(() => useRoster(null));
     signIn();
 
-    expect(onSnapshot.mock.calls.some(([q]) => (q as string[])[0] === "registrations")).toBe(false);
+    expect(onSnapshot).not.toHaveBeenCalled();
     expect(result.current.loading).toBe(false);
     expect(result.current.students).toEqual([]);
   });
@@ -133,12 +124,22 @@ describe("useRoster", () => {
     const { result } = renderHook(() => useRoster("s1"));
     signIn();
 
-    emit("registrations", [
-      doc("broken", { userId: ANNA, eventSeriesId: "s1" }),
-      doc(`s1__${ANNA}`, storedRecord()),
-    ]);
-    emit("users", [doc(ANNA, storedUser)]);
+    emit([doc("broken", { studentUpn: ANNA }), doc(ANNA, storedRecord())]);
 
     expect(result.current.students).toHaveLength(1);
+  });
+
+  it("surfaces a failed read rather than showing an empty roster", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => useRoster("s1"));
+    signIn();
+
+    act(() =>
+      (onSnapshot.mock.calls.at(-1)![2] as (error: Error) => void)(
+        new Error("Missing or insufficient permissions."),
+      ),
+    );
+
+    await waitFor(() => expect(result.current.error).toContain("permissions"));
   });
 });

--- a/src/lib/students/use-roster.ts
+++ b/src/lib/students/use-roster.ts
@@ -6,13 +6,12 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { collection, query, where } from "firebase/firestore";
+import { collection, query } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
 import { subscribeWithRecovery } from "@/lib/firebase/live-query";
-import { COLLECTIONS } from "@/lib/schemas/collections";
+import { registrationPath } from "@/lib/registration/registration";
 import { registrationSchema, type Registration } from "@/lib/schemas/registration";
-import { userSchema, type User } from "@/lib/schemas/user";
-import { joinRoster, type RosterStudent } from "./roster";
+import { toRoster, type RosterStudent } from "./roster";
 
 type RosterState = {
   students: RosterStudent[];
@@ -23,71 +22,40 @@ type RosterState = {
 /**
  * Every registration of one event series, with the names to show them under (US-12, US-13).
  *
- * A live read rather than a handler: a teacher may read the collection outright (see
+ * A live read rather than a handler: a teacher may read the subcollection outright (see
  * firestore.rules), and it is the subscription that makes the overview tables follow an
- * assignment the moment it is stored.
+ * assignment the moment it is stored. One subscription and no join — the registration carries
+ * the student's name itself (US-26).
  */
 export function useRoster(eventSeriesId: string | null): RosterState {
   const [records, setRecords] = useState<Registration[] | null>(null);
-  const [users, setUsers] = useState<User[] | null>(null);
-  const [recordError, setRecordError] = useState<string | null>(null);
-  const [userError, setUserError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (eventSeriesId === null) return;
+    const path = registrationPath(eventSeriesId);
 
     return subscribeWithRecovery<Registration>({
-      label: COLLECTIONS.registrations,
-      buildQuery: () =>
-        query(
-          collection(db, COLLECTIONS.registrations),
-          where("eventSeriesId", "==", eventSeriesId),
-        ),
+      label: path,
+      buildQuery: () => query(collection(db, path)),
       parse: (id, data) => {
         const parsed = registrationSchema.safeParse({ id, ...data });
         if (!parsed.success) {
-          console.error(
-            `${COLLECTIONS.registrations}/${id} does not match the schema`,
-            parsed.error,
-          );
+          console.error(`${path}/${id} does not match the schema`, parsed.error);
           return null;
         }
         return parsed.data;
       },
       onData: setRecords,
-      onError: setRecordError,
+      onError: setError,
     });
   }, [eventSeriesId]);
 
-  // Only the students: a teacher keeps no registration of their own (US-15), so their record
-  // could never be joined to one.
-  useEffect(
-    () =>
-      subscribeWithRecovery<User>({
-        label: COLLECTIONS.users,
-        buildQuery: () => query(collection(db, COLLECTIONS.users), where("role", "==", "student")),
-        parse: (id, data) => {
-          const parsed = userSchema.safeParse({ id, ...data });
-          if (!parsed.success) {
-            console.error(`${COLLECTIONS.users}/${id} does not match the schema`, parsed.error);
-            return null;
-          }
-          return parsed.data;
-        },
-        onData: setUsers,
-        onError: setUserError,
-      }),
-    [],
-  );
-
-  const students = useMemo(
-    () => (records === null || users === null ? [] : joinRoster(records, users)),
-    [records, users],
-  );
+  const students = useMemo(() => (records === null ? [] : toRoster(records)), [records]);
 
   return {
     students,
-    loading: eventSeriesId !== null && (records === null || users === null),
-    error: recordError ?? userError,
+    loading: eventSeriesId !== null && records === null,
+    error,
   };
 }

--- a/src/test/fake-firestore.ts
+++ b/src/test/fake-firestore.ts
@@ -65,6 +65,10 @@ export class FakeDocumentReference {
     return `${this.collectionPath}/${this.id}`;
   }
 
+  get parent(): FakeCollectionReference {
+    return new FakeCollectionReference(this.firestore, this.collectionPath);
+  }
+
   async get(): Promise<FakeDocumentSnapshot> {
     return this.firestore.readDoc(this.collectionPath, this.id);
   }
@@ -95,9 +99,12 @@ export class FakeAggregateSnapshot {
 export class FakeQuery {
   constructor(
     protected readonly firestore: FakeFirestore,
+    /** A collection path, or the last segment alone while `group` is set. */
     protected readonly collectionPath: string,
     protected readonly filters: Filter[] = [],
     protected readonly limitCount: number | null = null,
+    /** Matches every collection whose last path segment is `collectionPath`, at any depth. */
+    protected readonly group = false,
   ) {}
 
   where(field: string, operator: string, value: unknown): FakeQuery {
@@ -111,11 +118,12 @@ export class FakeQuery {
       this.collectionPath,
       [...this.filters, { field, operator, value }],
       this.limitCount,
+      this.group,
     );
   }
 
   limit(count: number): FakeQuery {
-    return new FakeQuery(this.firestore, this.collectionPath, this.filters, count);
+    return new FakeQuery(this.firestore, this.collectionPath, this.filters, count, this.group);
   }
 
   /** Aggregates server-side, so the documents themselves never cross the wire. */
@@ -127,11 +135,25 @@ export class FakeQuery {
   }
 
   async get(): Promise<FakeQuerySnapshot> {
-    return this.firestore.runQuery(this.collectionPath, this.filters, this.limitCount);
+    return this.group
+      ? this.firestore.runGroupQuery(this.collectionPath, this.filters, this.limitCount)
+      : this.firestore.runQuery(this.collectionPath, this.filters, this.limitCount);
   }
 }
 
 export class FakeCollectionReference extends FakeQuery {
+  /** Null for a top-level collection, the owning document for a subcollection. */
+  get parent(): FakeDocumentReference | null {
+    const segments = this.collectionPath.split("/");
+    if (segments.length < 3) return null;
+
+    return new FakeDocumentReference(
+      this.firestore,
+      segments.slice(0, -2).join("/"),
+      segments[segments.length - 2],
+    );
+  }
+
   doc(id?: string): FakeDocumentReference {
     return new FakeDocumentReference(
       this.firestore,
@@ -242,6 +264,11 @@ export class FakeFirestore {
     return new FakeCollectionReference(this, path);
   }
 
+  /** Every collection with this name, wherever it sits — subcollections included. */
+  collectionGroup(collectionId: string): FakeQuery {
+    return new FakeQuery(this, collectionId, [], null, true);
+  }
+
   batch(): FakeWriteBatch {
     return new FakeWriteBatch(this);
   }
@@ -311,6 +338,27 @@ export class FakeFirestore {
         new FakeDocumentSnapshot(id, data, new FakeDocumentReference(this, collectionPath, id)),
     );
 
+    return this.take(matches, limitCount);
+  }
+
+  runGroupQuery(
+    collectionId: string,
+    filters: Filter[],
+    limitCount: number | null,
+  ): FakeQuerySnapshot {
+    const matches = [...this.store.keys()]
+      .filter((path) => path.split("/").at(-1) === collectionId)
+      .flatMap((path) =>
+        this.matching(path, filters).map(
+          ([id, data]) =>
+            new FakeDocumentSnapshot(id, data, new FakeDocumentReference(this, path, id)),
+        ),
+      );
+
+    return this.take(matches, limitCount);
+  }
+
+  private take(matches: FakeDocumentSnapshot[], limitCount: number | null): FakeQuerySnapshot {
     const returned = limitCount === null ? matches : matches.slice(0, limitCount);
     this.queryDocumentsRead += returned.length;
     return new FakeQuerySnapshot(returned);

--- a/src/test/roster-student.ts
+++ b/src/test/roster-student.ts
@@ -13,9 +13,11 @@ import type { RosterStudent } from "@/lib/students/roster";
  */
 export function studentRecord(overrides: Partial<Registration> = {}): Registration {
   return {
-    id: "record1",
-    userId: "anna@student.htldornbirn.at",
-    eventSeriesId: "s1",
+    id: "anna@student.htldornbirn.at",
+    studentUpn: "anna@student.htldornbirn.at",
+    firstName: "Anna",
+    lastName: "Muster",
+    email: "anna@student.htldornbirn.at",
     event: null,
     isIncomplete: false,
     isAttendingSportsWeek: true,
@@ -56,8 +58,8 @@ export function rosterStudent(
   answers: Partial<Registration> = {},
 ): RosterStudent {
   const row = {
-    id: "record1",
-    userId: "anna@student.htldornbirn.at",
+    id: "anna@student.htldornbirn.at",
+    studentUpn: "anna@student.htldornbirn.at",
     email: "anna@student.htldornbirn.at",
     firstName: "Anna",
     lastName: "Muster",
@@ -81,7 +83,10 @@ export function rosterStudent(
     ...row,
     record: studentRecord({
       id: row.id,
-      userId: row.userId,
+      studentUpn: row.studentUpn,
+      firstName: row.firstName,
+      lastName: row.lastName,
+      email: row.email,
       event: row.event,
       isAttendingSportsWeek: row.isAttending,
       isIncomplete: row.isIncomplete,


### PR DESCRIPTION
Slice 4 of the event series refactoring (`spec/refactoring-event-series.md`): a registration becomes self-contained.

## What changes

A registration used to be a row in one flat `registrations` collection, pointing at its event series with an `eventSeriesId` field and at its student with a `userId`. It now lives at `eventSeries/{eventSeriesId}/registrations/{studentUpn}` — which series it belongs to is its path, and who it belongs to is its document id.

It also carries the student's `firstName`, `lastName` and `email` itself, rather than expecting a reader to fetch them from `/users`.

## Why

**Reads get cheaper and rules get simpler.** A student's own record is `isSelf(studentUpn)` against the document's own name — no query, no lookup behind it. A teacher reads the subcollection of the series they are planning, which is the set they actually wanted, rather than filtering every series at once. The seven composite indexes that existed only to serve that filter are replaced by a single collection-group index on `studentUpn`.

**The roster join goes away.** Joining every registration to its user document to display a name was the only reason a teacher could read `/users` at all. With the name on the record, the permission has no reader left, so `/users` is narrowed to `allow read: if isSelf(uid)`.

**The copy is kept honest where the truth changes.** Provisioning corrects a student's name on sign-in and writes it through to their live registrations, writing only fields that differ, and skipping archived series — an archived series is read-only in everything it holds (US-19).

`isRecordArchived` is removed along with the field it read.

## Deployment order

This one matters:

1. **The collection-group index on `studentUpn` goes first** — provisioning needs it.
2. **The narrowed `/users` rule goes last.** Deploying it while the previous release is still serving would deny a roster that still joins.

Development and staging need a purge and reseed after this merge, since stored data moves.

## Checks

- 1503 unit tests, 97 files
- 104 rules tests against the emulator
- lint, `tsc --noEmit`, Prettier, license headers all clean
