### PR TITLE
Put saved reports under their event series, and create one from a copy

### DIFF
--- a/firestore-tests/registration.rules.test.ts
+++ b/firestore-tests/registration.rules.test.ts
@@ -165,8 +165,14 @@ describe("/eventSeries/{id}/registrations", () => {
   });
 });
 
-/** Saved reports are shared among teachers (US-13) and are no business of a student's. */
-describe("/savedReports", () => {
+/**
+ * Saved reports are shared among teachers (US-13) and are no business of a student's. They sit
+ * beneath the series whose lists they filter on, which is what lets that be said: a rule grants
+ * a whole document or none of it, and a student reads the event series document to be asked its
+ * questions (US-11), so a field on it would have handed them every report of every series.
+ */
+describe("/eventSeries/{id}/savedReports", () => {
+  const SAVED_REPORTS = "eventSeries/eventSeries1/savedReports";
   const report = {
     createdByUserId: TEACHER_UPN,
     name: "5AHIF",
@@ -177,35 +183,39 @@ describe("/savedReports", () => {
     fields: ["class"],
   };
 
-  beforeEach(async () => await seed("savedReports", "report1", report));
+  beforeEach(async () => await seed(SAVED_REPORTS, "report1", report));
 
   it("lets a teacher read a report saved by another teacher, since they are shared", async () => {
-    await assertSucceeds(teacher().collection("savedReports").doc("report1").get());
+    await assertSucceeds(teacher().collection(SAVED_REPORTS).doc("report1").get());
   });
 
   it("lets a teacher query them, which is what the report's tag row does", async () => {
-    await assertSucceeds(teacher().collection("savedReports").get());
+    await assertSucceeds(teacher().collection(SAVED_REPORTS).get());
   });
 
   it("denies a student reading them", async () => {
-    await assertFails(student().collection("savedReports").doc("report1").get());
+    await assertFails(student().collection(SAVED_REPORTS).doc("report1").get());
+  });
+
+  it("denies a student querying them, which reading the series they registered for does not", async () => {
+    await assertFails(student().collection(SAVED_REPORTS).get());
   });
 
   it("denies an unauthenticated read", async () => {
-    await assertFails(anonymous().collection("savedReports").doc("report1").get());
+    await assertFails(anonymous().collection(SAVED_REPORTS).doc("report1").get());
   });
 
   it("denies a teacher writing one", async () => {
     await assertFails(
       teacher()
-        .collection("savedReports")
+        .collection(SAVED_REPORTS)
         .doc("report2")
         .set({ ...report, name: "5BHIF" }),
     );
   });
 
   it("denies a teacher deleting one", async () => {
-    await assertFails(teacher().collection("savedReports").doc("report1").delete());
+    await assertFails(teacher().collection(SAVED_REPORTS).doc("report1").delete());
   });
 });
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -83,28 +83,25 @@ service cloud.firestore {
       allow write: if false;
     }
 
-    /** Saved reports are shared among all teachers, not private to who saved them (US-13). */
-    match /savedReports/{reportId} {
+    /**
+     * Saved reports are shared among all teachers, not private to who saved them (US-13), and
+     * are no business of a student's.
+     *
+     * They sit beneath the series whose lists they filter on rather than in its document, which
+     * is what lets that last part be said at all: a rule grants a whole document or none of it,
+     * and anyone signed in may read an event series because a registration selects from its
+     * lists (US-11). A field would therefore have handed every student every report of every
+     * series; a subcollection has a rule of its own.
+     *
+     * Writes are closed for the reason the event series document's are: the author is the
+     * session's rather than the request's, and a copy has to prune what its new lists no longer
+     * offer (US-22). Both are done in transactions by the Route Handlers.
+     */
+    match /eventSeries/{eventSeriesId}/savedReports/{reportId} {
       allow read: if isTeacher();
       allow write: if false;
     }
 
-    /**
-     * The event series, and with it every list a teacher maintains — its events among them
-     * (US-21). Anyone signed in may read, because a registration selects from those lists
-     * (US-11) and the teacher views subscribe to them live. A rule grants a whole document or
-     * none of it, so a student can also read the saved reports once those move here — accepted
-     * deliberately, since a saved report holds a name, a filter and a set of field keys and
-     * nothing about any student.
-     *
-     * Writes are closed rather than merely restricted to teachers, because the invariants this
-     * document carries cannot be expressed here at all. Rules can `get()` a known path but cannot
-     * run a query, so "is this name already taken?" (US-4) and "is this item still in use?"
-     * (US-5 to US-10) are out of reach — and a list edit has to be a read-modify-write of one
-     * array, which no rule can hold to being one. They are enforced in transactions in the Route
-     * Handlers, which use the Admin SDK and bypass these rules — leaving a second, unchecked way
-     * in would make those guarantees worthless.
-     *
     /**
      * The invitation tokens (US-23). Closed to everybody, in both directions: a token is what
      * enrols somebody, so handing it to a reader would hand them the enrolment. It is resolved
@@ -120,6 +117,18 @@ service cloud.firestore {
     }
 
     /**
+     * The event series, and with it every list a teacher maintains — its events among them
+     * (US-21). Anyone signed in may read, because a registration selects from those lists
+     * (US-11) and the teacher views subscribe to them live.
+     *
+     * Writes are closed rather than merely restricted to teachers, because the invariants this
+     * document carries cannot be expressed here at all. Rules can `get()` a known path but cannot
+     * run a query, so "is this name already taken?" (US-4) and "is this item still in use?"
+     * (US-5 to US-10) are out of reach — and a list edit has to be a read-modify-write of one
+     * array, which no rule can hold to being one. They are enforced in transactions in the Route
+     * Handlers, which use the Admin SDK and bypass these rules — leaving a second, unchecked way
+     * in would make those guarantees worthless.
+     *
      * The name below is a copy: this language cannot import application code. It is owned by
      * COLLECTIONS in src/lib/schemas/collections.ts and has to be kept in step by hand.
      */

--- a/scripts/seed-environment.mts
+++ b/scripts/seed-environment.mts
@@ -336,6 +336,9 @@ async function inBatches(
 /**
  * Collections are discovered rather than taken from COLLECTIONS: a purge that only removes the
  * names the code still knows about leaves the ones a rename or a deletion orphaned.
+ *
+ * `recursiveDelete` takes each collection's subcollections with it, which a document delete does
+ * not — so the counts below are of top-level documents and undercount what actually goes.
  */
 async function purgeFirestore(db: Firestore): Promise<[string, number][]> {
   const collections = await db.listCollections();

--- a/spec/refactoring-event-series.md
+++ b/spec/refactoring-event-series.md
@@ -102,19 +102,6 @@ event series, labelled "Eventreihe".
   "seasonPassOptions": ["Keine", "Vielleicht", "Golm-Bielerhöhe (Illwerke)", "Silvretta-Montafon"],
   "busPickupPoints": ["HTL Dornbirn", "Bahnhof Bregenz", "Bahnhof Feldkirch", "Unterkunft"],
   "foodOptions": ["Alles", "Vegetarisch", "Vegan", "Kein Schweinefleisch"],
-
-  // A saved report is a selection the teacher asked to be remembered, and nothing else: a name,
-  // which students are shown, and which detail lines they show (US-13, US-25). It is here for
-  // the same reason the lists are — it belongs to this series and filters on these lists, so one
-  // transaction writes both and they cannot disagree. Array
-  // order is the order the tags were dragged into, so no report carries a position either.
-  "savedReports": [
-    {
-      "name": "Vegetarisch 2bWI",
-      "filter": { "name": "", "tags": { "class": ["2bWI"], "foodOption": ["Vegetarisch"] } },
-      "fields": ["class", "contact"],
-    },
-  ],
 }
 ```
 
@@ -124,22 +111,27 @@ assuming the item is one.
 
 ### What does not sit in it
 
-One thing does not, and cannot: the invitation token of US-23.
+Two things do not, and for the same reason: a rule grants a **whole document or none of it**, and
+any signed-in user may read an event series — a registration selects from its lists (US-11).
+Anything that must not reach a student therefore cannot be a field of it.
 
 ```
-invitations/{token}   resolved server-side; readable by nobody through the access rules
+invitations/{token}                          resolved server-side; readable by nobody
+eventSeries/{id}/savedReports/{reportId}     readable by a teacher, written by nobody
 ```
 
-A token is a secret. Firestore's access rules are per document, so a token stored as a field of
-the event series document is readable by everyone the document is readable by — and a secret with
-that property is not a secret. It therefore lives in a collection of its own that no client may
-read at all, and is resolved by the Route Handler behind the link.
+A token is a secret, and a secret readable by everyone the document is readable by is not a
+secret. It lives in a collection of its own that no client may read at all, and is resolved by
+the Route Handler behind the link.
 
-Everything else is in the document, saved reports included, and any signed-in user may read it.
-That is a decision rather than an oversight: a rule grants a whole document or none of it, so
-letting a student's registration form subscribe to the lists lets them read the saved reports
-too. It is accepted, because a saved report holds a name, a filter and a set of field keys — no
-student's answers, and nothing a student can write. See Q1.
+A saved report is a selection the teacher asked to be remembered — a name, which students are
+shown, and which detail lines they show (US-13, US-25). It belongs to one series and filters on
+that series' lists, so it sits **beneath** the document rather than in it: near enough that one
+transaction writes both and they cannot disagree, separate enough to carry a rule of its own. Its
+position is a field, as a collection's members' order always is. See Q1, which first answered
+this the other way.
+
+Everything else is in the document, and any signed-in user may read it.
 
 ### The registration document
 
@@ -185,7 +177,9 @@ student's answers, and nothing a student can write. See Q1.
 ### What is deleted outright
 
 - The `seasons`, `events`, `programs`, `classOptions`, `skillLevels`, `busPickupPoints`,
-  `foodOptions`, `seasonPassOptions` and `savedReports` collections.
+  `foodOptions` and `seasonPassOptions` collections.
+- The top-level `savedReports` collection, which becomes a subcollection of the series each
+  report belongs to (Q1).
 - `Season.isActive` as it stands: the exclusivity, the guards that enforced it and the activation
   transaction all go. `isOpenToStudents` takes its place in name only — it answers a different
   question and carries no exclusivity (US-19, Q19).
@@ -477,9 +471,10 @@ its lists with a Wintersportwoche.
   question and so can have no rental question either.
 - A program's required equipment is unchanged in every other respect: a list on the program,
   capped at `MAX_EQUIPMENT_ITEMS`, ordered by dragging, rewritten whole.
-- Because one subscription to one document now carries every list and every saved report, the six
-  `useMasterData` subscriptions, the `useEvents` subscription and `useSavedReports` collapse into
-  one.
+- Because one subscription to one document now carries every list, the six `useMasterData`
+  subscriptions and the `useEvents` subscription collapse into one. `useSavedReports` stays a
+  subscription of its own, since the reports are beneath the document rather than in it (Q1) —
+  which it already was, so nothing is spent that was not being spent before.
 - The roster's opt-in flags survive that, with one of their two reasons gone. They say which
   filter categories a view offers, which the board and the report still disagree about; they no
   longer say which lists are worth subscribing to, because there is one subscription and it
@@ -665,9 +660,12 @@ report rather than a report widened by tags that quietly stopped matching.
 
 **Acceptance criteria:**
 
-- Saved reports belong to one event series and are stored in its document, beside the lists they
-  filter on: they are created in it, listed only while it is selected, deleted with it, and their
-  order is the array's.
+- Saved reports belong to one event series and are stored **beneath** its document, in a
+  subcollection beside the lists they filter on: they are created in it, listed only while it is
+  selected, deleted with it, and their order is a `position` on each.
+- **Beneath rather than in it**, because a rule grants a whole document or none of it and any
+  signed-in user may read an event series (US-11). A field would publish every teacher's reports
+  to every student; a subcollection is granted separately, so `isTeacher()` can be said (Q1).
 - A saved report is a selection that was remembered, and nothing else: a name, a filter and a set
   of field keys. It names nobody and records nothing about how it came to exist.
 - The event filter tag holds the event's name rather than its id, so an event is the same kind of
@@ -1002,8 +1000,16 @@ rentals, because filtering on the series and the value is two equalities. They a
 go again in slice 4, when a registration moves beneath its series and the series stops being a
 field to filter by.
 
-The saved reports move into the event series document in this slice, beside the lists they filter
-on — one document, one transaction, so a report and its lists cannot disagree.
+The saved reports move beneath the event series in this slice, into a subcollection of the
+document holding the lists they filter on — one parent, one transaction, so a report and its
+lists cannot disagree.
+
+**Beneath rather than inside**, because a rule grants a whole document or none of it, and anyone
+signed in may read an event series: a registration selects from its lists (US-11), and the
+student view subscribes to the whole collection. As a field, every saved report of every series
+would have been handed to every student. A subcollection carries a rule of its own, so
+`isTeacher()` can be said and a denial can be tested. It also lifts the 1 MiB ceiling Q13 had to
+budget against.
 
 This is the slice that needs the concurrency tests, and the invariant of US-24 is the one worth
 writing first: after any edit, every list value on every registration is either unanswered or one
@@ -1069,27 +1075,31 @@ the options, and what this document assumes in the meantime.
 
 ### Model and storage
 
-**Q1 — Students can read the saved reports, and that is accepted. Decided.** Firestore's access
-rules grant a **whole document or none of it** — there is no field-level read — and the client SDK
-hands a document to anyone the rule admits, whatever the application chooses to draw on screen.
-The registration form subscribes to `eventSeries/{id}` for the class and program lists, so the
-rule admits students, so a signed-in student can read that document entire, saved reports
-included. This was worth deciding rather than discovering, because saved reports are teacher-only
-today (US-13) and this quietly ends that.
+**Q1 — Students must not read the saved reports, so those live beneath the document rather than
+in it. Decided, reversing an earlier answer.** Firestore's access rules grant a **whole document
+or none of it** — there is no field-level read — and the client SDK hands a document to anyone the
+rule admits, whatever the application chooses to draw on screen. The registration form subscribes
+to the event series for the class and program lists, so the rule admits students.
 
-**Decided: they stay in the document and students may read them.** What a saved report holds is a
-name, a filter and a set of field keys: no student's answers, nothing a student can write, and
-nothing that is not already visible to a teacher standing at a whiteboard. The alternative —
-serving the lists to students through a Route Handler so the document could stay teacher-only —
-would have cost the live updates for no proportionate gain.
+This was first answered the other way: keep the reports in the document, accept that students
+receive them, on the grounds that a report holds a name, a filter and a set of field keys and
+nothing about any student. Two things were wrong with that. The narrower one is that the student
+view subscribes to the **whole collection**, so it was never "the series they registered for" but
+every series in the school. The broader one is that a report name is free text a teacher writes
+for teachers, and the filter says who is being looked at — by health flag, by completeness, by
+class. That is teacher-only in intent even where it is anonymous in content.
+
+**Decided: `eventSeries/{id}/savedReports/{reportId}`.** A subcollection is granted separately,
+so the rule can say `isTeacher()` and the denial can be tested. It costs nothing that mattered:
+the copy of US-22 stays atomic, because a transaction spans collections; the tag row already
+spent a subscription of its own; and the 1 MiB budget Q13 had to reason about stops applying.
 
 Two consequences to write down rather than leave implicit:
 
-- The rules test suite asserts this deliberately: a student **may** read an event series document
-  and everything in it, and may still write none of it. A test that reads as a leak needs the
-  comment saying it is a decision.
-- Nothing in the document is about a person, and it is worth keeping it that way. A field added
-  later that names a teacher is a field every student in the school can read.
+- The rules test suite asserts both halves: a teacher may read and query a series' reports, and a
+  student may read neither — the denial being the half that had no rule to test against before.
+- The event series document itself stays readable by any signed-in user, and nothing in it is
+  about a person. A field added later that names a teacher is a field every student can read.
 
 The invitation token is not part of this and never was: it is a secret, and it lives outside the
 document regardless.
@@ -1221,9 +1231,9 @@ per series, and a generous ceiling per maintained list, both in the schema in th
 `MAX_EQUIPMENT_ITEMS`, which stays 10.
 
 One limit is tighter than bytes and worth naming: Firestore indexes **each array element
-separately**, against 20,000 index entries per document. Nothing ever queries by the contents of
-a saved report, so the `savedReports` field is exempted from indexing with a `fieldOverrides`
-entry in `firestore.indexes.json` — one line of configuration that removes the pressure entirely.
+separately**, against 20,000 index entries per document. The seven lists are what that applies
+to, and a few hundred names between them is nowhere near it. The saved reports escape the
+question altogether by living in a subcollection (Q1) rather than in an array field.
 
 What this does not settle is the **write rate**. Every list edit, every reorder, every saved
 report and every `hasRegistrations` update writes the same document, against roughly one
@@ -1419,8 +1429,7 @@ What this refactoring adds is an **ordering constraint**, because rules and inde
 their own schedule while the code depends on both:
 
 - **A new index goes first** — the `registrations` collection group override on `studentUpn`
-  (US-26) and the `savedReports` `fieldOverrides` (Q13) — because a build takes time and a query
-  without its index fails.
+  (US-26) — because a build takes time and a query without its index fails.
 - **A rule that widens goes before or with its code**, such as students reading the event series
   document (Q1).
 - **A rule that narrows goes after its code**, such as teachers losing the `users` read (US-26).
@@ -1502,6 +1511,13 @@ anything**. Dropping at copy time avoids that entirely.
 
 The read-time tolerance is still kept, for what it was always for: a report saved before a
 category or a field key existed (US-25).
+
+**Where they live was reopened and answered differently.** "Into the document" was the original
+answer, for the atomicity a single document gives. A subcollection of that document gives the
+same atomicity — a transaction spans collections — and gives something the field cannot: a read
+rule of its own. Since anyone signed in may read an event series, a field would have published
+every teacher's saved reports to every student. That is not a leak worth accepting for a
+convenience a subcollection also provides.
 
 **Q11 — A teacher can delete a registration, from the overview page. Decided, as US-28.**
 There is no such path today, and the invitation links of US-23 create the need: a link is per

--- a/src/app/api/auth/fake/route.fake.ts
+++ b/src/app/api/auth/fake/route.fake.ts
@@ -79,7 +79,7 @@ const bodySchema = z.object({
   role: userRoleSchema,
 });
 
-const listedUserSchema = userSchema.omit({ id: true, email: true });
+const listedUserSchema = userSchema.omit({ id: true, email: true, photo: true });
 
 /** The UPNs already in Firestore, so a known user can be picked instead of retyped. */
 export async function GET() {

--- a/src/app/api/event-series/[eventSeriesId]/saved-reports/[reportId]/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/saved-reports/[reportId]/route.test.ts
@@ -21,8 +21,9 @@ const { ServiceError } = await import("@/lib/service-error");
 const { ErrorCode } = await import("@/lib/errors");
 
 const TEACHER = "jane.doe@htldornbirn.at";
+const SERIES = "s1";
 const selection = toggleTag(EMPTY_FILTER, "class", "5AHIF");
-const params = Promise.resolve({ reportId: "r1" });
+const params = Promise.resolve({ eventSeriesId: SERIES, reportId: "r1" });
 const report = {
   id: "r1",
   name: "5BHIF",
@@ -32,7 +33,7 @@ const report = {
 };
 
 function patchRequest(body: unknown) {
-  return new Request("https://example.com/api/saved-reports/r1", {
+  return new Request(`https://example.com/api/event-series/${SERIES}/saved-reports/r1`, {
     method: "PATCH",
     body: JSON.stringify(body),
   });
@@ -45,14 +46,14 @@ beforeEach(() => {
   deleteSavedReport.mockResolvedValue(undefined);
 });
 
-describe("PATCH /api/saved-reports/[reportId]", () => {
-  it("stores the name and both selections as one edit", async () => {
+describe("PATCH /api/event-series/[eventSeriesId]/saved-reports/[reportId]", () => {
+  it("stores the name and both selections as one edit, in the series the address names", async () => {
     const edit = { name: "5BHIF", filter: selection, fields: ["class"] };
 
     const response = await PATCH(patchRequest(edit), { params });
 
     expect(response.status).toBe(200);
-    expect(updateSavedReport).toHaveBeenCalledWith("r1", edit);
+    expect(updateSavedReport).toHaveBeenCalledWith(SERIES, "r1", edit);
   });
 
   it("refuses a name on its own, which would store half a report", async () => {
@@ -100,12 +101,12 @@ describe("PATCH /api/saved-reports/[reportId]", () => {
   });
 });
 
-describe("DELETE /api/saved-reports/[reportId]", () => {
+describe("DELETE /api/event-series/[eventSeriesId]/saved-reports/[reportId]", () => {
   it("removes the saved report", async () => {
     const response = await DELETE(new Request("https://example.com"), { params });
 
     expect(response.status).toBe(204);
-    expect(deleteSavedReport).toHaveBeenCalledWith("r1");
+    expect(deleteSavedReport).toHaveBeenCalledWith(SERIES, "r1");
   });
 
   it("rejects a student with 403", async () => {

--- a/src/app/api/event-series/[eventSeriesId]/saved-reports/[reportId]/route.ts
+++ b/src/app/api/event-series/[eventSeriesId]/saved-reports/[reportId]/route.ts
@@ -8,7 +8,7 @@ import { handleServiceFailure, parseJsonBody, requireTeacherOrResponse } from "@
 import { savedReportEditSchema } from "@/lib/schemas/saved-report";
 import { deleteSavedReport, updateSavedReport } from "@/lib/report/saved-report-service";
 
-type Context = { params: Promise<{ reportId: string }> };
+type Context = { params: Promise<{ eventSeriesId: string; reportId: string }> };
 
 /** One edit, whichever control sent it: the report as the teacher now has it, name included. */
 export async function PATCH(request: Request, { params }: Context) {
@@ -18,10 +18,10 @@ export async function PATCH(request: Request, { params }: Context) {
   const body = await parseJsonBody(request, savedReportEditSchema);
   if (!body.ok) return body.response;
 
-  const { reportId } = await params;
+  const { eventSeriesId, reportId } = await params;
 
   try {
-    const report = await updateSavedReport(reportId, body.data);
+    const report = await updateSavedReport(eventSeriesId, reportId, body.data);
     return NextResponse.json({ report });
   } catch (error) {
     return handleServiceFailure(error, `Editing saved report ${reportId}`);
@@ -33,10 +33,10 @@ export async function DELETE(_request: Request, { params }: Context) {
   const denied = await requireTeacherOrResponse();
   if (denied) return denied;
 
-  const { reportId } = await params;
+  const { eventSeriesId, reportId } = await params;
 
   try {
-    await deleteSavedReport(reportId);
+    await deleteSavedReport(eventSeriesId, reportId);
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     return handleServiceFailure(error, `Deleting saved report ${reportId}`);

--- a/src/app/api/event-series/[eventSeriesId]/saved-reports/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/saved-reports/route.test.ts
@@ -19,19 +19,21 @@ vi.mock("@/lib/report/saved-report-service", () => ({
 const { PATCH, POST } = await import("./route");
 
 const TEACHER = "jane.doe@htldornbirn.at";
+const SERIES = "s1";
+const context = { params: Promise.resolve({ eventSeriesId: SERIES }) };
 const selection = toggleTag(EMPTY_FILTER, "class", "5AHIF");
 const fields = ["class", "contact"];
 const input = { name: "5AHIF", filter: selection, fields };
 
 function postRequest(body: unknown) {
-  return new Request("https://example.com/api/saved-reports", {
+  return new Request(`https://example.com/api/event-series/${SERIES}/saved-reports`, {
     method: "POST",
     body: JSON.stringify(body),
   });
 }
 
 function patchRequest(body: unknown) {
-  return new Request("https://example.com/api/saved-reports", {
+  return new Request(`https://example.com/api/event-series/${SERIES}/saved-reports`, {
     method: "PATCH",
     body: JSON.stringify(body),
   });
@@ -44,9 +46,9 @@ beforeEach(() => {
   reorderSavedReports.mockResolvedValue(undefined);
 });
 
-describe("POST /api/saved-reports", () => {
+describe("POST /api/event-series/[eventSeriesId]/saved-reports", () => {
   it("saves both selections under one name", async () => {
-    const response = await POST(postRequest(input));
+    const response = await POST(postRequest(input), context);
 
     expect(response.status).toBe(201);
     expect(await response.json()).toEqual({
@@ -55,21 +57,22 @@ describe("POST /api/saved-reports", () => {
   });
 
   it("attributes it to the session rather than to anything the request says", async () => {
-    await POST(postRequest({ ...input, createdByUserId: "someone@else.at" }));
+    await POST(postRequest({ ...input, createdByUserId: "someone@else.at" }), context);
 
     expect(createSavedReport).not.toHaveBeenCalled();
   });
 
-  it("takes the author from the session", async () => {
-    await POST(postRequest(input));
+  /** A report filters on one series' lists, so which series is the path rather than a field. */
+  it("saves it into the series the address names, and takes the author from the session", async () => {
+    await POST(postRequest(input), context);
 
-    expect(createSavedReport).toHaveBeenCalledWith(input, TEACHER);
+    expect(createSavedReport).toHaveBeenCalledWith(SERIES, input, TEACHER);
   });
 
   it("rejects a student with 403, since the report is a teacher's (US-13)", async () => {
     getUserWithRole.mockResolvedValue({ uid: "u2", email: "s@x.at", role: "student" });
 
-    const response = await POST(postRequest(input));
+    const response = await POST(postRequest(input), context);
 
     expect(response.status).toBe(403);
     expect(createSavedReport).not.toHaveBeenCalled();
@@ -78,11 +81,11 @@ describe("POST /api/saved-reports", () => {
   it("rejects an unauthenticated caller with 401", async () => {
     getUserWithRole.mockResolvedValue(null);
 
-    expect((await POST(postRequest(input))).status).toBe(401);
+    expect((await POST(postRequest(input), context)).status).toBe(401);
   });
 
   it("rejects a blank name with the shared envelope", async () => {
-    const response = await POST(postRequest({ ...input, name: "  " }));
+    const response = await POST(postRequest({ ...input, name: "  " }), context);
     const body = await response.json();
 
     expect(response.status).toBe(400);
@@ -95,29 +98,29 @@ describe("POST /api/saved-reports", () => {
       Object.entries(selection.tags).filter(([category]) => category !== "event"),
     );
 
-    await POST(postRequest({ ...input, filter: { ...selection, tags } }));
+    await POST(postRequest({ ...input, filter: { ...selection, tags } }), context);
 
-    expect(createSavedReport).toHaveBeenCalledWith(input, TEACHER);
+    expect(createSavedReport).toHaveBeenCalledWith(SERIES, input, TEACHER);
   });
 });
 
-describe("PATCH /api/saved-reports", () => {
+describe("PATCH /api/event-series/[eventSeriesId]/saved-reports", () => {
   it("renumbers the row in the order the tags were dropped into", async () => {
-    const response = await PATCH(patchRequest({ order: ["r2", "r1"] }));
+    const response = await PATCH(patchRequest({ order: ["r2", "r1"] }), context);
 
     expect(response.status).toBe(204);
-    expect(reorderSavedReports).toHaveBeenCalledWith(["r2", "r1"]);
+    expect(reorderSavedReports).toHaveBeenCalledWith(SERIES, ["r2", "r1"]);
   });
 
   it("rejects a student with 403, so a bypassed client cannot reorder", async () => {
     getUserWithRole.mockResolvedValue({ uid: "u2", email: "s@x.at", role: "student" });
 
-    expect((await PATCH(patchRequest({ order: ["r1"] }))).status).toBe(403);
+    expect((await PATCH(patchRequest({ order: ["r1"] }), context)).status).toBe(403);
     expect(reorderSavedReports).not.toHaveBeenCalled();
   });
 
   it("rejects a body that is not an order", async () => {
-    const response = await PATCH(patchRequest({ order: ["r1"], name: "5AHIF" }));
+    const response = await PATCH(patchRequest({ order: ["r1"], name: "5AHIF" }), context);
 
     expect(response.status).toBe(400);
     expect(reorderSavedReports).not.toHaveBeenCalled();

--- a/src/app/api/event-series/[eventSeriesId]/saved-reports/route.ts
+++ b/src/app/api/event-series/[eventSeriesId]/saved-reports/route.ts
@@ -17,15 +17,19 @@ import { createSavedReport, reorderSavedReports } from "@/lib/report/saved-repor
 
 const reorderSchema = z.strictObject({ order: orderSchema });
 
-export async function POST(request: Request) {
+type Context = { params: Promise<{ eventSeriesId: string }> };
+
+export async function POST(request: Request, context: Context) {
   const teacher = await requireTeacherIdentityOrResponse();
   if (!teacher.ok) return teacher.response;
 
   const body = await parseJsonBody(request, savedReportInputSchema);
   if (!body.ok) return body.response;
 
+  const { eventSeriesId } = await context.params;
+
   try {
-    const report = await createSavedReport(body.data, teacher.userId);
+    const report = await createSavedReport(eventSeriesId, body.data, teacher.userId);
     return NextResponse.json({ report }, { status: 201 });
   } catch (error) {
     return handleServiceFailure(error, "Saving a report");
@@ -33,15 +37,17 @@ export async function POST(request: Request) {
 }
 
 /** Reorders the tag row (see Ordering); it changes nothing a report holds, so it needs no guard. */
-export async function PATCH(request: Request) {
+export async function PATCH(request: Request, context: Context) {
   const denied = await requireTeacherOrResponse();
   if (denied) return denied;
 
   const body = await parseJsonBody(request, reorderSchema);
   if (!body.ok) return body.response;
 
+  const { eventSeriesId } = await context.params;
+
   try {
-    await reorderSavedReports(body.data.order);
+    await reorderSavedReports(eventSeriesId, body.data.order);
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     return handleServiceFailure(error, "Reordering saved reports");

--- a/src/app/api/event-series/route.test.ts
+++ b/src/app/api/event-series/route.test.ts
@@ -48,7 +48,29 @@ describe("POST /api/event-series", () => {
     expect(await response.json()).toEqual({
       eventSeries: { id: "s1", name: "Winter 2026", isArchived: false },
     });
-    expect(createEventSeries).toHaveBeenCalledWith({ name: "Winter 2026" });
+    expect(createEventSeries).toHaveBeenCalledWith({
+      name: "Winter 2026",
+      isTemplate: false,
+      sourceId: null,
+    });
+  });
+
+  /** Both are answered at creation and neither has a bearing on the other (US-22). */
+  it("carries the kind and the source through as they were asked for", async () => {
+    await POST(postRequest({ name: "Vorlage", isTemplate: true, sourceId: "s9" }));
+
+    expect(createEventSeries).toHaveBeenCalledWith({
+      name: "Vorlage",
+      isTemplate: true,
+      sourceId: "s9",
+    });
+  });
+
+  it("refuses a field creation does not ask for, rather than dropping it", async () => {
+    const response = await POST(postRequest({ name: "Winter 2026", isArchived: true }));
+
+    expect(response.status).toBe(400);
+    expect(createEventSeries).not.toHaveBeenCalled();
   });
 
   it("rejects an anonymous caller with 401", async () => {

--- a/src/app/api/event-series/route.ts
+++ b/src/app/api/event-series/route.ts
@@ -7,10 +7,20 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { handleServiceFailure, parseJsonBody, requireTeacherOrResponse } from "@/lib/api/handler";
 import { orderSchema } from "@/lib/schemas/order";
+import { documentIdSchema } from "@/lib/schemas/common";
 import { eventSeriesSchema } from "@/lib/schemas/event-series";
 import { createEventSeries, reorderEventSeries } from "@/lib/event-series/event-series-service";
 
-const createEventSeriesSchema = z.strictObject({ name: eventSeriesSchema.shape.name });
+/**
+ * Three answers, one write (US-22): what it is called, whether it is a series or a template, and
+ * which existing one its lists come from. There is no separate duplicate action and no separate
+ * "make a template" action, so this is the only way an event series comes into being.
+ */
+const createEventSeriesSchema = z.strictObject({
+  name: eventSeriesSchema.shape.name,
+  isTemplate: z.boolean().default(false),
+  sourceId: documentIdSchema.nullable().default(null),
+});
 
 const reorderSchema = z.strictObject({ order: orderSchema });
 

--- a/src/app/app/(teacher)/[eventSeriesId]/master-data/page.tsx
+++ b/src/app/app/(teacher)/[eventSeriesId]/master-data/page.tsx
@@ -4,7 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { redirect } from "next/navigation";
-import { MASTER_DATA_CATEGORIES } from "@/lib/master-data/categories";
+import { firstMasterDataPath } from "@/lib/master-data/categories";
 
 // The section itself has no view; it opens on the first category of the selected event series.
 export default async function MasterDataIndexPage({
@@ -13,7 +13,6 @@ export default async function MasterDataIndexPage({
   params: Promise<{ eventSeriesId: string }>;
 }) {
   const { eventSeriesId } = await params;
-  const [firstCategory] = Object.keys(MASTER_DATA_CATEGORIES);
 
-  redirect(`/app/${encodeURIComponent(eventSeriesId)}/master-data/${firstCategory}`);
+  redirect(firstMasterDataPath(eventSeriesId));
 }

--- a/src/app/app/(teacher)/layout.tsx
+++ b/src/app/app/(teacher)/layout.tsx
@@ -4,33 +4,12 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import type { ReactNode } from "react";
-import { cookies } from "next/headers";
 import { requireTeacher } from "@/lib/auth/guards";
-import { resolveSelectedEventSeriesId } from "@/lib/event-series/event-series-service";
-import { EVENT_SERIES_COOKIE_NAME } from "@/lib/event-series/event-series-selection";
-import { TeacherNav } from "@/components/layout/teacher-nav";
 
-// Guards the whole teacher area; the proxy check ahead of it is optimistic only.
+// Guards the whole teacher area; the proxy check ahead of it is optimistic only. The navigation
+// bar is the shell's, because it shares a grid column with the pages below it.
 export default async function TeacherLayout({ children }: { children: ReactNode }) {
   await requireTeacher();
-  // This layout sits above the series id segment, so on the event series list — the one page not
-  // scoped to a selection — nothing in the URL says which series to link to. Resolved rather than
-  // read straight from the cookie, so a teacher who has remembered nothing yet, or remembered one
-  // since deleted, still gets a bar that points somewhere.
-  const remembered = (await cookies()).get(EVENT_SERIES_COOKIE_NAME)?.value;
-  const fallbackEventSeriesId = await resolveSelectedEventSeriesId(remembered);
 
-  return (
-    <div className="flex flex-1 flex-col md:flex-row md:overflow-hidden">
-      {/* The width lives on the nav, which is what decides whether it is collapsed. The height is
-          spelled out rather than stretched: Safari will not carry a stretch down through the
-          scrolling column above, and the bar's last row has to reach the foot of the window. */}
-      <aside className="border-border shrink-0 border-b md:flex md:h-[calc(100dvh-var(--header-height))] md:border-r md:border-b-0">
-        <TeacherNav fallbackEventSeriesId={fallbackEventSeriesId} />
-      </aside>
-      {/* min-w-0: without it the column is floored at the width of its widest table and the
-          row overflows, so narrowing the bar beside it hands the content no room back. */}
-      <div className="flex min-w-0 flex-1 flex-col md:overflow-y-auto">{children}</div>
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -7,7 +7,7 @@ import { cookies } from "next/headers";
 import { AppShell } from "@/components/layout/app-shell";
 import { EventSeriesTagRows } from "@/components/layout/event-series-tag-rows";
 import { TeacherNav } from "@/components/layout/teacher-nav";
-import { requireUser } from "@/lib/auth/guards";
+import { requireUser, fetchUserPhoto } from "@/lib/auth/guards";
 import { resolveSelectedEventSeriesId } from "@/lib/event-series/event-series-service";
 import { EVENT_SERIES_COOKIE_NAME } from "@/lib/event-series/event-series-selection";
 
@@ -24,12 +24,18 @@ export default async function AppLayout({ children }: LayoutProps<"/app">) {
     ? ((await cookies()).get(EVENT_SERIES_COOKIE_NAME)?.value ?? undefined)
     : undefined;
   const fallbackEventSeriesId = isTeacher ? await resolveSelectedEventSeriesId(remembered) : null;
+  const photo = await fetchUserPhoto(user.email);
 
   // Students manage no event series and reach their registration through a link (US-20, US-23).
   return (
     <AppShell
-      nav={isTeacher ? <TeacherNav fallbackEventSeriesId={fallbackEventSeriesId} /> : null}
+      nav={
+        isTeacher ? (
+          <TeacherNav fallbackEventSeriesId={fallbackEventSeriesId} photo={photo} />
+        ) : null
+      }
       scope={isTeacher ? <EventSeriesTagRows /> : null}
+      photo={photo}
     >
       {children}
     </AppShell>

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -3,16 +3,35 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
+import { cookies } from "next/headers";
 import { AppShell } from "@/components/layout/app-shell";
 import { EventSeriesTagRows } from "@/components/layout/event-series-tag-rows";
+import { TeacherNav } from "@/components/layout/teacher-nav";
 import { requireUser } from "@/lib/auth/guards";
+import { resolveSelectedEventSeriesId } from "@/lib/event-series/event-series-service";
+import { EVENT_SERIES_COOKIE_NAME } from "@/lib/event-series/event-series-selection";
 
-// Both roles share this header; the teacher-only navigation is added by a nested layout (US-14, US-15).
+// Both roles share this frame; only a teacher is given a navigation bar (US-14, US-15).
 export default async function AppLayout({ children }: LayoutProps<"/app">) {
   const user = await requireUser();
+  const isTeacher = user.role === "teacher";
+
+  // Read here rather than below the series id, where the layout renders once and then not again
+  // while the teacher moves about beneath it. Resolved rather than trusted: a teacher who has
+  // remembered nothing yet, or remembered one since deleted, still gets a bar that points
+  // somewhere.
+  const remembered = isTeacher
+    ? ((await cookies()).get(EVENT_SERIES_COOKIE_NAME)?.value ?? undefined)
+    : undefined;
+  const fallbackEventSeriesId = isTeacher ? await resolveSelectedEventSeriesId(remembered) : null;
 
   // Students manage no event series and reach their registration through a link (US-20, US-23).
   return (
-    <AppShell scope={user.role === "teacher" ? <EventSeriesTagRows /> : null}>{children}</AppShell>
+    <AppShell
+      nav={isTeacher ? <TeacherNav fallbackEventSeriesId={fallbackEventSeriesId} /> : null}
+      scope={isTeacher ? <EventSeriesTagRows /> : null}
+    >
+      {children}
+    </AppShell>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -60,10 +60,6 @@
 /* Breakpoints follow the Tailwind defaults: base = mobile, md = tablet, lg = desktop. */
 
 :root {
-  /* Fixed, so the columns beside it can be told what is left of the window. Deriving that from
-     the flex layout instead works in Chrome and not in Safari, which will not resolve a stretch
-     through a scroll container whose own height comes from flex-grow. */
-  --header-height: 3rem;
   /* The single accent colour, at the hue of the HTL logo's slate. Nothing else may add chroma. */
   --brand: oklch(0.55 0.17 250);
   --brand-foreground: oklch(0.985 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -70,7 +70,7 @@
   --control-height: calc(var(--spacing) * 8);
   /* The accent colour, at the hue of the HTL logo's slate. */
   --brand: oklch(0.55 0.17 250);
-  --brand-foreground: oklch(0.985 0 0);
+  --brand-foreground: var(--color-white);
   /* The only other chroma in the palette: a series taking registrations. It earns a hue because
      an open series is the state that must be spotted without reading the tag (US-19). */
   --open: var(--color-green-700);
@@ -116,8 +116,10 @@
 }
 
 .dark {
-  --brand: oklch(0.7 0.15 250);
-  --brand-foreground: oklch(0.205 0 0);
+  /* Darker than a dark theme would otherwise ask for, because a filled control is written in
+     white here too, and a lighter accent could not carry it. */
+  --brand: oklch(0.58 0.17 250);
+  --brand-foreground: var(--color-white);
   --open: var(--color-green-600);
   --open-foreground: var(--color-white);
   --open-subtle: var(--color-green-500);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,16 +73,14 @@
   --brand-foreground: oklch(0.985 0 0);
   /* The only other chroma in the palette: a series taking registrations. It earns a hue because
      an open series is the state that must be spotted without reading the tag (US-19). */
-  --open: oklch(0.55 0.14 150);
-  --open-foreground: oklch(0.985 0 0);
-  /* The same thing said quietly, for a series that is open but not the one being worked in.
-     Dimmed by draining the chroma rather than by lightening: a paler green would have to take
-     dark text, and the two greens would then differ in two ways instead of one. */
-  --open-subtle: oklch(0.55 0.06 150);
-  /* A chosen tag standing apart from the rest: a template among series, a report since edited.
-     Filled, so it plainly is chosen, but the lightest fill that still says so. */
-  --neutral: oklch(0.88 0 0);
-  --neutral-foreground: oklch(0.205 0 0);
+  --open: var(--color-green-700);
+  /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
+  --open-foreground: var(--color-white);
+  /* The same green said quietly, for a series that is open but not the one being worked in. */
+  --open-subtle: var(--color-green-600);
+  /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
+  --neutral: var(--color-gray-500);
+  --neutral-foreground: var(--color-white);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -120,11 +118,11 @@
 .dark {
   --brand: oklch(0.7 0.15 250);
   --brand-foreground: oklch(0.205 0 0);
-  --open: oklch(0.72 0.13 150);
-  --open-foreground: oklch(0.205 0 0);
-  --open-subtle: oklch(0.72 0.055 150);
-  --neutral: oklch(0.32 0 0);
-  --neutral-foreground: oklch(0.985 0 0);
+  --open: var(--color-green-600);
+  --open-foreground: var(--color-white);
+  --open-subtle: var(--color-green-500);
+  --neutral: var(--color-gray-500);
+  --neutral-foreground: var(--color-white);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,11 +73,11 @@
   --brand-foreground: var(--color-white);
   /* The only other chroma in the palette: a series taking registrations. It earns a hue because
      an open series is the state that must be spotted without reading the tag (US-19). */
-  --open: var(--color-green-700);
+  --open: var(--color-green-600);
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-600);
+  --open-subtle: var(--color-green-800);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-500);
   --neutral-foreground: var(--color-white);
@@ -120,9 +120,9 @@
      white here too, and a lighter accent could not carry it. */
   --brand: oklch(0.58 0.17 250);
   --brand-foreground: var(--color-white);
-  --open: var(--color-green-600);
+  --open: var(--color-green-500);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-500);
+  --open-subtle: var(--color-green-700);
   --neutral: var(--color-gray-500);
   --neutral-foreground: var(--color-white);
   --background: oklch(0.145 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,6 +48,8 @@
   --color-open-subtle: var(--open-subtle);
   --color-neutral-foreground: var(--neutral-foreground);
   --color-neutral: var(--neutral);
+  --color-template-foreground: var(--template-foreground);
+  --color-template: var(--template);
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
@@ -81,6 +83,9 @@
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
+  /* A template, which is neither open nor closed and cannot become either (US-22). */
+  --template: var(--color-amber-500);
+  --template-foreground: var(--color-white);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -125,6 +130,8 @@
   --open-subtle: var(--color-green-600);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
+  --template: var(--color-amber-400);
+  --template-foreground: var(--color-white);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,14 +80,14 @@
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-900);
+  --open-subtle: var(--color-green-800);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
   --template: var(--color-amber-500);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-900);
+  --template-subtle: var(--color-amber-800);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -129,12 +129,12 @@
   --brand-foreground: var(--color-white);
   --open: var(--color-green-400);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-900);
+  --open-subtle: var(--color-green-800);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --template: var(--color-amber-400);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-900);
+  --template-subtle: var(--color-amber-800);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,7 +77,7 @@
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-700);
+  --open-subtle: var(--color-green-500);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
@@ -122,7 +122,7 @@
   --brand-foreground: var(--color-white);
   --open: var(--color-green-500);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-600);
+  --open-subtle: var(--color-green-400);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --background: oklch(0.145 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,9 +89,9 @@
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
-  --template: var(--color-amber-500);
+  --template: var(--color-gray-500);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-800);
+  --template-subtle: var(--color-gray-800);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -137,9 +137,9 @@
   --open-subtle: var(--color-green-800);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
-  --template: var(--color-amber-400);
+  --template: var(--color-gray-400);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-800);
+  --template-subtle: var(--color-gray-800);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,14 +80,14 @@
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-700);
+  --open-subtle: var(--color-green-600);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
   --template: var(--color-amber-500);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-700);
+  --template-subtle: var(--color-amber-600);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -129,12 +129,12 @@
   --brand-foreground: var(--color-white);
   --open: var(--color-green-400);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-600);
+  --open-subtle: var(--color-green-500);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --template: var(--color-amber-400);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-600);
+  --template-subtle: var(--color-amber-500);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,14 +80,14 @@
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-600);
+  --open-subtle: var(--color-green-900);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
   --template: var(--color-amber-500);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-600);
+  --template-subtle: var(--color-amber-900);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -129,12 +129,12 @@
   --brand-foreground: var(--color-white);
   --open: var(--color-green-400);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-500);
+  --open-subtle: var(--color-green-900);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --template: var(--color-amber-400);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-500);
+  --template-subtle: var(--color-amber-900);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,6 +43,8 @@
   --color-secondary: var(--secondary);
   --color-primary-foreground: var(--primary-foreground);
   --color-primary: var(--primary);
+  --color-open-foreground: var(--open-foreground);
+  --color-open: var(--open);
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
@@ -60,9 +62,13 @@
 /* Breakpoints follow the Tailwind defaults: base = mobile, md = tablet, lg = desktop. */
 
 :root {
-  /* The single accent colour, at the hue of the HTL logo's slate. Nothing else may add chroma. */
+  /* The accent colour, at the hue of the HTL logo's slate. */
   --brand: oklch(0.55 0.17 250);
   --brand-foreground: oklch(0.985 0 0);
+  /* The only other chroma in the palette: a series taking registrations. It earns a hue because
+     an open series is the state that must be spotted without reading the tag (US-19). */
+  --open: oklch(0.55 0.14 150);
+  --open-foreground: oklch(0.985 0 0);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -100,6 +106,8 @@
 .dark {
   --brand: oklch(0.7 0.15 250);
   --brand-foreground: oklch(0.205 0 0);
+  --open: oklch(0.72 0.13 150);
+  --open-foreground: oklch(0.205 0 0);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,7 +77,7 @@
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-800);
+  --open-subtle: var(--color-green-700);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
@@ -122,7 +122,7 @@
   --brand-foreground: var(--color-white);
   --open: var(--color-green-500);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-700);
+  --open-subtle: var(--color-green-600);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --background: oklch(0.145 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,14 +80,14 @@
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-900);
+  --open-subtle: var(--color-green-950);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
   --template: var(--color-amber-500);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-900);
+  --template-subtle: var(--color-amber-950);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -129,12 +129,12 @@
   --brand-foreground: var(--color-white);
   --open: var(--color-green-400);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-900);
+  --open-subtle: var(--color-green-950);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --template: var(--color-amber-400);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-900);
+  --template-subtle: var(--color-amber-950);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,9 +89,9 @@
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
-  --template: var(--color-orange-500);
+  --template: var(--color-yellow-500);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-orange-800);
+  --template-subtle: var(--color-yellow-800);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -137,9 +137,9 @@
   --open-subtle: var(--color-green-800);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
-  --template: var(--color-orange-400);
+  --template: var(--color-yellow-400);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-orange-800);
+  --template-subtle: var(--color-yellow-800);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,14 +80,14 @@
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-600);
+  --open-subtle: var(--color-green-700);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
   --template: var(--color-amber-500);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-600);
+  --template-subtle: var(--color-amber-700);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -129,12 +129,12 @@
   --brand-foreground: var(--color-white);
   --open: var(--color-green-400);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-500);
+  --open-subtle: var(--color-green-600);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --template: var(--color-amber-400);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-500);
+  --template-subtle: var(--color-amber-600);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,6 +43,7 @@
   --color-secondary: var(--secondary);
   --color-primary-foreground: var(--primary-foreground);
   --color-primary: var(--primary);
+  --color-brand-subtle: var(--brand-subtle);
   --color-open-foreground: var(--open-foreground);
   --color-open: var(--open);
   --color-open-subtle: var(--open-subtle);
@@ -74,6 +75,9 @@
   /* The accent colour, at the hue of the HTL logo's slate. */
   --brand: oklch(0.55 0.17 250);
   --brand-foreground: var(--color-white);
+  /* The same blue at the weight the other tag colours use unselected, so a series, a template
+     and an open series recede by the same amount when they are not the chosen one. */
+  --brand-subtle: oklch(0.35 0.12 250);
   /* The only other chroma in the palette: a series taking registrations. It earns a hue because
      an open series is the state that must be spotted without reading the tag (US-19). */
   --open: var(--color-green-500);
@@ -127,6 +131,7 @@
      white here too, and a lighter accent could not carry it. */
   --brand: oklch(0.58 0.17 250);
   --brand-foreground: var(--color-white);
+  --brand-subtle: oklch(0.35 0.12 250);
   --open: var(--color-green-400);
   --open-foreground: var(--color-white);
   --open-subtle: var(--color-green-800);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,8 +76,9 @@
   --open: oklch(0.55 0.14 150);
   --open-foreground: oklch(0.985 0 0);
   /* The same thing said quietly, for a series that is open but not the one being worked in.
-     Enough green to be read as green across a row, and no more. */
-  --open-subtle: color-mix(in oklch, var(--open) 25%, var(--background));
+     Dimmed by draining the chroma rather than by lightening: a paler green would have to take
+     dark text, and the two greens would then differ in two ways instead of one. */
+  --open-subtle: oklch(0.55 0.06 150);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited.
      Filled, so it plainly is chosen, but the lightest fill that still says so. */
   --neutral: oklch(0.88 0 0);
@@ -121,7 +122,7 @@
   --brand-foreground: oklch(0.205 0 0);
   --open: oklch(0.72 0.13 150);
   --open-foreground: oklch(0.205 0 0);
-  --open-subtle: color-mix(in oklch, var(--open) 30%, var(--background));
+  --open-subtle: oklch(0.72 0.055 150);
   --neutral: oklch(0.32 0 0);
   --neutral-foreground: oklch(0.985 0 0);
   --background: oklch(0.145 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,14 +80,14 @@
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-950);
+  --open-subtle: var(--color-green-900);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
   --template: var(--color-amber-500);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-950);
+  --template-subtle: var(--color-amber-900);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -129,12 +129,12 @@
   --brand-foreground: var(--color-white);
   --open: var(--color-green-400);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-950);
+  --open-subtle: var(--color-green-900);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --template: var(--color-amber-400);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-950);
+  --template-subtle: var(--color-amber-900);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,7 +79,7 @@
   /* The same green said quietly, for a series that is open but not the one being worked in. */
   --open-subtle: var(--color-green-800);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
-  --neutral: var(--color-gray-500);
+  --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -123,7 +123,7 @@
   --open: var(--color-green-500);
   --open-foreground: var(--color-white);
   --open-subtle: var(--color-green-700);
-  --neutral: var(--color-gray-500);
+  --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,7 +77,7 @@
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-500);
+  --open-subtle: var(--color-green-700);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
@@ -122,7 +122,7 @@
   --brand-foreground: var(--color-white);
   --open: var(--color-green-500);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-400);
+  --open-subtle: var(--color-green-600);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --background: oklch(0.145 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,6 +45,9 @@
   --color-primary: var(--primary);
   --color-open-foreground: var(--open-foreground);
   --color-open: var(--open);
+  --color-open-subtle: var(--open-subtle);
+  --color-neutral-foreground: var(--neutral-foreground);
+  --color-neutral: var(--neutral);
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
@@ -69,6 +72,11 @@
      an open series is the state that must be spotted without reading the tag (US-19). */
   --open: oklch(0.55 0.14 150);
   --open-foreground: oklch(0.985 0 0);
+  /* The same thing said quietly, for a series that is open but not the one being worked in. */
+  --open-subtle: color-mix(in oklch, var(--open) 12%, var(--background));
+  /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
+  --neutral: oklch(0.45 0 0);
+  --neutral-foreground: oklch(0.985 0 0);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -108,6 +116,9 @@
   --brand-foreground: oklch(0.205 0 0);
   --open: oklch(0.72 0.13 150);
   --open-foreground: oklch(0.205 0 0);
+  --open-subtle: color-mix(in oklch, var(--open) 18%, var(--background));
+  --neutral: oklch(0.75 0 0);
+  --neutral-foreground: oklch(0.205 0 0);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,6 +65,9 @@
 /* Breakpoints follow the Tailwind defaults: base = mobile, md = tablet, lg = desktop. */
 
 :root {
+  /* The height every control shares — buttons, fields, selects, tags — so a row of them lines up
+     without anyone choosing. A single control may override it; nothing else should have to. */
+  --control-height: calc(var(--spacing) * 8);
   /* The accent colour, at the hue of the HTL logo's slate. */
   --brand: oklch(0.55 0.17 250);
   --brand-foreground: oklch(0.985 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,6 +50,7 @@
   --color-neutral: var(--neutral);
   --color-template-foreground: var(--template-foreground);
   --color-template: var(--template);
+  --color-template-subtle: var(--template-subtle);
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
@@ -75,17 +76,18 @@
   --brand-foreground: var(--color-white);
   /* The only other chroma in the palette: a series taking registrations. It earns a hue because
      an open series is the state that must be spotted without reading the tag (US-19). */
-  --open: var(--color-green-500);
+  --open: var(--color-green-600);
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-700);
+  --open-subtle: var(--color-green-500);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
-  --template: var(--color-amber-500);
+  --template: var(--color-amber-600);
   --template-foreground: var(--color-white);
+  --template-subtle: var(--color-amber-500);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -125,13 +127,14 @@
      white here too, and a lighter accent could not carry it. */
   --brand: oklch(0.58 0.17 250);
   --brand-foreground: var(--color-white);
-  --open: var(--color-green-400);
+  --open: var(--color-green-500);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-600);
+  --open-subtle: var(--color-green-400);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
-  --template: var(--color-amber-400);
+  --template: var(--color-amber-500);
   --template-foreground: var(--color-white);
+  --template-subtle: var(--color-amber-400);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,9 +89,9 @@
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
-  --template: var(--color-yellow-500);
+  --template: var(--color-gray-500);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-yellow-800);
+  --template-subtle: var(--color-gray-800);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -137,9 +137,9 @@
   --open-subtle: var(--color-green-800);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
-  --template: var(--color-yellow-400);
+  --template: var(--color-gray-400);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-yellow-800);
+  --template-subtle: var(--color-gray-800);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,18 +76,18 @@
   --brand-foreground: var(--color-white);
   /* The only other chroma in the palette: a series taking registrations. It earns a hue because
      an open series is the state that must be spotted without reading the tag (US-19). */
-  --open: var(--color-green-600);
+  --open: var(--color-green-500);
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-500);
+  --open-subtle: var(--color-green-600);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
-  --template: var(--color-amber-600);
+  --template: var(--color-amber-500);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-500);
+  --template-subtle: var(--color-amber-600);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -127,14 +127,14 @@
      white here too, and a lighter accent could not carry it. */
   --brand: oklch(0.58 0.17 250);
   --brand-foreground: var(--color-white);
-  --open: var(--color-green-500);
+  --open: var(--color-green-400);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-400);
+  --open-subtle: var(--color-green-500);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
-  --template: var(--color-amber-500);
+  --template: var(--color-amber-400);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-amber-400);
+  --template-subtle: var(--color-amber-500);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,11 +73,11 @@
   --brand-foreground: var(--color-white);
   /* The only other chroma in the palette: a series taking registrations. It earns a hue because
      an open series is the state that must be spotted without reading the tag (US-19). */
-  --open: var(--color-green-800);
+  --open: var(--color-green-500);
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-400);
+  --open-subtle: var(--color-green-700);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
@@ -120,9 +120,9 @@
      white here too, and a lighter accent could not carry it. */
   --brand: oklch(0.58 0.17 250);
   --brand-foreground: var(--color-white);
-  --open: var(--color-green-800);
+  --open: var(--color-green-400);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-400);
+  --open-subtle: var(--color-green-600);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --background: oklch(0.145 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,11 +73,11 @@
   --brand-foreground: var(--color-white);
   /* The only other chroma in the palette: a series taking registrations. It earns a hue because
      an open series is the state that must be spotted without reading the tag (US-19). */
-  --open: var(--color-green-600);
+  --open: var(--color-green-800);
   /* Selected always means white on a fill, so every one of these is dark enough to carry it. */
   --open-foreground: var(--color-white);
   /* The same green said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: var(--color-green-700);
+  --open-subtle: var(--color-green-400);
   /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
@@ -120,9 +120,9 @@
      white here too, and a lighter accent could not carry it. */
   --brand: oklch(0.58 0.17 250);
   --brand-foreground: var(--color-white);
-  --open: var(--color-green-500);
+  --open: var(--color-green-800);
   --open-foreground: var(--color-white);
-  --open-subtle: var(--color-green-600);
+  --open-subtle: var(--color-green-400);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
   --background: oklch(0.145 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,9 +89,9 @@
   --neutral: var(--color-gray-700);
   --neutral-foreground: var(--color-white);
   /* A template, which is neither open nor closed and cannot become either (US-22). */
-  --template: var(--color-gray-500);
+  --template: var(--color-orange-500);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-gray-800);
+  --template-subtle: var(--color-orange-800);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -137,9 +137,9 @@
   --open-subtle: var(--color-green-800);
   --neutral: var(--color-gray-600);
   --neutral-foreground: var(--color-white);
-  --template: var(--color-gray-400);
+  --template: var(--color-orange-400);
   --template-foreground: var(--color-white);
-  --template-subtle: var(--color-gray-800);
+  --template-subtle: var(--color-orange-800);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,11 +75,13 @@
      an open series is the state that must be spotted without reading the tag (US-19). */
   --open: oklch(0.55 0.14 150);
   --open-foreground: oklch(0.985 0 0);
-  /* The same thing said quietly, for a series that is open but not the one being worked in. */
-  --open-subtle: color-mix(in oklch, var(--open) 12%, var(--background));
-  /* A chosen tag standing apart from the rest: a template among series, a report since edited. */
-  --neutral: oklch(0.45 0 0);
-  --neutral-foreground: oklch(0.985 0 0);
+  /* The same thing said quietly, for a series that is open but not the one being worked in.
+     Enough green to be read as green across a row, and no more. */
+  --open-subtle: color-mix(in oklch, var(--open) 25%, var(--background));
+  /* A chosen tag standing apart from the rest: a template among series, a report since edited.
+     Filled, so it plainly is chosen, but the lightest fill that still says so. */
+  --neutral: oklch(0.88 0 0);
+  --neutral-foreground: oklch(0.205 0 0);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -119,9 +121,9 @@
   --brand-foreground: oklch(0.205 0 0);
   --open: oklch(0.72 0.13 150);
   --open-foreground: oklch(0.205 0 0);
-  --open-subtle: color-mix(in oklch, var(--open) 18%, var(--background));
-  --neutral: oklch(0.75 0 0);
-  --neutral-foreground: oklch(0.205 0 0);
+  --open-subtle: color-mix(in oklch, var(--open) 30%, var(--background));
+  --neutral: oklch(0.32 0 0);
+  --neutral-foreground: oklch(0.985 0 0);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/globals.test.ts
+++ b/src/app/globals.test.ts
@@ -14,7 +14,7 @@ const css = readFileSync("src/app/globals.css", "utf8");
  * The only tokens allowed to carry chroma: the accent, the danger colour, and the two greens of
  * a series taking registrations — the one state a teacher has to spot without reading (US-19).
  */
-const CHROMATIC_TOKENS = ["--brand", "--destructive", "--open", "--open-subtle"];
+const CHROMATIC_TOKENS = ["--brand", "--destructive", "--open", "--open-subtle", "--template"];
 
 function themeBlock(selector: string): string {
   const match = css.match(new RegExp(`${selector}\\s*\\{([\\s\\S]*?)\\n\\}`));
@@ -72,12 +72,14 @@ describe.each([
    * Selected means white on a fill, in either theme. A control that changed its ink between
    * themes would be two designs, and a row of them would agree in one and not the other.
    */
-  it.each(["--brand-foreground", "--open-foreground", "--neutral-foreground"])(
-    "writes %s in the white a selected control is written in",
-    (token) => {
-      expect(decls.find((d) => d.name === token)?.value).toBe("var(--color-white)");
-    },
-  );
+  it.each([
+    "--brand-foreground",
+    "--open-foreground",
+    "--neutral-foreground",
+    "--template-foreground",
+  ])("writes %s in the white a selected control is written in", (token) => {
+    expect(decls.find((d) => d.name === token)?.value).toBe("var(--color-white)");
+  });
 
   it("drives focus rings from the accent", () => {
     expect(decls.find((d) => d.name === "--ring")?.value).toContain("var(--brand)");

--- a/src/app/globals.test.ts
+++ b/src/app/globals.test.ts
@@ -16,6 +16,7 @@ const css = readFileSync("src/app/globals.css", "utf8");
  */
 const CHROMATIC_TOKENS = [
   "--brand",
+  "--brand-subtle",
   "--destructive",
   "--open",
   "--open-subtle",

--- a/src/app/globals.test.ts
+++ b/src/app/globals.test.ts
@@ -14,7 +14,15 @@ const css = readFileSync("src/app/globals.css", "utf8");
  * The only tokens allowed to carry chroma: the accent, the danger colour, and the two greens of
  * a series taking registrations — the one state a teacher has to spot without reading (US-19).
  */
-const CHROMATIC_TOKENS = ["--brand", "--brand-subtle", "--destructive", "--open", "--open-subtle"];
+const CHROMATIC_TOKENS = [
+  "--brand",
+  "--brand-subtle",
+  "--destructive",
+  "--open",
+  "--open-subtle",
+  "--template",
+  "--template-subtle",
+];
 
 function themeBlock(selector: string): string {
   const match = css.match(new RegExp(`${selector}\\s*\\{([\\s\\S]*?)\\n\\}`));

--- a/src/app/globals.test.ts
+++ b/src/app/globals.test.ts
@@ -10,8 +10,11 @@ import { describe, expect, it } from "vitest";
 // and red reserved for warning dialogs / error messages.
 const css = readFileSync("src/app/globals.css", "utf8");
 
-/** The only tokens allowed to carry chroma: the single accent, and the danger colour. */
-const CHROMATIC_TOKENS = ["--brand", "--destructive"];
+/**
+ * The only tokens allowed to carry chroma: the accent, the danger colour, and the green of a
+ * series taking registrations — the one state a teacher has to spot without reading (US-19).
+ */
+const CHROMATIC_TOKENS = ["--brand", "--destructive", "--open"];
 
 function themeBlock(selector: string): string {
   const match = css.match(new RegExp(`${selector}\\s*\\{([\\s\\S]*?)\\n\\}`));
@@ -44,7 +47,7 @@ describe.each([
     expect(chroma(brand!.value)).toBeGreaterThan(0);
   });
 
-  it("introduces no colour beyond the accent and the danger token", () => {
+  it("introduces no colour beyond the accent, the danger and the open token", () => {
     const chromatic = decls
       .filter((d) => (chroma(d.value) ?? 0) > 0)
       .map((d) => d.name)

--- a/src/app/globals.test.ts
+++ b/src/app/globals.test.ts
@@ -11,10 +11,10 @@ import { describe, expect, it } from "vitest";
 const css = readFileSync("src/app/globals.css", "utf8");
 
 /**
- * The only tokens allowed to carry chroma: the accent, the danger colour, and the green of a
- * series taking registrations — the one state a teacher has to spot without reading (US-19).
+ * The only tokens allowed to carry chroma: the accent, the danger colour, and the two greens of
+ * a series taking registrations — the one state a teacher has to spot without reading (US-19).
  */
-const CHROMATIC_TOKENS = ["--brand", "--destructive", "--open"];
+const CHROMATIC_TOKENS = ["--brand", "--destructive", "--open", "--open-subtle"];
 
 function themeBlock(selector: string): string {
   const match = css.match(new RegExp(`${selector}\\s*\\{([\\s\\S]*?)\\n\\}`));

--- a/src/app/globals.test.ts
+++ b/src/app/globals.test.ts
@@ -68,6 +68,17 @@ describe.each([
     expect(chromatic).toEqual([...CHROMATIC_TOKENS].sort());
   });
 
+  /**
+   * Selected means white on a fill, in either theme. A control that changed its ink between
+   * themes would be two designs, and a row of them would agree in one and not the other.
+   */
+  it.each(["--brand-foreground", "--open-foreground", "--neutral-foreground"])(
+    "writes %s in the white a selected control is written in",
+    (token) => {
+      expect(decls.find((d) => d.name === token)?.value).toBe("var(--color-white)");
+    },
+  );
+
   it("drives focus rings from the accent", () => {
     expect(decls.find((d) => d.name === "--ring")?.value).toContain("var(--brand)");
   });

--- a/src/app/globals.test.ts
+++ b/src/app/globals.test.ts
@@ -14,15 +14,7 @@ const css = readFileSync("src/app/globals.css", "utf8");
  * The only tokens allowed to carry chroma: the accent, the danger colour, and the two greens of
  * a series taking registrations — the one state a teacher has to spot without reading (US-19).
  */
-const CHROMATIC_TOKENS = [
-  "--brand",
-  "--brand-subtle",
-  "--destructive",
-  "--open",
-  "--open-subtle",
-  "--template",
-  "--template-subtle",
-];
+const CHROMATIC_TOKENS = ["--brand", "--brand-subtle", "--destructive", "--open", "--open-subtle"];
 
 function themeBlock(selector: string): string {
   const match = css.match(new RegExp(`${selector}\\s*\\{([\\s\\S]*?)\\n\\}`));

--- a/src/app/globals.test.ts
+++ b/src/app/globals.test.ts
@@ -29,10 +29,22 @@ function declarations(block: string): { name: string; value: string }[] {
   }));
 }
 
-/** Chroma of a literal `oklch(L C H)` value, or null when the value isn't a literal colour. */
+/** Families that carry no chroma, whatever step of them is used. */
+const GREYSCALE = ["slate", "gray", "zinc", "neutral", "stone"];
+
+/**
+ * Chroma of a literal `oklch(L C H)` value, or of a reference to the Tailwind palette, or null
+ * when the value is neither. A palette step is taken at its word rather than resolved: what the
+ * check is for is that no third hue appears, not what shade the second one is.
+ */
 function chroma(value: string): number | null {
-  const match = value.match(/^oklch\(\s*[\d.]+%?\s+([\d.]+)/);
-  return match ? Number(match[1]) : null;
+  const literal = value.match(/^oklch\(\s*[\d.]+%?\s+([\d.]+)/);
+  if (literal) return Number(literal[1]);
+
+  const palette = value.match(/^var\(--color-([a-z]+)-\d+\)$/);
+  if (palette) return GREYSCALE.includes(palette[1]) ? 0 : 1;
+
+  return null;
 }
 
 describe.each([

--- a/src/app/globals.test.ts
+++ b/src/app/globals.test.ts
@@ -14,7 +14,14 @@ const css = readFileSync("src/app/globals.css", "utf8");
  * The only tokens allowed to carry chroma: the accent, the danger colour, and the two greens of
  * a series taking registrations — the one state a teacher has to spot without reading (US-19).
  */
-const CHROMATIC_TOKENS = ["--brand", "--destructive", "--open", "--open-subtle", "--template"];
+const CHROMATIC_TOKENS = [
+  "--brand",
+  "--destructive",
+  "--open",
+  "--open-subtle",
+  "--template",
+  "--template-subtle",
+];
 
 function themeBlock(selector: string): string {
   const match = css.match(new RegExp(`${selector}\\s*\\{([\\s\\S]*?)\\n\\}`));

--- a/src/components/assignment/assignment-board.test.tsx
+++ b/src/components/assignment/assignment-board.test.tsx
@@ -281,7 +281,8 @@ describe("AssignmentBoard — what the figures count", () => {
 
     const heading = card("Nicht zugeteilt").getByRole("heading", { name: "Statistik" });
 
-    expect(heading.parentElement).toContainElement(toggleIn("Nicht zugeteilt"));
+    // The heading row itself, whatever the heading is wrapped in on the way up to it.
+    expect(heading.closest("div")).toContainElement(toggleIn("Nicht zugeteilt"));
   });
 
   it("carries the two genders, their sum and the share of everyone taking part in one table", () => {

--- a/src/components/assignment/assignment-card.tsx
+++ b/src/components/assignment/assignment-card.tsx
@@ -14,9 +14,9 @@ import {
   type PointerEventHandler,
 } from "react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
-import { ChevronRight, GripVertical } from "lucide-react";
+import { GripVertical } from "lucide-react";
 import { FilterTagList } from "@/components/filters/filter-tag-list";
-import { Card, CardContent, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeading, CardTitle } from "@/components/ui/card";
 import {
   attendingCounts,
   type AssignmentGroup,
@@ -99,21 +99,15 @@ export function AssignmentCard({
       className={cn("transition-shadow", isOver && "ring-ring ring-2")}
     >
       <CardContent className="flex flex-col gap-4">
-        <CardTitle className="flex items-center gap-1.5">
-          <button
-            type="button"
-            aria-label={`Details zu ${group.title}`}
-            aria-expanded={expanded}
-            onClick={() => setExpanded((open) => !open)}
-            className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 rounded-md p-0.5 transition-colors outline-none focus-visible:ring-3"
-          >
-            <ChevronRight
-              aria-hidden
-              className={cn("size-4 transition-transform", expanded && "rotate-90")}
-            />
-          </button>
-          {`${group.title}: ${group.students.length}`}
-        </CardTitle>
+        <CardHeading
+          fold={{
+            open: expanded,
+            label: `Details zu ${group.title}`,
+            onOpenChange: setExpanded,
+          }}
+        >
+          <CardTitle className="truncate">{`${group.title}: ${group.students.length}`}</CardTitle>
+        </CardHeading>
 
         {expanded && (
           <div className={AREAS}>

--- a/src/components/assignment/card-areas.tsx
+++ b/src/components/assignment/card-areas.tsx
@@ -4,7 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import type { ReactNode } from "react";
-import { Tag } from "@/components/ui/tag";
+import { Tag, TagName } from "@/components/ui/tag";
 
 /**
  * Each area gets a surface of its own, so three columns of content read as three areas rather
@@ -49,11 +49,8 @@ export function FilteredTag({
   onPress: () => void;
 }) {
   return (
-    <Tag
-      label={`${card}: ${FILTERED_LABEL}`}
-      text={FILTERED_LABEL}
-      pressed={pressed}
-      onPress={onPress}
-    />
+    <Tag pressed={pressed}>
+      <TagName label={`${card}: ${FILTERED_LABEL}`} text={FILTERED_LABEL} onPress={onPress} />
+    </Tag>
   );
 }

--- a/src/components/assignment/card-areas.tsx
+++ b/src/components/assignment/card-areas.tsx
@@ -23,7 +23,7 @@ export function AreaTitle({ children, aside }: { children: string; aside?: React
   return (
     // Floored at the height of the tallest aside, or an area carrying a tag would sit lower than
     // one carrying plain text and the three headings would stop lining up.
-    <div className="mb-2 flex min-h-7 items-center justify-between gap-3">
+    <div className="mb-2 flex min-h-8 items-center justify-between gap-3">
       <h3 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
         {children}
       </h3>

--- a/src/components/assignment/card-areas.tsx
+++ b/src/components/assignment/card-areas.tsx
@@ -4,6 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import type { ReactNode } from "react";
+import { CardHeading } from "@/components/ui/card";
 import { Tag, TagName } from "@/components/ui/tag";
 
 /**
@@ -21,14 +22,11 @@ export const AREA = "border-border bg-muted/40 flex min-h-0 min-w-0 flex-col rou
 /** The aside sits at the far end of the title line — a tally on one area, a toggle on another. */
 export function AreaTitle({ children, aside }: { children: string; aside?: ReactNode }) {
   return (
-    // Floored at the height of the tallest aside, or an area carrying a tag would sit lower than
-    // one carrying plain text and the three headings would stop lining up.
-    <div className="mb-2 flex min-h-8 items-center justify-between gap-3">
-      <h3 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+    <CardHeading control={aside} className="mb-2">
+      <h3 className="text-muted-foreground truncate text-xs font-medium tracking-wide uppercase">
         {children}
       </h3>
-      {aside}
-    </div>
+    </CardHeading>
   );
 }
 

--- a/src/components/auth/sign-out-button.test.tsx
+++ b/src/components/auth/sign-out-button.test.tsx
@@ -38,4 +38,27 @@ describe("SignOutButton", () => {
     expect(signOut).toHaveBeenCalled();
     expect(push).toHaveBeenCalledWith("/");
   });
+
+  /** The mark is the person's own where Entra has one, and a generic one where it has not. */
+  it("wears the photo it is given", () => {
+    render(<SignOutButton photo="data:image/jpeg;base64,AAA" />);
+
+    const mark = screen.getByRole("button", { name: "Abmelden" }).querySelector("img");
+    expect(mark).toHaveAttribute("src", expect.stringContaining("data:image/jpeg"));
+  });
+
+  it("falls back to a drawn mark when there is no photo", () => {
+    render(<SignOutButton />);
+
+    const button = screen.getByRole("button", { name: "Abmelden" });
+    expect(button.querySelector("img")).not.toBeInTheDocument();
+    expect(button.querySelector("svg")).toBeInTheDocument();
+  });
+
+  /** The name is already on the button, so the photo repeating it would only be read twice. */
+  it("leaves the photo out of the accessible name", () => {
+    render(<SignOutButton photo="data:image/jpeg;base64,AAA" />);
+
+    expect(screen.getByRole("button", { name: "Abmelden" })).toBeInTheDocument();
+  });
 });

--- a/src/components/auth/sign-out-button.tsx
+++ b/src/components/auth/sign-out-button.tsx
@@ -7,10 +7,16 @@
 
 import { useRouter } from "next/navigation";
 import { signOut } from "firebase/auth";
+import { CircleUserRound } from "lucide-react";
 import { auth } from "@/lib/firebase/client";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
-export function SignOutButton() {
+/**
+ * Signing out, wearing the person who is signed in. It reads as a row of the navigation bar,
+ * because that is where it sits for a teacher; a student has no bar and gets it in the header.
+ */
+export function SignOutButton({ labelHidden = false }: { labelHidden?: boolean }) {
   const router = useRouter();
 
   async function handleSignOut() {
@@ -22,8 +28,13 @@ export function SignOutButton() {
 
   return (
     // No fill at all: a filled button marks what a page wants pressed, and signing out never is.
-    <Button variant="ghost" onClick={handleSignOut}>
-      Abmelden
+    <Button
+      variant="ghost"
+      className="min-h-9 w-full justify-start gap-3 px-2 py-2"
+      onClick={handleSignOut}
+    >
+      <CircleUserRound aria-hidden className="size-6 shrink-0" />
+      <span className={cn(labelHidden && "md:sr-only")}>Abmelden</span>
     </Button>
   );
 }

--- a/src/components/auth/sign-out-button.tsx
+++ b/src/components/auth/sign-out-button.tsx
@@ -23,11 +23,9 @@ import { cn } from "@/lib/utils";
  */
 export function SignOutButton({
   className,
-  labelHidden = false,
   photo = null,
 }: {
   className?: string;
-  labelHidden?: boolean;
   photo?: string | null;
 }) {
   const router = useRouter();
@@ -54,7 +52,7 @@ export function SignOutButton({
           className="size-6 shrink-0 rounded-full object-cover"
         />
       )}
-      <span className={cn(labelHidden && "md:sr-only")}>Abmelden</span>
+      <span>Abmelden</span>
     </Button>
   );
 }

--- a/src/components/auth/sign-out-button.tsx
+++ b/src/components/auth/sign-out-button.tsx
@@ -13,10 +13,17 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 /**
- * Signing out, wearing the person who is signed in. It reads as a row of the navigation bar,
- * because that is where it sits for a teacher; a student has no bar and gets it in the header.
+ * Signing out, wearing the mark of the person doing it. Where it sits decides its shape: a row
+ * at the foot of the navigation bar for a teacher, a control on the right of the header for a
+ * student, who has no bar.
  */
-export function SignOutButton({ labelHidden = false }: { labelHidden?: boolean }) {
+export function SignOutButton({
+  className,
+  labelHidden = false,
+}: {
+  className?: string;
+  labelHidden?: boolean;
+}) {
   const router = useRouter();
 
   async function handleSignOut() {
@@ -28,11 +35,7 @@ export function SignOutButton({ labelHidden = false }: { labelHidden?: boolean }
 
   return (
     // No fill at all: a filled button marks what a page wants pressed, and signing out never is.
-    <Button
-      variant="ghost"
-      className="min-h-9 w-full justify-start gap-3 px-2 py-2"
-      onClick={handleSignOut}
-    >
+    <Button variant="ghost" className={cn("gap-3", className)} onClick={handleSignOut}>
       <CircleUserRound aria-hidden className="size-6 shrink-0" />
       <span className={cn(labelHidden && "md:sr-only")}>Abmelden</span>
     </Button>

--- a/src/components/auth/sign-out-button.tsx
+++ b/src/components/auth/sign-out-button.tsx
@@ -6,6 +6,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { signOut } from "firebase/auth";
 import { CircleUserRound } from "lucide-react";
 import { auth } from "@/lib/firebase/client";
@@ -16,13 +17,18 @@ import { cn } from "@/lib/utils";
  * Signing out, wearing the mark of the person doing it. Where it sits decides its shape: a row
  * at the foot of the navigation bar for a teacher, a control on the right of the header for a
  * student, who has no bar.
+ *
+ * The mark is the Entra photo where the account has one, read at sign-in and kept on the record
+ * (US-1) — Graph serves it to a bearer token, which the browser does not have.
  */
 export function SignOutButton({
   className,
   labelHidden = false,
+  photo = null,
 }: {
   className?: string;
   labelHidden?: boolean;
+  photo?: string | null;
 }) {
   const router = useRouter();
 
@@ -36,7 +42,18 @@ export function SignOutButton({
   return (
     // No fill at all: a filled button marks what a page wants pressed, and signing out never is.
     <Button variant="ghost" className={cn("gap-3", className)} onClick={handleSignOut}>
-      <CircleUserRound aria-hidden className="size-6 shrink-0" />
+      {photo === null ? (
+        <CircleUserRound aria-hidden className="size-6 shrink-0" />
+      ) : (
+        // The button is already named, so the photo adds nothing by being described again.
+        <Image
+          src={photo}
+          alt=""
+          width={24}
+          height={24}
+          className="size-6 shrink-0 rounded-full object-cover"
+        />
+      )}
       <span className={cn(labelHidden && "md:sr-only")}>Abmelden</span>
     </Button>
   );

--- a/src/components/event-series/event-series-form-dialog.test.tsx
+++ b/src/components/event-series/event-series-form-dialog.test.tsx
@@ -10,7 +10,7 @@ import { ApiRequestError } from "@/lib/api/client";
 import type { ErrorCode } from "@/lib/errors";
 import type { EventSeries } from "@/lib/schemas/event-series";
 import { storedEventSeries } from "@/test/event-series";
-import { EventSeriesFormDialog } from "./event-series-form-dialog";
+import { EventSeriesFormDialog, type NewEventSeries } from "./event-series-form-dialog";
 
 const eventSeries: EventSeries = { id: "s1", ...storedEventSeries({ name: "Winter 2026" }) };
 
@@ -21,7 +21,8 @@ const eventSeries: EventSeries = { id: "s1", ...storedEventSeries({ name: "Winte
 function renderDialog(
   options: {
     eventSeries?: EventSeries | null;
-    onSubmit?: (name: string, eventSeries: EventSeries | null) => Promise<void>;
+    sources?: EventSeries[];
+    onSubmit?: (values: NewEventSeries, eventSeries: EventSeries | null) => Promise<void>;
   } = {},
 ) {
   const onSubmit = options.onSubmit ?? vi.fn().mockResolvedValue(undefined);
@@ -32,6 +33,7 @@ function renderDialog(
     <EventSeriesFormDialog
       open
       eventSeries={options.eventSeries ?? null}
+      sources={options.sources ?? []}
       onSubmit={onSubmit}
       onClose={onClose}
       onSaved={onSaved}
@@ -51,7 +53,73 @@ describe("EventSeriesFormDialog — creating", () => {
     await userEvent.type(screen.getByLabelText("Name"), "Wintersportwoche 2026");
     await userEvent.click(screen.getByRole("button", { name: "Anlegen" }));
 
-    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith("Wintersportwoche 2026", null));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { name: "Wintersportwoche 2026", isTemplate: false, sourceId: null },
+        null,
+      ),
+    );
+  });
+
+  /**
+   * Three questions, one write (US-22). The kind is answered on its own, so a template copied
+   * from a template is as ordinary as a series copied from one.
+   */
+  it("makes a template when that is the kind chosen", async () => {
+    const { onSubmit } = renderDialog();
+
+    await userEvent.type(screen.getByLabelText("Name"), "Wintersportwochen");
+    await userEvent.click(screen.getByRole("radio", { name: "Vorlage" }));
+    await userEvent.click(screen.getByRole("button", { name: "Anlegen" }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { name: "Wintersportwochen", isTemplate: true, sourceId: null },
+        null,
+      ),
+    );
+  });
+
+  it("starts blank, which is what naming no source means", () => {
+    renderDialog({ sources: [eventSeries] });
+
+    expect(screen.getByRole("radio", { name: "Eventreihe" })).toBeChecked();
+    expect(screen.getByLabelText("Einstellungen übernehmen von")).toHaveTextContent("Ohne");
+  });
+
+  /** Colour is already spoken for, so what an entry is says so in words (US-22). */
+  it("says which sources are templates and which are archived", async () => {
+    renderDialog({
+      sources: [
+        { id: "t1", ...storedEventSeries({ name: "Wintersportwochen", isTemplate: true }) },
+        { id: "a1", ...storedEventSeries({ name: "Winter 2025", isArchived: true }) },
+        eventSeries,
+      ],
+    });
+
+    await userEvent.click(screen.getByLabelText("Einstellungen übernehmen von"));
+
+    expect(
+      await screen.findByRole("option", { name: "Wintersportwochen (Vorlage)" }),
+    ).toBeVisible();
+    expect(await screen.findByRole("option", { name: "Winter 2025 (Archiviert)" })).toBeVisible();
+    expect(await screen.findByRole("option", { name: "Winter 2026" })).toBeVisible();
+  });
+
+  it("hands over the source that was chosen", async () => {
+    const { onSubmit } = renderDialog({ sources: [eventSeries] });
+
+    await userEvent.type(screen.getByLabelText("Name"), "Winter 2027");
+    await userEvent.click(screen.getByLabelText("Einstellungen übernehmen von"));
+    await userEvent.click(await screen.findByRole("option", { name: "Winter 2026" }));
+    await userEvent.click(screen.getByRole("button", { name: "Anlegen" }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { name: "Winter 2027", isTemplate: false, sourceId: "s1" },
+        null,
+      ),
+    );
   });
 
   it("reports the saved event series to the caller so the list can react", async () => {
@@ -116,7 +184,20 @@ describe("EventSeriesFormDialog — editing", () => {
     await userEvent.type(screen.getByLabelText("Name"), "Winter 2027");
     await userEvent.click(screen.getByRole("button", { name: "Speichern" }));
 
-    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith("Winter 2027", eventSeries));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { name: "Winter 2027", isTemplate: false, sourceId: null },
+        eventSeries,
+      ),
+    );
+  });
+
+  /** The kind and the source are answered at creation; renaming settles neither again (US-22). */
+  it("asks neither the kind nor the source of an event series that exists", () => {
+    renderDialog({ eventSeries, sources: [eventSeries] });
+
+    expect(screen.queryByRole("group", { name: "Art" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Einstellungen übernehmen von")).not.toBeInTheDocument();
   });
 
   it("closes without writing when cancelled", async () => {

--- a/src/components/event-series/event-series-form-dialog.test.tsx
+++ b/src/components/event-series/event-series-form-dialog.test.tsx
@@ -62,15 +62,14 @@ describe("EventSeriesFormDialog — creating", () => {
   });
 
   /**
-   * Three questions, one write (US-22). The kind is answered on its own, so a template copied
-   * from a template is as ordinary as a series copied from one.
+   * Three questions, one write (US-22). The kind is the button that was pressed rather than a
+   * field, so a template copied from a template is as ordinary as a series copied from one.
    */
-  it("makes a template when that is the kind chosen", async () => {
+  it("makes a template when that is the button pressed", async () => {
     const { onSubmit } = renderDialog();
 
     await userEvent.type(screen.getByLabelText("Name"), "Wintersportwochen");
-    await userEvent.click(screen.getByRole("radio", { name: "Vorlage" }));
-    await userEvent.click(screen.getByRole("button", { name: "Anlegen" }));
+    await userEvent.click(screen.getByRole("button", { name: "Als Vorlage anlegen" }));
 
     await waitFor(() =>
       expect(onSubmit).toHaveBeenCalledWith(
@@ -83,7 +82,6 @@ describe("EventSeriesFormDialog — creating", () => {
   it("starts blank, which is what naming no source means", () => {
     renderDialog({ sources: [eventSeries] });
 
-    expect(screen.getByRole("radio", { name: "Eventreihe" })).toBeChecked();
     expect(screen.getByLabelText("Einstellungen übernehmen von")).toHaveTextContent("Ohne");
   });
 
@@ -196,8 +194,44 @@ describe("EventSeriesFormDialog — editing", () => {
   it("asks neither the kind nor the source of an event series that exists", () => {
     renderDialog({ eventSeries, sources: [eventSeries] });
 
-    expect(screen.queryByRole("group", { name: "Art" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Einstellungen übernehmen von")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Names are unique across series and templates alike (US-4), so a template made from a series
+   * cannot keep its name. It is proposed rather than imposed: the field is the teacher's to
+   * change before anything is written.
+   */
+  it("proposes a name for the template rather than reusing one already taken", async () => {
+    renderDialog({ eventSeries });
+
+    await userEvent.click(screen.getByRole("button", { name: "Als Vorlage speichern" }));
+
+    expect(screen.getByLabelText("Name")).toHaveValue("Winter 2026 Vorlage");
+  });
+
+  it("makes the template from the series it was opened on, once the name is settled", async () => {
+    const { onSubmit } = renderDialog({ eventSeries });
+
+    await userEvent.click(screen.getByRole("button", { name: "Als Vorlage speichern" }));
+    await userEvent.clear(screen.getByLabelText("Name"));
+    await userEvent.type(screen.getByLabelText("Name"), "Wintersportwochen");
+    await userEvent.click(screen.getByRole("button", { name: "Anlegen" }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { name: "Wintersportwochen", isTemplate: true, sourceId: "s1" },
+        null,
+      ),
+    );
+  });
+
+  it("saves nothing on the press that proposes the name", async () => {
+    const { onSubmit } = renderDialog({ eventSeries });
+
+    await userEvent.click(screen.getByRole("button", { name: "Als Vorlage speichern" }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it("closes without writing when cancelled", async () => {

--- a/src/components/event-series/event-series-form-dialog.tsx
+++ b/src/components/event-series/event-series-form-dialog.tsx
@@ -26,7 +26,6 @@ import { eventSeriesSchema, type EventSeries } from "@/lib/schemas/event-series"
 
 const formSchema = z.object({
   name: eventSeriesSchema.shape.name,
-  isTemplate: z.boolean(),
   sourceId: z.string(),
 });
 type FormValues = z.infer<typeof formSchema>;
@@ -34,13 +33,15 @@ type FormValues = z.infer<typeof formSchema>;
 /** What creating asks for, once all three questions are answered (US-22). */
 export type NewEventSeries = { name: string; isTemplate: boolean; sourceId: string | null };
 
-const KINDS = [
-  { value: false, label: "Eventreihe" },
-  { value: true, label: EVENT_SERIES_STATE_LABELS.template },
-] as const;
-
-const NO_SOURCE = "";
+/**
+ * Not the empty string: base-ui reads that as no value at all and drops the entry, which left
+ * the whole list unreachable. An id is twenty generated characters, so this collides with none.
+ */
+const NO_SOURCE = "__none__";
 const NO_SOURCE_LABEL = "Ohne";
+
+/** What a template made from a series is called until the teacher says otherwise. */
+const templateNameFor = (name: string) => `${name} ${EVENT_SERIES_STATE_LABELS.template}`;
 
 /** In words rather than by colour, which the tag rows have already spent (US-22). */
 function sourceLabel(one: EventSeries): string {
@@ -69,11 +70,15 @@ export function EventSeriesFormDialog({
   onClose,
   onSaved,
 }: EventSeriesFormDialogProps) {
-  const isEdit = eventSeries !== null;
   const [submitError, setSubmitError] = React.useState<string | null>(null);
+  // Pressing "save as template" turns an edit into the creation of a template copied from what
+  // was being edited, because the two cannot share a name (US-4).
+  const [templateFrom, setTemplateFrom] = React.useState<EventSeries | null>(null);
   const nameId = React.useId();
   const errorId = React.useId();
   const sourceId = React.useId();
+
+  const isEdit = eventSeries !== null && templateFrom === null;
 
   // No reset effect: the dialog is mounted only while open (and keyed by event series), so every
   // open starts from these defaults.
@@ -81,49 +86,55 @@ export function EventSeriesFormDialog({
     register,
     control,
     handleSubmit,
+    setValue,
     setError,
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(formSchema),
-    defaultValues: {
-      name: eventSeries?.name ?? "",
-      isTemplate: false,
-      sourceId: NO_SOURCE,
-    },
+    defaultValues: { name: eventSeries?.name ?? "", sourceId: NO_SOURCE },
   });
 
-  const onSubmit = handleSubmit(async (values) => {
-    setSubmitError(null);
-    try {
-      await save(
-        {
-          name: values.name,
-          isTemplate: values.isTemplate,
-          sourceId: values.sourceId === NO_SOURCE ? null : values.sourceId,
-        },
-        eventSeries,
-      );
-      onSaved();
-    } catch (error) {
-      // A duplicate name is a problem with the field, so it is reported there rather than
-      // as a detached alert the teacher has to connect back to the input themselves (US-4).
-      if (error instanceof ApiRequestError && error.code === "CONFLICT") {
-        setError("name", { message: error.message });
-        return;
+  const submitAs = (isTemplate: boolean) =>
+    handleSubmit(async (values) => {
+      setSubmitError(null);
+      try {
+        await save(
+          {
+            name: values.name,
+            isTemplate,
+            sourceId: templateFrom?.id ?? (values.sourceId === NO_SOURCE ? null : values.sourceId),
+          },
+          // A template made from a series is a new one, so it is created rather than edited.
+          templateFrom === null ? eventSeries : null,
+        );
+        onSaved();
+      } catch (error) {
+        // A duplicate name is a problem with the field, so it is reported there rather than
+        // as a detached alert the teacher has to connect back to the input themselves (US-4).
+        if (error instanceof ApiRequestError && error.code === "CONFLICT") {
+          setError("name", { message: error.message });
+          return;
+        }
+        setSubmitError(
+          error instanceof ApiRequestError ? error.message : "Das hat leider nicht geklappt.",
+        );
       }
-      setSubmitError(
-        error instanceof ApiRequestError ? error.message : "Das hat leider nicht geklappt.",
-      );
-    }
-  });
+    });
+
+  function proposeTemplate() {
+    setTemplateFrom(eventSeries);
+    setValue("name", templateNameFor(eventSeries?.name ?? ""));
+  }
+
+  const title = isEdit
+    ? "Eventreihe bearbeiten"
+    : templateFrom === null
+      ? "Neue Eventreihe"
+      : `Neue Vorlage aus „${templateFrom.name}"`;
 
   return (
-    <Dialog
-      open={open}
-      title={isEdit ? "Eventreihe bearbeiten" : "Neue Eventreihe"}
-      onClose={onClose}
-    >
-      <form onSubmit={onSubmit} className="flex flex-col gap-4" noValidate>
+    <Dialog open={open} title={title} onClose={onClose}>
+      <form onSubmit={submitAs(templateFrom !== null)} className="flex flex-col gap-4" noValidate>
         <div className="flex flex-col gap-1.5">
           <Label htmlFor={nameId}>Name</Label>
           <Input
@@ -140,64 +151,39 @@ export function EventSeriesFormDialog({
           ) : null}
         </div>
 
-        {/* Both are settled at creation and neither settles the other, so renaming asks again for
-            nothing: a copy is no more a template for having come from one (US-22). */}
-        {isEdit ? null : (
-          <>
+        {/* Where the lists come from is asked only of something being made; renaming settles it
+            again for nothing, and a template made from a series already has its source. */}
+        {eventSeries === null ? (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={sourceId}>Einstellungen übernehmen von</Label>
             <Controller
               control={control}
-              name="isTemplate"
+              name="sourceId"
               render={({ field }) => (
-                <div role="group" aria-label="Art" className="flex flex-col gap-1.5">
-                  <span className="text-sm font-medium">Art</span>
-                  <div className="flex items-center gap-4">
-                    {KINDS.map((kind) => (
-                      <label key={kind.label} className="flex items-center gap-2 text-sm">
-                        <input
-                          type="radio"
-                          className="accent-primary size-4"
-                          checked={field.value === kind.value}
-                          onChange={() => field.onChange(kind.value)}
-                        />
-                        {kind.label}
-                      </label>
+                <Select
+                  items={[
+                    { label: NO_SOURCE_LABEL, value: NO_SOURCE },
+                    ...sources.map((one) => ({ label: sourceLabel(one), value: one.id })),
+                  ]}
+                  value={field.value}
+                  onValueChange={(value) => field.onChange(value)}
+                >
+                  <SelectTrigger id={sourceId} className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NO_SOURCE}>{NO_SOURCE_LABEL}</SelectItem>
+                    {sources.map((one) => (
+                      <SelectItem key={one.id} value={one.id}>
+                        {sourceLabel(one)}
+                      </SelectItem>
                     ))}
-                  </div>
-                </div>
+                  </SelectContent>
+                </Select>
               )}
             />
-
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor={sourceId}>Einstellungen übernehmen von</Label>
-              <Controller
-                control={control}
-                name="sourceId"
-                render={({ field }) => (
-                  <Select
-                    items={[
-                      { label: NO_SOURCE_LABEL, value: NO_SOURCE },
-                      ...sources.map((one) => ({ label: sourceLabel(one), value: one.id })),
-                    ]}
-                    value={field.value}
-                    onValueChange={(value) => field.onChange(value)}
-                  >
-                    <SelectTrigger id={sourceId} className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={NO_SOURCE}>{NO_SOURCE_LABEL}</SelectItem>
-                      {sources.map((one) => (
-                        <SelectItem key={one.id} value={one.id}>
-                          {sourceLabel(one)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              />
-            </div>
-          </>
-        )}
+          </div>
+        ) : null}
 
         {submitError ? (
           <p role="alert" className="text-destructive text-sm">
@@ -205,10 +191,22 @@ export function EventSeriesFormDialog({
           </p>
         ) : null}
 
-        <div className="flex items-center justify-end gap-2">
+        {/* The kind is the button that was pressed, so there is one control per outcome rather
+            than a field to set and a single button to guess from (US-22). */}
+        <div className="flex flex-wrap items-center justify-end gap-2">
           <Button type="button" variant="outline" onClick={onClose}>
             Abbrechen
           </Button>
+          {templateFrom === null ? (
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isSubmitting}
+              onClick={isEdit ? proposeTemplate : submitAs(true)}
+            >
+              {isEdit ? "Als Vorlage speichern" : "Als Vorlage anlegen"}
+            </Button>
+          ) : null}
           <Button type="submit" disabled={isSubmitting}>
             {isEdit ? "Speichern" : "Anlegen"}
           </Button>

--- a/src/components/event-series/event-series-form-dialog.tsx
+++ b/src/components/event-series/event-series-form-dialog.tsx
@@ -6,24 +6,57 @@
 "use client";
 
 import * as React from "react";
-import { useForm } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Dialog } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { ApiRequestError } from "@/lib/api/client";
+import { EVENT_SERIES_STATE_LABELS } from "@/lib/event-series/event-series-state";
 import { eventSeriesSchema, type EventSeries } from "@/lib/schemas/event-series";
-const formSchema = z.object({ name: eventSeriesSchema.shape.name });
+
+const formSchema = z.object({
+  name: eventSeriesSchema.shape.name,
+  isTemplate: z.boolean(),
+  sourceId: z.string(),
+});
 type FormValues = z.infer<typeof formSchema>;
+
+/** What creating asks for, once all three questions are answered (US-22). */
+export type NewEventSeries = { name: string; isTemplate: boolean; sourceId: string | null };
+
+const KINDS = [
+  { value: false, label: "Eventreihe" },
+  { value: true, label: EVENT_SERIES_STATE_LABELS.template },
+] as const;
+
+const NO_SOURCE = "";
+const NO_SOURCE_LABEL = "Ohne";
+
+/** In words rather than by colour, which the tag rows have already spent (US-22). */
+function sourceLabel(one: EventSeries): string {
+  if (one.isTemplate) return `${one.name} (${EVENT_SERIES_STATE_LABELS.template})`;
+  if (one.isArchived) return `${one.name} (${EVENT_SERIES_STATE_LABELS.archived})`;
+  return one.name;
+}
 
 type EventSeriesFormDialogProps = {
   open: boolean;
   /** `null` opens the dialog for a new event series. */
   eventSeries: EventSeries | null;
+  /** What a new one may take its lists from — any series or template, archived ones included. */
+  sources: readonly EventSeries[];
   /** Rejects with an ApiRequestError; a CONFLICT is reported on the name field. */
-  onSubmit: (name: string, eventSeries: EventSeries | null) => Promise<void>;
+  onSubmit: (values: NewEventSeries, eventSeries: EventSeries | null) => Promise<void>;
   onClose: () => void;
   onSaved: () => void;
 };
@@ -31,6 +64,7 @@ type EventSeriesFormDialogProps = {
 export function EventSeriesFormDialog({
   open,
   eventSeries,
+  sources,
   onSubmit: save,
   onClose,
   onSaved,
@@ -39,23 +73,36 @@ export function EventSeriesFormDialog({
   const [submitError, setSubmitError] = React.useState<string | null>(null);
   const nameId = React.useId();
   const errorId = React.useId();
+  const sourceId = React.useId();
 
   // No reset effect: the dialog is mounted only while open (and keyed by event series), so every
   // open starts from these defaults.
   const {
     register,
+    control,
     handleSubmit,
     setError,
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(formSchema),
-    defaultValues: { name: eventSeries?.name ?? "" },
+    defaultValues: {
+      name: eventSeries?.name ?? "",
+      isTemplate: false,
+      sourceId: NO_SOURCE,
+    },
   });
 
   const onSubmit = handleSubmit(async (values) => {
     setSubmitError(null);
     try {
-      await save(values.name, eventSeries);
+      await save(
+        {
+          name: values.name,
+          isTemplate: values.isTemplate,
+          sourceId: values.sourceId === NO_SOURCE ? null : values.sourceId,
+        },
+        eventSeries,
+      );
       onSaved();
     } catch (error) {
       // A duplicate name is a problem with the field, so it is reported there rather than
@@ -92,6 +139,65 @@ export function EventSeriesFormDialog({
             </p>
           ) : null}
         </div>
+
+        {/* Both are settled at creation and neither settles the other, so renaming asks again for
+            nothing: a copy is no more a template for having come from one (US-22). */}
+        {isEdit ? null : (
+          <>
+            <Controller
+              control={control}
+              name="isTemplate"
+              render={({ field }) => (
+                <div role="group" aria-label="Art" className="flex flex-col gap-1.5">
+                  <span className="text-sm font-medium">Art</span>
+                  <div className="flex items-center gap-4">
+                    {KINDS.map((kind) => (
+                      <label key={kind.label} className="flex items-center gap-2 text-sm">
+                        <input
+                          type="radio"
+                          className="accent-primary size-4"
+                          checked={field.value === kind.value}
+                          onChange={() => field.onChange(kind.value)}
+                        />
+                        {kind.label}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )}
+            />
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor={sourceId}>Einstellungen übernehmen von</Label>
+              <Controller
+                control={control}
+                name="sourceId"
+                render={({ field }) => (
+                  <Select
+                    items={[
+                      { label: NO_SOURCE_LABEL, value: NO_SOURCE },
+                      ...sources.map((one) => ({ label: sourceLabel(one), value: one.id })),
+                    ]}
+                    value={field.value}
+                    onValueChange={(value) => field.onChange(value)}
+                  >
+                    <SelectTrigger id={sourceId} className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={NO_SOURCE}>{NO_SOURCE_LABEL}</SelectItem>
+                      {sources.map((one) => (
+                        <SelectItem key={one.id} value={one.id}>
+                          {sourceLabel(one)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          </>
+        )}
 
         {submitError ? (
           <p role="alert" className="text-destructive text-sm">

--- a/src/components/event-series/event-series-list.tsx
+++ b/src/components/event-series/event-series-list.tsx
@@ -116,7 +116,7 @@ export function EventSeriesList({
                   <Tooltip label="Bearbeiten">
                     <Button
                       variant="ghost"
-                      size="icon-sm"
+                      size="icon"
                       disabled={busy}
                       aria-label={`Eventreihe ${eventSeries.name} bearbeiten`}
                       onClick={() => onEdit(eventSeries)}
@@ -137,7 +137,7 @@ export function EventSeriesList({
                   <span className="inline-flex">
                     <Button
                       variant="ghost"
-                      size="icon-sm"
+                      size="icon"
                       disabled={archivingDisabled || busy}
                       aria-label={
                         eventSeries.isArchived
@@ -168,7 +168,7 @@ export function EventSeriesList({
                   <span className="inline-flex">
                     <Button
                       variant="ghost"
-                      size="icon-sm"
+                      size="icon"
                       disabled={deletingDisabled || busy}
                       aria-label={`Eventreihe ${eventSeries.name} löschen`}
                       aria-describedby={deletingDisabled ? deleteHintId : undefined}

--- a/src/components/event-series/event-series-view.tsx
+++ b/src/components/event-series/event-series-view.tsx
@@ -123,13 +123,16 @@ export function EventSeriesView() {
           key={dialog.eventSeries?.id ?? "new"}
           open
           eventSeries={dialog.eventSeries}
-          onSubmit={(name, eventSeries) =>
-            run(eventSeries?.id ?? null, () =>
-              eventSeries === null
-                ? apiRequest("/api/event-series", { method: "POST", body: { name } })
-                : apiRequest(`/api/event-series/${eventSeries.id}`, {
+          // Every one of them, archived included: naming an archived series as the source is how
+          // the master data in it comes back into something that can be edited (US-22).
+          sources={eventSeries}
+          onSubmit={(values, existing) =>
+            run(existing?.id ?? null, () =>
+              existing === null
+                ? apiRequest("/api/event-series", { method: "POST", body: values })
+                : apiRequest(`/api/event-series/${existing.id}`, {
                     method: "PATCH",
-                    body: { name },
+                    body: { name: values.name },
                   }),
             ).then(() => {})
           }

--- a/src/components/event-series/event-series-view.tsx
+++ b/src/components/event-series/event-series-view.tsx
@@ -20,7 +20,7 @@ import type { EventSeries } from "@/lib/schemas/event-series";
 import { visibleEventSeries } from "@/lib/event-series/event-series-state";
 import { useEventSeries } from "@/lib/event-series/use-event-series";
 import { useShowArchived } from "@/lib/event-series/show-archived";
-import { Tag } from "@/components/ui/tag";
+import { Tag, TagName } from "@/components/ui/tag";
 import { PageHeading } from "@/components/layout/page-heading";
 
 type OpenDialog =
@@ -80,11 +80,12 @@ export function EventSeriesView() {
           </PageHeading>
 
           <div>
-            <Tag
-              label="Archivierte Eventreihen anzeigen"
-              pressed={showArchived}
-              onPress={() => setShowArchived(!showArchived)}
-            />
+            <Tag pressed={showArchived}>
+              <TagName
+                label="Archivierte Eventreihen anzeigen"
+                onPress={() => setShowArchived(!showArchived)}
+              />
+            </Tag>
           </div>
 
           {actionError ? (

--- a/src/components/filters/filter-tag-list.tsx
+++ b/src/components/filters/filter-tag-list.tsx
@@ -8,7 +8,7 @@
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Tag } from "@/components/ui/tag";
+import { Tag, TagName } from "@/components/ui/tag";
 import {
   clearTags,
   hasNoTags,
@@ -58,17 +58,22 @@ export function FilterTagList({ label, groups, value, onChange }: FilterTagListP
       </div>
 
       <div role="group" aria-label={`${label}: Filter`} className="flex flex-wrap gap-1.5">
-        <Tag label="Alle" pressed={hasNoTags(value)} onPress={() => onChange(clearTags(value))} />
+        <Tag pressed={hasNoTags(value)}>
+          <TagName label="Alle" onPress={() => onChange(clearTags(value))} />
+        </Tag>
         {groups.map((group) =>
           group.options.map((option) => (
             <Tag
               key={`${group.category}:${option.value}`}
-              // The row carries no headings, so the category is what the tag says it is.
-              label={option.name ?? `${group.label}: ${option.label}`}
-              text={option.label}
               pressed={value.tags[group.category].includes(option.value)}
-              onPress={() => onChange(toggleTag(value, group.category, option.value))}
-            />
+            >
+              <TagName
+                // The row carries no headings, so the category is what the tag says it is.
+                label={option.name ?? `${group.label}: ${option.label}`}
+                text={option.label}
+                onPress={() => onChange(toggleTag(value, group.category, option.value))}
+              />
+            </Tag>
           )),
         )}
       </div>

--- a/src/components/filters/filter-tag-list.tsx
+++ b/src/components/filters/filter-tag-list.tsx
@@ -47,7 +47,7 @@ export function FilterTagList({ label, groups, value, onChange }: FilterTagListP
           <Button
             type="button"
             variant="ghost"
-            size="icon-sm"
+            size="icon"
             aria-label={`${label}: Name zurücksetzen`}
             onClick={() => onChange({ ...value, name: "" })}
             className="absolute inset-y-0 right-0.5 my-auto"

--- a/src/components/layout/app-shell.test.tsx
+++ b/src/components/layout/app-shell.test.tsx
@@ -23,6 +23,30 @@ describe("AppShell", () => {
     expect(screen.getByRole("banner")).toHaveTextContent("Sportsweek");
   });
 
+  /**
+   * The bar spans both rows so that it runs to the top of the window, which puts the brand
+   * inside it — and leaves the header holding only what is about the page below it.
+   */
+  it("hands the brand to the navigation bar where there is one", () => {
+    render(
+      <AppShell nav={<nav aria-label="Hauptnavigation">Navigation</nav>}>
+        <p>Inhalt</p>
+      </AppShell>,
+    );
+
+    expect(screen.getByRole("banner")).not.toHaveTextContent("Sportsweek");
+  });
+
+  it("keeps the brand in the header for a student, who is given no bar", () => {
+    render(
+      <AppShell>
+        <p>Inhalt</p>
+      </AppShell>,
+    );
+
+    expect(screen.getByRole("banner")).toHaveTextContent("Sportsweek");
+  });
+
   it("brands the header with the school's logo, ahead of the title", () => {
     render(
       <AppShell>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -16,7 +16,7 @@ export function AppShell({ children, scope }: { children: ReactNode; scope?: Rea
       {/* A fixed height rather than a minimum, so the columns below can be as tall as the window
           and no taller — which is what lets the navigation bar reach the foot of the screen. */}
       <div className="flex h-dvh flex-col">
-        <header className="border-border bg-background sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center justify-between gap-4 border-b px-4 md:px-6">
+        <header className="border-border bg-background sticky top-0 z-10 flex h-(--header-height) shrink-0 items-center justify-between gap-4 border-b px-4 md:px-6">
           <span className="flex shrink-0 items-center gap-2">
             <Image src="/htl-logo.svg" alt="HTL Dornbirn Logo" width={24} height={28} priority />
             <span className="font-heading text-xl font-semibold tracking-tight">Sportsweek</span>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -40,7 +40,7 @@ export function AppShell({
           </div>
         ) : null}
 
-        <header className="border-border bg-sidebar col-start-2 row-start-1 flex items-center justify-between gap-4 border-b px-4 py-2 md:px-6">
+        <header className="border-border bg-background col-start-2 row-start-1 flex items-center justify-between gap-4 border-b px-4 py-2 md:px-6">
           {nav ? null : <Brand />}
           {/* The scope leads the header, because it says what every page below it is about. */}
           {scope}

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -26,10 +26,12 @@ export function AppShell({
   children,
   nav,
   scope,
+  photo = null,
 }: {
   children: ReactNode;
   nav?: ReactNode;
   scope?: ReactNode;
+  photo?: string | null;
 }) {
   return (
     <BusyProvider>
@@ -46,7 +48,7 @@ export function AppShell({
           {scope}
           {/* Where there is a bar, signing out sits at the foot of it, under the person's own
               mark. A student has no bar, so it stays here. */}
-          {nav ? null : <SignOutButton />}
+          {nav ? null : <SignOutButton photo={photo} />}
           {/* Last, and positioned against the header, whose bottom border it sits on. */}
           <BusyBar />
         </header>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -44,7 +44,9 @@ export function AppShell({
           {nav ? null : <Brand />}
           {/* The scope leads the header, because it says what every page below it is about. */}
           {scope}
-          <SignOutButton />
+          {/* Where there is a bar, signing out sits at the foot of it, under the person's own
+              mark. A student has no bar, so it stays here. */}
+          {nav ? null : <SignOutButton />}
           {/* Last, and positioned against the header, whose bottom border it sits on. */}
           <BusyBar />
         </header>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -4,30 +4,56 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import type { ReactNode } from "react";
-import Image from "next/image";
 import { SignOutButton } from "@/components/auth/sign-out-button";
+import { Brand } from "@/components/layout/brand";
 import { BusyProvider } from "@/lib/api/busy";
 import { BusyBar } from "@/components/layout/busy-bar";
 
-/** Header row shared by the teacher dashboard (US-14) and the student view (US-15). */
-export function AppShell({ children, scope }: { children: ReactNode; scope?: ReactNode }) {
+/**
+ * The frame both roles share (US-14, US-15). One grid rather than a header above a row of
+ * columns, because the tags in the header and the heading of the page beneath them have to line
+ * up: sharing a grid column is what makes that true at any width the bar happens to be, and the
+ * bar's width is its own business — it decides whether it is collapsed.
+ *
+ * The bar spans both rows, so it runs to the top of the window and carries the brand itself.
+ * A student is given none, and the brand sits in the header instead.
+ *
+ * A grid track is also a definite height, which is what lets the bar reach the foot of the
+ * window — Safari will not resolve that from flex-grow. The header track sizes to its content,
+ * so it grows when the tags wrap.
+ */
+export function AppShell({
+  children,
+  nav,
+  scope,
+}: {
+  children: ReactNode;
+  nav?: ReactNode;
+  scope?: ReactNode;
+}) {
   return (
     <BusyProvider>
-      {/* A fixed height rather than a minimum, so the columns below can be as tall as the window
-          and no taller — which is what lets the navigation bar reach the foot of the screen. */}
-      <div className="flex h-dvh flex-col">
-        <header className="border-border bg-background sticky top-0 z-10 flex h-(--header-height) shrink-0 items-center justify-between gap-4 border-b px-4 md:px-6">
-          <span className="flex shrink-0 items-center gap-2">
-            <Image src="/htl-logo.svg" alt="HTL Dornbirn Logo" width={24} height={28} priority />
-            <span className="font-heading text-xl font-semibold tracking-tight">Sportsweek</span>
-          </span>
-          {/* The scope sits immediately after the title, because it says what every page is about. */}
+      <div className="grid h-dvh grid-cols-[auto_minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)]">
+        {nav ? (
+          <div className="border-border bg-sidebar col-start-1 row-span-2 row-start-1 hidden shrink-0 border-r md:block">
+            {nav}
+          </div>
+        ) : null}
+
+        <header className="border-border bg-sidebar col-start-2 row-start-1 flex items-center justify-between gap-4 border-b px-4 py-2 md:px-6">
+          {nav ? null : <Brand />}
+          {/* The scope leads the header, because it says what every page below it is about. */}
           {scope}
           <SignOutButton />
           {/* Last, and positioned against the header, whose bottom border it sits on. */}
           <BusyBar />
         </header>
-        <main className="flex min-h-0 flex-1 flex-col overflow-y-auto">{children}</main>
+
+        <main className="bg-background col-start-2 row-start-2 flex min-h-0 flex-col overflow-y-auto">
+          {/* Narrow screens have no column for the bar, so it goes above what it points at. */}
+          {nav ? <div className="border-border bg-sidebar border-b md:hidden">{nav}</div> : null}
+          {children}
+        </main>
       </div>
     </BusyProvider>
   );

--- a/src/components/layout/brand.tsx
+++ b/src/components/layout/brand.tsx
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+/**
+ * The school's mark and the application's name. It heads the navigation bar for a teacher and
+ * the header itself for a student, who has no bar — so it is written once and placed twice.
+ *
+ * Laid out as a navigation row is: the logo occupies the same square the icons do and is centred
+ * in it, so the name starts where every label below it starts. The name goes away with the bar
+ * it sits in, a collapsed rail being the width of that square.
+ */
+export function Brand({ nameHidden = false }: { nameHidden?: boolean }) {
+  return (
+    <span className="flex min-h-9 shrink-0 items-center gap-2 px-3 py-2">
+      <span className="flex w-6 shrink-0 items-center justify-center">
+        <Image
+          src="/htl-logo.svg"
+          alt="HTL Dornbirn Logo"
+          width={24}
+          height={28}
+          priority
+          className="h-auto w-6"
+        />
+      </span>
+      <span
+        className={cn(
+          "font-heading text-xl font-semibold tracking-tight",
+          nameHidden && "md:sr-only",
+        )}
+      >
+        Sportsweek
+      </span>
+    </span>
+  );
+}

--- a/src/components/layout/brand.tsx
+++ b/src/components/layout/brand.tsx
@@ -4,31 +4,17 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import Image from "next/image";
-import { cn } from "@/lib/utils";
-
-export const NAV_TOGGLE_LABEL = "Navigation ein-/ausklappen";
 
 /**
  * The school's mark and the application's name. It heads the navigation bar for a teacher and
  * the header itself for a student, who has no bar — so it is written once and placed twice.
  *
  * Laid out as a navigation row is: the logo occupies the same square the icons do and is centred
- * in it, so the name starts where every label below it starts. The name goes away with the bar
- * it sits in, a collapsed rail being the width of that square.
- *
- * Given `onToggle` it becomes the bar's one fold control. Nothing else in the bar folds it: every
- * other row is somewhere to go, and a row that sometimes goes there instead cannot be pressed
- * without first knowing which of the two it will do.
+ * in it, so the name starts where every label below it starts.
  */
-export function Brand({
-  nameHidden = false,
-  onToggle,
-}: {
-  nameHidden?: boolean;
-  onToggle?: () => void;
-}) {
-  const mark = (
-    <>
+export function Brand() {
+  return (
+    <span className="flex min-h-9 shrink-0 items-center gap-3 px-2 py-2">
       <span className="flex w-6 shrink-0 items-center justify-center">
         <Image
           src="/htl-logo.svg"
@@ -39,30 +25,7 @@ export function Brand({
           className="h-auto w-6"
         />
       </span>
-      <span
-        className={cn(
-          "font-heading text-xl font-semibold tracking-tight",
-          nameHidden && "md:sr-only",
-        )}
-      >
-        Sportsweek
-      </span>
-    </>
-  );
-
-  const row = "flex min-h-9 shrink-0 items-center gap-3 px-2 py-2";
-  if (onToggle === undefined) return <span className={row}>{mark}</span>;
-
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      aria-label={NAV_TOGGLE_LABEL}
-      aria-expanded={!nameHidden}
-      title={NAV_TOGGLE_LABEL}
-      className={cn(row, "hover:bg-muted w-full rounded-md transition-colors")}
-    >
-      {mark}
-    </button>
+      <span className="font-heading text-xl font-semibold tracking-tight">Sportsweek</span>
+    </span>
   );
 }

--- a/src/components/layout/brand.tsx
+++ b/src/components/layout/brand.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
  */
 export function Brand({ nameHidden = false }: { nameHidden?: boolean }) {
   return (
-    <span className="flex min-h-9 shrink-0 items-center gap-2 px-3 py-2">
+    <span className="flex min-h-9 shrink-0 items-center gap-3 px-2 py-2">
       <span className="flex w-6 shrink-0 items-center justify-center">
         <Image
           src="/htl-logo.svg"

--- a/src/components/layout/brand.tsx
+++ b/src/components/layout/brand.tsx
@@ -6,6 +6,8 @@
 import Image from "next/image";
 import { cn } from "@/lib/utils";
 
+export const NAV_TOGGLE_LABEL = "Navigation ein-/ausklappen";
+
 /**
  * The school's mark and the application's name. It heads the navigation bar for a teacher and
  * the header itself for a student, who has no bar — so it is written once and placed twice.
@@ -13,10 +15,20 @@ import { cn } from "@/lib/utils";
  * Laid out as a navigation row is: the logo occupies the same square the icons do and is centred
  * in it, so the name starts where every label below it starts. The name goes away with the bar
  * it sits in, a collapsed rail being the width of that square.
+ *
+ * Given `onToggle` it becomes the bar's one fold control. Nothing else in the bar folds it: every
+ * other row is somewhere to go, and a row that sometimes goes there instead cannot be pressed
+ * without first knowing which of the two it will do.
  */
-export function Brand({ nameHidden = false }: { nameHidden?: boolean }) {
-  return (
-    <span className="flex min-h-9 shrink-0 items-center gap-3 px-2 py-2">
+export function Brand({
+  nameHidden = false,
+  onToggle,
+}: {
+  nameHidden?: boolean;
+  onToggle?: () => void;
+}) {
+  const mark = (
+    <>
       <span className="flex w-6 shrink-0 items-center justify-center">
         <Image
           src="/htl-logo.svg"
@@ -35,6 +47,22 @@ export function Brand({ nameHidden = false }: { nameHidden?: boolean }) {
       >
         Sportsweek
       </span>
-    </span>
+    </>
+  );
+
+  const row = "flex min-h-9 shrink-0 items-center gap-3 px-2 py-2";
+  if (onToggle === undefined) return <span className={row}>{mark}</span>;
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={NAV_TOGGLE_LABEL}
+      aria-expanded={!nameHidden}
+      title={NAV_TOGGLE_LABEL}
+      className={cn(row, "hover:bg-muted w-full rounded-md transition-colors")}
+    >
+      {mark}
+    </button>
   );
 }

--- a/src/components/layout/event-series-tag-rows.test.tsx
+++ b/src/components/layout/event-series-tag-rows.test.tsx
@@ -47,6 +47,7 @@ describe("EventSeriesTagRows", () => {
   });
 
   it("puts the templates in a row of their own", () => {
+    pathname.mockReturnValue("/app/s1/master-data/classes");
     showing(
       seriesNamed("s1", "Wintersportwoche"),
       seriesNamed("t1", "Wintersportwochen", { isTemplate: true }),
@@ -67,6 +68,7 @@ describe("EventSeriesTagRows", () => {
 
   /** A school that never makes one never sees a space set aside for it (US-20). */
   it("leaves the template row out entirely when there are none", () => {
+    pathname.mockReturnValue("/app/s1/master-data/classes");
     showing(seriesNamed("s1", "Wintersportwoche"));
 
     render(<EventSeriesTagRows />);
@@ -74,8 +76,44 @@ describe("EventSeriesTagRows", () => {
     expect(screen.queryByRole("group", { name: TEMPLATE_ROW_LABEL })).not.toBeInTheDocument();
   });
 
+  /**
+   * A template holds lists and no registrations, so it has nothing an overview, an assignment or
+   * a report could show. Only where the lists themselves are maintained is it worth offering.
+   */
+  it.each(["/app/s1/overview", "/app/s1/assignment", "/app/s1/report"])(
+    "offers no template on %s, leaving the series the whole width",
+    (path) => {
+      pathname.mockReturnValue(path);
+      showing(
+        seriesNamed("s1", "Wintersportwoche"),
+        seriesNamed("t1", "Wintersportwochen", { isTemplate: true }),
+      );
+
+      render(<EventSeriesTagRows />);
+
+      expect(screen.queryByRole("group", { name: TEMPLATE_ROW_LABEL })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Wintersportwochen/ })).not.toBeInTheDocument();
+    },
+  );
+
+  it.each(["/app/event-series", "/app/s1/master-data/programs"])(
+    "offers the templates on %s, where the lists are maintained",
+    (path) => {
+      pathname.mockReturnValue(path);
+      showing(
+        seriesNamed("s1", "Wintersportwoche"),
+        seriesNamed("t1", "Wintersportwochen", { isTemplate: true }),
+      );
+
+      render(<EventSeriesTagRows />);
+
+      expect(screen.getByRole("group", { name: TEMPLATE_ROW_LABEL })).toBeInTheDocument();
+    },
+  );
+
   /** Archived is what takes a series off every screen, the header included (US-19). */
   it("shows an archived series in neither row", () => {
+    pathname.mockReturnValue("/app/s1/master-data/classes");
     showing(
       seriesNamed("s1", "Wintersportwoche"),
       seriesNamed("old", "Letztes Jahr", { isArchived: true }),

--- a/src/components/layout/event-series-tag-rows.test.tsx
+++ b/src/components/layout/event-series-tag-rows.test.tsx
@@ -11,12 +11,20 @@ import { storedEventSeries } from "@/test/event-series";
 const push = vi.fn();
 const pathname = vi.fn(() => "/app/s1/report");
 const eventSeries = vi.fn<() => { eventSeries: unknown[] }>(() => ({ eventSeries: [] }));
+const apiRequest = vi.fn();
 
 vi.mock("next/navigation", () => ({
   usePathname: () => pathname(),
   useRouter: () => ({ push }),
 }));
 vi.mock("@/lib/event-series/use-event-series", () => ({ useEventSeries: () => eventSeries() }));
+vi.mock("@/lib/api/busy", () => ({ useBusyWhile: () => {} }));
+vi.mock("@/lib/api/client", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  apiRequest: (...args: unknown[]) => apiRequest(...args),
+}));
+
+const { ApiRequestError } = await import("@/lib/api/client");
 
 const {
   EventSeriesTagRows,
@@ -25,6 +33,8 @@ const {
   OPEN_TO_STUDENTS_LABEL,
   CLOSED_TO_STUDENTS_LABEL,
   TEMPLATE_LABEL,
+  openActionLabel,
+  closeActionLabel,
 } = await import("@/components/layout/event-series-tag-rows");
 
 function seriesNamed(id: string, name: string, overrides = {}) {
@@ -38,6 +48,7 @@ function showing(...list: ReturnType<typeof seriesNamed>[]) {
 describe("EventSeriesTagRows", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    apiRequest.mockResolvedValue(undefined);
     pathname.mockReturnValue("/app/s1/report");
     document.cookie = "sportsweek_event_series=; max-age=0; path=/";
   });
@@ -48,8 +59,8 @@ describe("EventSeriesTagRows", () => {
     render(<EventSeriesTagRows />);
 
     const row = screen.getByRole("group", { name: EVENT_SERIES_ROW_LABEL });
-    expect(within(row).getByRole("button", { name: /Wintersportwoche/ })).toBeInTheDocument();
-    expect(within(row).getByRole("button", { name: /Kulturwoche/ })).toBeInTheDocument();
+    expect(within(row).getByRole("button", { name: "Wintersportwoche" })).toBeInTheDocument();
+    expect(within(row).getByRole("button", { name: "Kulturwoche" })).toBeInTheDocument();
   });
 
   it("puts the templates in a row of their own", () => {
@@ -63,11 +74,11 @@ describe("EventSeriesTagRows", () => {
 
     const templates = screen.getByRole("group", { name: TEMPLATE_ROW_LABEL });
     expect(
-      within(templates).getByRole("button", { name: /Wintersportwochen/ }),
+      within(templates).getByRole("button", { name: "Wintersportwochen" }),
     ).toBeInTheDocument();
     expect(
       within(screen.getByRole("group", { name: EVENT_SERIES_ROW_LABEL })).queryByRole("button", {
-        name: /Wintersportwochen/,
+        name: "Wintersportwochen",
       }),
     ).not.toBeInTheDocument();
   });
@@ -98,7 +109,7 @@ describe("EventSeriesTagRows", () => {
       render(<EventSeriesTagRows />);
 
       expect(screen.queryByRole("group", { name: TEMPLATE_ROW_LABEL })).not.toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: /Wintersportwochen/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Wintersportwochen" })).not.toBeInTheDocument();
     },
   );
 
@@ -128,7 +139,7 @@ describe("EventSeriesTagRows", () => {
 
     render(<EventSeriesTagRows />);
 
-    expect(screen.queryByRole("button", { name: /Letztes Jahr/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Letztes Jahr" })).not.toBeInTheDocument();
     expect(screen.queryByRole("group", { name: TEMPLATE_ROW_LABEL })).not.toBeInTheDocument();
   });
 
@@ -157,8 +168,8 @@ describe("EventSeriesTagRows", () => {
 
     render(<EventSeriesTagRows />);
 
-    expect(screen.getByRole("button", { name: /Vorlage/ })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: /Wintersportwoche/ })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Vorlage" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Wintersportwoche" })).toHaveAttribute(
       "aria-pressed",
       "false",
     );
@@ -208,7 +219,7 @@ describe("EventSeriesTagRows", () => {
     showing(seriesNamed("s1", "Wintersportwoche"), seriesNamed("s2", "Kulturwoche"));
 
     render(<EventSeriesTagRows />);
-    await userEvent.click(screen.getByRole("button", { name: /Kulturwoche/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Kulturwoche" }));
 
     expect(push).toHaveBeenCalledWith("/app/s2/master-data/classes");
   });
@@ -217,7 +228,7 @@ describe("EventSeriesTagRows", () => {
     showing(seriesNamed("s1", "Wintersportwoche"), seriesNamed("s2", "Kulturwoche"));
 
     render(<EventSeriesTagRows />);
-    await userEvent.click(screen.getByRole("button", { name: /Kulturwoche/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Kulturwoche" }));
 
     expect(document.cookie).toContain("sportsweek_event_series=s2");
   });
@@ -229,5 +240,114 @@ describe("EventSeriesTagRows", () => {
     const { container } = render(<EventSeriesTagRows />);
 
     expect(container).toBeEmptyDOMElement();
+  });
+});
+
+/**
+ * Opening registration to students is done on the tag of the series it concerns (US-19, US-29).
+ * There is no second control anywhere else — two controls for one decision would be two answers
+ * to it — and it is offered only on the tag that is selected, so a press cannot land on the
+ * wrong series.
+ */
+describe("EventSeriesTagRows — opening and closing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiRequest.mockResolvedValue(undefined);
+    pathname.mockReturnValue("/app/s1/report");
+    document.cookie = "sportsweek_event_series=; max-age=0; path=/";
+  });
+
+  it("offers the action on the selected tag and on no other", () => {
+    showing(seriesNamed("s1", "Wintersportwoche"), seriesNamed("s2", "Kulturwoche"));
+
+    render(<EventSeriesTagRows />);
+
+    expect(
+      screen.getByRole("button", { name: openActionLabel("Wintersportwoche") }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: openActionLabel("Kulturwoche") }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers closing instead while the series is open", () => {
+    showing(seriesNamed("s1", "Wintersportwoche", { isOpenToStudents: true }));
+
+    render(<EventSeriesTagRows />);
+
+    expect(
+      screen.getByRole("button", { name: closeActionLabel("Wintersportwoche") }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: openActionLabel("Wintersportwoche") }),
+    ).not.toBeInTheDocument();
+  });
+
+  /** A tag that offers to open what cannot be opened is a tag explaining a refusal (US-22). */
+  it("offers no action on a template, which can never be opened", () => {
+    pathname.mockReturnValue("/app/t1/master-data/classes");
+    showing(seriesNamed("t1", "Vorlage", { isTemplate: true }));
+
+    render(<EventSeriesTagRows />);
+
+    expect(
+      screen.queryByRole("button", { name: openActionLabel("Vorlage") }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the series when the action is pressed", async () => {
+    showing(seriesNamed("s1", "Wintersportwoche"));
+
+    render(<EventSeriesTagRows />);
+    await userEvent.click(
+      screen.getByRole("button", { name: openActionLabel("Wintersportwoche") }),
+    );
+
+    expect(apiRequest).toHaveBeenCalledWith("/api/event-series/s1", {
+      method: "PATCH",
+      body: { isOpenToStudents: true },
+    });
+  });
+
+  it("closes it again when pressed while open", async () => {
+    showing(seriesNamed("s1", "Wintersportwoche", { isOpenToStudents: true }));
+
+    render(<EventSeriesTagRows />);
+    await userEvent.click(
+      screen.getByRole("button", { name: closeActionLabel("Wintersportwoche") }),
+    );
+
+    expect(apiRequest).toHaveBeenCalledWith("/api/event-series/s1", {
+      method: "PATCH",
+      body: { isOpenToStudents: false },
+    });
+  });
+
+  /** The tag is already the selected one, so the action has no series to move to. */
+  it("does not navigate when the action rather than the name is pressed", async () => {
+    showing(seriesNamed("s1", "Wintersportwoche"));
+
+    render(<EventSeriesTagRows />);
+    await userEvent.click(
+      screen.getByRole("button", { name: openActionLabel("Wintersportwoche") }),
+    );
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A series with no class has nobody to invite, so the server refuses (US-19). The header is
+   * where the press happened, so it is where the answer has to appear.
+   */
+  it("says what the server said when the change is refused", async () => {
+    apiRequest.mockRejectedValue(new ApiRequestError("Ohne Klasse geht das nicht."));
+    showing(seriesNamed("s1", "Wintersportwoche"));
+
+    render(<EventSeriesTagRows />);
+    await userEvent.click(
+      screen.getByRole("button", { name: openActionLabel("Wintersportwoche") }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Ohne Klasse geht das nicht.");
   });
 });

--- a/src/components/layout/event-series-tag-rows.test.tsx
+++ b/src/components/layout/event-series-tag-rows.test.tsx
@@ -18,8 +18,14 @@ vi.mock("next/navigation", () => ({
 }));
 vi.mock("@/lib/event-series/use-event-series", () => ({ useEventSeries: () => eventSeries() }));
 
-const { EventSeriesTagRows, EVENT_SERIES_ROW_LABEL, TEMPLATE_ROW_LABEL, OPEN_TO_STUDENTS_LABEL } =
-  await import("@/components/layout/event-series-tag-rows");
+const {
+  EventSeriesTagRows,
+  EVENT_SERIES_ROW_LABEL,
+  TEMPLATE_ROW_LABEL,
+  OPEN_TO_STUDENTS_LABEL,
+  CLOSED_TO_STUDENTS_LABEL,
+  TEMPLATE_LABEL,
+} = await import("@/components/layout/event-series-tag-rows");
 
 function seriesNamed(id: string, name: string, overrides = {}) {
   return { id, ...storedEventSeries({ name, ...overrides }) };
@@ -169,6 +175,32 @@ describe("EventSeriesTagRows", () => {
 
     expect(screen.getByLabelText(OPEN_TO_STUDENTS_LABEL)).toBeInTheDocument();
     expect(screen.getAllByLabelText(OPEN_TO_STUDENTS_LABEL)).toHaveLength(1);
+  });
+
+  /** A closed series says so too: silence would read as an icon that failed to load. */
+  it("names the closed state as well, so no tag is left saying nothing", () => {
+    showing(
+      seriesNamed("s1", "Wintersportwoche", { isOpenToStudents: true }),
+      seriesNamed("s2", "Kulturwoche"),
+    );
+
+    render(<EventSeriesTagRows />);
+
+    expect(screen.getAllByLabelText(CLOSED_TO_STUDENTS_LABEL)).toHaveLength(1);
+  });
+
+  /** A template is neither open nor closed — it can never be opened at all (US-22). */
+  it("marks a template as one rather than as a door", () => {
+    pathname.mockReturnValue("/app/s1/master-data/classes");
+    showing(
+      seriesNamed("s1", "Wintersportwoche"),
+      seriesNamed("t1", "Wintersportwochen", { isTemplate: true }),
+    );
+
+    render(<EventSeriesTagRows />);
+
+    expect(screen.getAllByLabelText(TEMPLATE_LABEL)).toHaveLength(1);
+    expect(screen.queryAllByLabelText(OPEN_TO_STUDENTS_LABEL)).toHaveLength(0);
   });
 
   it("re-scopes the page that is open rather than navigating away from it", async () => {

--- a/src/components/layout/event-series-tag-rows.tsx
+++ b/src/components/layout/event-series-tag-rows.tsx
@@ -60,7 +60,7 @@ export const closeActionLabel = (name: string) => `${name} für Schüler:innen s
  */
 function fillFor(one: EventSeries): TagVariant {
   if (one.isTemplate) return "template";
-  return one.isOpenToStudents ? "open" : "default";
+  return one.isOpenToStudents ? "open" : "series";
 }
 
 function TagRow({ label, eventSeries, selectedId, onSelect, onSetOpen, pending }: RowProps) {

--- a/src/components/layout/event-series-tag-rows.tsx
+++ b/src/components/layout/event-series-tag-rows.tsx
@@ -45,7 +45,7 @@ type RowProps = {
   selectedId: string | null;
   /** Accent for a series, grey for a template — both already in the base palette (Q21). */
   variant: "default" | "secondary";
-  onSelect: (id: string) => void;
+  onSelect: (eventSeries: EventSeries) => void;
 };
 
 /**
@@ -71,7 +71,7 @@ function TagRow({ label, eventSeries, selectedId, variant, onSelect }: RowProps)
             variant={pressed ? variant : "outline"}
             className={cn(pressed && variant === "secondary" && PRESSED_TEMPLATE)}
             aria-pressed={pressed}
-            onClick={() => onSelect(one.id)}
+            onClick={() => onSelect(one)}
           >
             <StateIcon eventSeries={one} />
             {one.name}
@@ -103,9 +103,9 @@ export function EventSeriesTagRows() {
   // a report could show. Only where the lists are maintained is it worth offering (US-22).
   const templates = isMasterDataPath(pathname) ? live.filter((one) => one.isTemplate) : [];
 
-  function select(id: string) {
-    rememberEventSeries(id);
-    router.push(rescopedPath(pathname, id));
+  function select(one: EventSeries) {
+    rememberEventSeries(one.id);
+    router.push(rescopedPath(pathname, one.id, one.isTemplate));
   }
 
   if (live.length === 0) return null;

--- a/src/components/layout/event-series-tag-rows.tsx
+++ b/src/components/layout/event-series-tag-rows.tsx
@@ -8,11 +8,9 @@
 import { useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { DoorClosed, DoorOpen, LayoutTemplate, LogIn, LogOut } from "lucide-react";
-import { Button, buttonVariants } from "@/components/ui/button";
-import { TAG_ICON_CLASSES } from "@/components/ui/tag";
+import { Tag, TagAction, TagName, type TagVariant } from "@/components/ui/tag";
 import { ApiRequestError, apiRequest } from "@/lib/api/client";
 import { useBusyWhile } from "@/lib/api/busy";
-import { cn } from "@/lib/utils";
 import { useEventSeries } from "@/lib/event-series/use-event-series";
 import {
   isMasterDataPath,
@@ -60,10 +58,9 @@ export const closeActionLabel = (name: string) => `${name} für Schüler:innen s
  * teacher scans the row for; blue is simply the one being worked in; grey is a template, which is
  * neither and cannot become either.
  */
-function pressedFill(one: EventSeries): string {
-  if (one.isTemplate) return "bg-foreground/75 text-background hover:bg-foreground/65";
-  if (one.isOpenToStudents) return "bg-open text-open-foreground hover:bg-open/85";
-  return "bg-primary text-primary-foreground hover:bg-primary/80";
+function fillFor(one: EventSeries): TagVariant {
+  if (one.isTemplate) return "neutral";
+  return one.isOpenToStudents ? "open" : "default";
 }
 
 function TagRow({ label, eventSeries, selectedId, onSelect, onSetOpen, pending }: RowProps) {
@@ -75,39 +72,20 @@ function TagRow({ label, eventSeries, selectedId, onSelect, onSetOpen, pending }
       {eventSeries.map((one) => {
         const pressed = one.id === selectedId;
         return (
-          <div
-            key={one.id}
-            className={cn(
-              buttonVariants({ variant: "outline" }),
-              "gap-1 px-1.5",
-              pressed && ["border-transparent", pressedFill(one)],
-            )}
-          >
+          <Tag key={one.id} pressed={pressed} variant={fillFor(one)} disabled={pending}>
             <StateIcon eventSeries={one} />
-            <button
-              type="button"
-              aria-pressed={pressed}
-              onClick={() => onSelect(one)}
-              className="focus-visible:ring-ring/50 max-w-60 truncate rounded-md px-0.5 outline-none focus-visible:ring-3"
-            >
-              {one.name}
-            </button>
+            <TagName label={one.name} onPress={() => onSelect(one)} />
             {/* Only on the tag that is selected, so a press cannot land on another series, and
                 never on a template, which can never be opened (US-19, US-22). */}
             {pressed && !one.isTemplate ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label={(one.isOpenToStudents ? closeActionLabel : openActionLabel)(one.name)}
-                disabled={pending}
+              <TagAction
+                label={(one.isOpenToStudents ? closeActionLabel : openActionLabel)(one.name)}
                 onClick={() => onSetOpen(one, !one.isOpenToStudents)}
-                className={TAG_ICON_CLASSES}
               >
                 {one.isOpenToStudents ? <LogOut aria-hidden /> : <LogIn aria-hidden />}
-              </Button>
+              </TagAction>
             ) : null}
-          </div>
+          </Tag>
         );
       })}
     </div>

--- a/src/components/layout/event-series-tag-rows.tsx
+++ b/src/components/layout/event-series-tag-rows.tsx
@@ -8,8 +8,10 @@
 import { usePathname, useRouter } from "next/navigation";
 import { DoorOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { useEventSeries } from "@/lib/event-series/use-event-series";
 import {
+  isMasterDataPath,
   rememberEventSeries,
   rescopedPath,
   selectedEventSeriesIdFrom,
@@ -32,6 +34,13 @@ type RowProps = {
   onSelect: (id: string) => void;
 };
 
+/**
+ * The grey a pressed template is filled with. `secondary` is greyscale but sits at 0.97, which
+ * against a white row leaves pressed and unpressed telling each other apart by nothing.
+ */
+const PRESSED_TEMPLATE =
+  "bg-foreground/75 text-background hover:bg-foreground/65 active:bg-foreground/60";
+
 function TagRow({ label, eventSeries, selectedId, variant, onSelect }: RowProps) {
   return (
     <div role="group" aria-label={label} className="flex flex-wrap items-center gap-2">
@@ -43,6 +52,7 @@ function TagRow({ label, eventSeries, selectedId, variant, onSelect }: RowProps)
             type="button"
             size="sm"
             variant={pressed ? variant : "outline"}
+            className={cn(pressed && variant === "secondary" && PRESSED_TEMPLATE)}
             aria-pressed={pressed}
             onClick={() => onSelect(one.id)}
           >
@@ -74,7 +84,9 @@ export function EventSeriesTagRows() {
 
   const live = eventSeries.filter((one) => !one.isArchived);
   const series = live.filter((one) => !one.isTemplate);
-  const templates = live.filter((one) => one.isTemplate);
+  // A template holds lists and no registrations, so it has nothing an overview, an assignment or
+  // a report could show. Only where the lists are maintained is it worth offering (US-22).
+  const templates = isMasterDataPath(pathname) ? live.filter((one) => one.isTemplate) : [];
 
   function select(id: string) {
     rememberEventSeries(id);
@@ -84,7 +96,7 @@ export function EventSeriesTagRows() {
   if (live.length === 0) return null;
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
       <TagRow
         label={EVENT_SERIES_ROW_LABEL}
         eventSeries={series}

--- a/src/components/layout/event-series-tag-rows.tsx
+++ b/src/components/layout/event-series-tag-rows.tsx
@@ -68,13 +68,13 @@ function TagRow({ label, eventSeries, selectedId, variant, onSelect }: RowProps)
 }
 
 /**
- * Which event series a teacher is working in (US-20). Two rows: the series that carry data above,
- * the templates below — and exactly one tag is pressed across both, because exactly one thing is
- * scoped. Archived series are in neither, which is what makes archiving the thing that takes a
- * series off every screen (US-19).
+ * Which event series a teacher is working in (US-20). One row: the series that carry data first,
+ * the templates after them — and exactly one tag is pressed across both, because exactly one
+ * thing is scoped. Archived series are in neither, which is what makes archiving the thing that
+ * takes a series off every screen (US-19).
  *
- * A row wraps rather than scrolling sideways, so a school with many of either can still see them
- * all, and each carries its own name because colour alone does not say which row a tag is in.
+ * It wraps rather than scrolling sideways, so a school with many of either can still see them
+ * all, and each group carries its own name because colour alone does not say which is which.
  */
 export function EventSeriesTagRows() {
   const { eventSeries } = useEventSeries();
@@ -96,7 +96,7 @@ export function EventSeriesTagRows() {
   if (live.length === 0) return null;
 
   return (
-    <div className="flex min-w-0 flex-1 flex-col gap-1">
+    <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
       <TagRow
         label={EVENT_SERIES_ROW_LABEL}
         eventSeries={series}

--- a/src/components/layout/event-series-tag-rows.tsx
+++ b/src/components/layout/event-series-tag-rows.tsx
@@ -6,7 +6,7 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
-import { DoorOpen } from "lucide-react";
+import { DoorClosed, DoorOpen, LayoutTemplate } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useEventSeries } from "@/lib/event-series/use-event-series";
@@ -24,6 +24,20 @@ export const TEMPLATE_ROW_LABEL = "Vorlagen";
 
 /** Said on the icon a tag carries while its series is taking registrations (US-19, US-20). */
 export const OPEN_TO_STUDENTS_LABEL = EVENT_SERIES_STATE_LABELS.open;
+export const CLOSED_TO_STUDENTS_LABEL = EVENT_SERIES_STATE_LABELS.closed;
+export const TEMPLATE_LABEL = EVENT_SERIES_STATE_LABELS.template;
+
+/** What a tag is, in one icon: a template, or a series with its door open or shut. */
+function StateIcon({ eventSeries }: { eventSeries: EventSeries }) {
+  if (eventSeries.isTemplate) {
+    return <LayoutTemplate aria-label={TEMPLATE_LABEL} className="size-4 shrink-0" />;
+  }
+  return eventSeries.isOpenToStudents ? (
+    <DoorOpen aria-label={OPEN_TO_STUDENTS_LABEL} className="size-4 shrink-0" />
+  ) : (
+    <DoorClosed aria-label={CLOSED_TO_STUDENTS_LABEL} className="size-4 shrink-0" />
+  );
+}
 
 type RowProps = {
   label: string;
@@ -43,7 +57,10 @@ const PRESSED_TEMPLATE =
 
 function TagRow({ label, eventSeries, selectedId, variant, onSelect }: RowProps) {
   return (
-    <div role="group" aria-label={label} className="flex flex-wrap items-center gap-2">
+    // `contents` rather than a box of its own: two boxes cannot share a line once the first one
+    // fills it, so the templates would drop below the series instead of following them. The
+    // group survives in the accessibility tree, which is where it is doing its work.
+    <div role="group" aria-label={label} className="contents">
       {eventSeries.map((one) => {
         const pressed = one.id === selectedId;
         return (
@@ -56,9 +73,7 @@ function TagRow({ label, eventSeries, selectedId, variant, onSelect }: RowProps)
             aria-pressed={pressed}
             onClick={() => onSelect(one.id)}
           >
-            {one.isOpenToStudents ? (
-              <DoorOpen aria-label={OPEN_TO_STUDENTS_LABEL} className="size-4 shrink-0" />
-            ) : null}
+            <StateIcon eventSeries={one} />
             {one.name}
           </Button>
         );

--- a/src/components/layout/event-series-tag-rows.tsx
+++ b/src/components/layout/event-series-tag-rows.tsx
@@ -5,9 +5,13 @@
  */
 "use client";
 
+import { useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { DoorClosed, DoorOpen, LayoutTemplate } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { DoorClosed, DoorOpen, LayoutTemplate, LogIn, LogOut } from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { TAG_ICON_CLASSES } from "@/components/ui/tag";
+import { ApiRequestError, apiRequest } from "@/lib/api/client";
+import { useBusyWhile } from "@/lib/api/busy";
 import { cn } from "@/lib/utils";
 import { useEventSeries } from "@/lib/event-series/use-event-series";
 import {
@@ -43,19 +47,26 @@ type RowProps = {
   label: string;
   eventSeries: EventSeries[];
   selectedId: string | null;
-  /** Accent for a series, grey for a template — both already in the base palette (Q21). */
-  variant: "default" | "secondary";
   onSelect: (eventSeries: EventSeries) => void;
+  onSetOpen: (eventSeries: EventSeries, isOpenToStudents: boolean) => void;
+  pending: boolean;
 };
 
-/**
- * The grey a pressed template is filled with. `secondary` is greyscale but sits at 0.97, which
- * against a white row leaves pressed and unpressed telling each other apart by nothing.
- */
-const PRESSED_TEMPLATE =
-  "bg-foreground/75 text-background hover:bg-foreground/65 active:bg-foreground/60";
+export const openActionLabel = (name: string) => `${name} für Schüler:innen öffnen`;
+export const closeActionLabel = (name: string) => `${name} für Schüler:innen schließen`;
 
-function TagRow({ label, eventSeries, selectedId, variant, onSelect }: RowProps) {
+/**
+ * What the fill of a pressed tag says. Green is the series taking registrations, which is what a
+ * teacher scans the row for; blue is simply the one being worked in; grey is a template, which is
+ * neither and cannot become either.
+ */
+function pressedFill(one: EventSeries): string {
+  if (one.isTemplate) return "bg-foreground/75 text-background hover:bg-foreground/65";
+  if (one.isOpenToStudents) return "bg-open text-open-foreground hover:bg-open/85";
+  return "bg-primary text-primary-foreground hover:bg-primary/80";
+}
+
+function TagRow({ label, eventSeries, selectedId, onSelect, onSetOpen, pending }: RowProps) {
   return (
     // `contents` rather than a box of its own: two boxes cannot share a line once the first one
     // fills it, so the templates would drop below the series instead of following them. The
@@ -64,17 +75,39 @@ function TagRow({ label, eventSeries, selectedId, variant, onSelect }: RowProps)
       {eventSeries.map((one) => {
         const pressed = one.id === selectedId;
         return (
-          <Button
+          <div
             key={one.id}
-            type="button"
-            variant={pressed ? variant : "outline"}
-            className={cn(pressed && variant === "secondary" && PRESSED_TEMPLATE)}
-            aria-pressed={pressed}
-            onClick={() => onSelect(one)}
+            className={cn(
+              buttonVariants({ variant: "outline" }),
+              "gap-1 px-1.5",
+              pressed && ["border-transparent", pressedFill(one)],
+            )}
           >
             <StateIcon eventSeries={one} />
-            {one.name}
-          </Button>
+            <button
+              type="button"
+              aria-pressed={pressed}
+              onClick={() => onSelect(one)}
+              className="focus-visible:ring-ring/50 max-w-60 truncate rounded-md px-0.5 outline-none focus-visible:ring-3"
+            >
+              {one.name}
+            </button>
+            {/* Only on the tag that is selected, so a press cannot land on another series, and
+                never on a template, which can never be opened (US-19, US-22). */}
+            {pressed && !one.isTemplate ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={(one.isOpenToStudents ? closeActionLabel : openActionLabel)(one.name)}
+                disabled={pending}
+                onClick={() => onSetOpen(one, !one.isOpenToStudents)}
+                className={TAG_ICON_CLASSES}
+              >
+                {one.isOpenToStudents ? <LogOut aria-hidden /> : <LogIn aria-hidden />}
+              </Button>
+            ) : null}
+          </div>
         );
       })}
     </div>
@@ -82,10 +115,14 @@ function TagRow({ label, eventSeries, selectedId, variant, onSelect }: RowProps)
 }
 
 /**
- * Which event series a teacher is working in (US-20). One row: the series that carry data first,
- * the templates after them — and exactly one tag is pressed across both, because exactly one
- * thing is scoped. Archived series are in neither, which is what makes archiving the thing that
- * takes a series off every screen (US-19).
+ * Which event series a teacher is working in (US-20), and whether it is taking registrations
+ * (US-19, US-29). One row: the series that carry data first, the templates after them — and
+ * exactly one tag is pressed across both, because exactly one thing is scoped. Archived series
+ * are in neither, which is what makes archiving the thing that takes a series off every screen.
+ *
+ * Opening and closing lives on the tag rather than on a page, because the tag names the series
+ * it concerns and is on screen wherever the teacher happens to be. There is no second control
+ * for it anywhere: two controls for one decision would be two answers to it.
  *
  * It wraps rather than scrolling sideways, so a school with many of either can still see them
  * all, and each group carries its own name because colour alone does not say which is which.
@@ -95,6 +132,10 @@ export function EventSeriesTagRows() {
   const pathname = usePathname();
   const router = useRouter();
   const selectedId = selectedEventSeriesIdFrom(pathname);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useBusyWhile(saving);
 
   const live = eventSeries.filter((one) => !one.isArchived);
   const series = live.filter((one) => !one.isTemplate);
@@ -107,27 +148,43 @@ export function EventSeriesTagRows() {
     router.push(rescopedPath(pathname, one.id, one.isTemplate));
   }
 
+  async function setOpenToStudents(one: EventSeries, isOpenToStudents: boolean) {
+    setActionError(null);
+    setSaving(true);
+    try {
+      await apiRequest(`/api/event-series/${one.id}`, {
+        method: "PATCH",
+        body: { isOpenToStudents },
+      });
+    } catch (caught) {
+      setActionError(
+        caught instanceof ApiRequestError ? caught.message : "Das hat leider nicht geklappt.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
   if (live.length === 0) return null;
 
+  const rowProps = { selectedId, onSelect: select, onSetOpen: setOpenToStudents, pending: saving };
+
   return (
-    <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
-      <TagRow
-        label={EVENT_SERIES_ROW_LABEL}
-        eventSeries={series}
-        selectedId={selectedId}
-        variant="default"
-        onSelect={select}
-      />
-      {/* Absent rather than empty, so a school that never makes a template never sees a space
-          set aside for one. */}
-      {templates.length === 0 ? null : (
-        <TagRow
-          label={TEMPLATE_ROW_LABEL}
-          eventSeries={templates}
-          selectedId={selectedId}
-          variant="secondary"
-          onSelect={select}
-        />
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <div className="flex flex-wrap items-center gap-2">
+        <TagRow label={EVENT_SERIES_ROW_LABEL} eventSeries={series} {...rowProps} />
+        {/* Absent rather than empty, so a school that never makes a template never sees a space
+            set aside for one. */}
+        {templates.length === 0 ? null : (
+          <TagRow label={TEMPLATE_ROW_LABEL} eventSeries={templates} {...rowProps} />
+        )}
+      </div>
+
+      {/* The press happened here, so the refusal is answered here (US-19). */}
+      {actionError === null ? null : (
+        <p role="alert" className="text-destructive text-sm">
+          {actionError}
+        </p>
       )}
     </div>
   );

--- a/src/components/layout/event-series-tag-rows.tsx
+++ b/src/components/layout/event-series-tag-rows.tsx
@@ -67,7 +67,6 @@ function TagRow({ label, eventSeries, selectedId, variant, onSelect }: RowProps)
           <Button
             key={one.id}
             type="button"
-            size="sm"
             variant={pressed ? variant : "outline"}
             className={cn(pressed && variant === "secondary" && PRESSED_TEMPLATE)}
             aria-pressed={pressed}

--- a/src/components/layout/event-series-tag-rows.tsx
+++ b/src/components/layout/event-series-tag-rows.tsx
@@ -59,7 +59,7 @@ export const closeActionLabel = (name: string) => `${name} für Schüler:innen s
  * neither and cannot become either.
  */
 function fillFor(one: EventSeries): TagVariant {
-  if (one.isTemplate) return "neutral";
+  if (one.isTemplate) return "template";
   return one.isOpenToStudents ? "open" : "default";
 }
 

--- a/src/components/layout/teacher-nav.test.tsx
+++ b/src/components/layout/teacher-nav.test.tsx
@@ -17,7 +17,6 @@ vi.mock("@/components/auth/sign-out-button", () => ({
 }));
 
 const { TeacherNav } = await import("@/components/layout/teacher-nav");
-const { NAV_TOGGLE_LABEL } = await import("@/components/layout/brand");
 
 const SUB_ITEMS = [
   "Eventreihen",
@@ -157,65 +156,31 @@ describe("TeacherNav", () => {
 });
 
 /**
- * The logo folds the bar and unfolds it again, and nothing else does. Every other row is
- * somewhere to go, and a row that sometimes goes there and sometimes folds the bar instead
- * cannot be pressed without first knowing which of the two it is about to do.
+ * The bar does not fold. It had a control on the logo and, before that, on whichever row you
+ * were already standing on; both are gone until the width is worth the second state.
  */
-describe("TeacherNav — collapsing", () => {
+describe("TeacherNav — always open", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     pathname.mockReturnValue("/app/s1/report");
   });
 
   const openSubItems = () => screen.queryByRole("link", { name: "Klassen" });
-  const logo = () => screen.getByRole("button", { name: NAV_TOGGLE_LABEL });
 
-  it("folds away when the logo is pressed, and comes back when it is pressed again", async () => {
+  it("offers nothing that folds it", () => {
     render(<TeacherNav />);
 
-    await userEvent.click(logo());
-    expect(openSubItems()).not.toBeInTheDocument();
-
-    await userEvent.click(logo());
-    expect(openSubItems()).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /navigation/i })).not.toBeInTheDocument();
   });
 
-  it("says which way it is about to go, the mark itself saying nothing", async () => {
-    render(<TeacherNav />);
+  it.each(["Bericht", "\u00dcbersicht", "Stammdaten"])(
+    "stays open when %s is pressed, whether it is where you already are or not",
+    async (label) => {
+      render(<TeacherNav />);
 
-    expect(logo()).toHaveAttribute("aria-expanded", "true");
+      await userEvent.click(screen.getByRole("link", { name: label }));
 
-    await userEvent.click(logo());
-    expect(logo()).toHaveAttribute("aria-expanded", "false");
-  });
-
-  /** Pressing the page you are already on used to fold the bar, which made every row two rows. */
-  it("leaves the bar alone when the page it is already on is pressed", async () => {
-    render(<TeacherNav />);
-
-    await userEvent.click(screen.getByRole("link", { name: "Bericht" }));
-
-    expect(openSubItems()).toBeInTheDocument();
-  });
-
-  it("keeps every destination reachable by name while collapsed", async () => {
-    render(<TeacherNav />);
-
-    await userEvent.click(logo());
-
-    for (const label of ["Bericht", "Zuteilung", "\u00dcbersicht", "Stammdaten"]) {
-      expect(screen.getByRole("link", { name: label })).toBeInTheDocument();
-    }
-  });
-
-  // The bar is collapsed because the teacher wants the width, so going somewhere else must not
-  // take that decision back.
-  it("stays collapsed when another destination is chosen", async () => {
-    render(<TeacherNav />);
-
-    await userEvent.click(logo());
-    await userEvent.click(screen.getByRole("link", { name: "\u00dcbersicht" }));
-
-    expect(openSubItems()).not.toBeInTheDocument();
-  });
+      expect(openSubItems()).toBeInTheDocument();
+    },
+  );
 });

--- a/src/components/layout/teacher-nav.test.tsx
+++ b/src/components/layout/teacher-nav.test.tsx
@@ -11,6 +11,11 @@ const pathname = vi.fn(() => "/app/s1/report");
 
 vi.mock("next/navigation", () => ({ usePathname: () => pathname() }));
 
+// The bar carries it at its foot, and it reaches Firebase, which no test here has cause to start.
+vi.mock("@/components/auth/sign-out-button", () => ({
+  SignOutButton: () => <button type="button">Abmelden</button>,
+}));
+
 const { TeacherNav } = await import("@/components/layout/teacher-nav");
 
 const SUB_ITEMS = [

--- a/src/components/layout/teacher-nav.test.tsx
+++ b/src/components/layout/teacher-nav.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/components/auth/sign-out-button", () => ({
 }));
 
 const { TeacherNav } = await import("@/components/layout/teacher-nav");
+const { NAV_TOGGLE_LABEL } = await import("@/components/layout/brand");
 
 const SUB_ITEMS = [
   "Eventreihen",
@@ -58,8 +59,18 @@ describe("TeacherNav", () => {
       expect(screen.getByRole("link", { name: label }).querySelector("svg")).toBeInTheDocument();
     }
     expect(
-      screen.getByRole("button", { name: /stammdaten/i }).querySelector("svg"),
+      screen.getByRole("link", { name: /stammdaten/i }).querySelector("svg"),
     ).toBeInTheDocument();
+  });
+
+  /** The section has no view of its own, so it opens on the first list the bar offers under it. */
+  it("opens the section on its first list when Stammdaten is pressed", () => {
+    render(<TeacherNav />);
+
+    expect(screen.getByRole("link", { name: /stammdaten/i })).toHaveAttribute(
+      "href",
+      "/app/event-series",
+    );
   });
 
   /**
@@ -111,7 +122,7 @@ describe("TeacherNav", () => {
   it("leaves them there when Stammdaten is clicked, which folds nothing", async () => {
     render(<TeacherNav />);
 
-    await userEvent.click(screen.getByRole("button", { name: /stammdaten/i }));
+    await userEvent.click(screen.getByRole("link", { name: /stammdaten/i }));
 
     for (const label of SUB_ITEMS) {
       expect(screen.getByRole("link", { name: label })).toBeInTheDocument();
@@ -146,9 +157,9 @@ describe("TeacherNav", () => {
 });
 
 /**
- * There is no control of its own for this. Pressing the page you are already on folds the bar
- * away and pressing it again brings it back, as an activity bar does — a second press of what
- * you are already looking at has nowhere else to take you, so it is free to mean this.
+ * The logo folds the bar and unfolds it again, and nothing else does. Every other row is
+ * somewhere to go, and a row that sometimes goes there and sometimes folds the bar instead
+ * cannot be pressed without first knowing which of the two it is about to do.
  */
 describe("TeacherNav — collapsing", () => {
   beforeEach(() => {
@@ -157,53 +168,54 @@ describe("TeacherNav — collapsing", () => {
   });
 
   const openSubItems = () => screen.queryByRole("link", { name: "Klassen" });
+  const logo = () => screen.getByRole("button", { name: NAV_TOGGLE_LABEL });
 
-  it("offers no control of its own", () => {
+  it("folds away when the logo is pressed, and comes back when it is pressed again", async () => {
     render(<TeacherNav />);
 
-    expect(
-      screen.queryByRole("button", { name: /navigation (ein|aus)klappen/i }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("folds away when the page it is on is pressed, and comes back when it is pressed again", async () => {
-    render(<TeacherNav />);
-    const here = () => screen.getByRole("link", { name: "Bericht" });
-
-    await userEvent.click(here());
+    await userEvent.click(logo());
     expect(openSubItems()).not.toBeInTheDocument();
 
-    await userEvent.click(here());
+    await userEvent.click(logo());
+    expect(openSubItems()).toBeInTheDocument();
+  });
+
+  it("says which way it is about to go, the mark itself saying nothing", async () => {
+    render(<TeacherNav />);
+
+    expect(logo()).toHaveAttribute("aria-expanded", "true");
+
+    await userEvent.click(logo());
+    expect(logo()).toHaveAttribute("aria-expanded", "false");
+  });
+
+  /** Pressing the page you are already on used to fold the bar, which made every row two rows. */
+  it("leaves the bar alone when the page it is already on is pressed", async () => {
+    render(<TeacherNav />);
+
+    await userEvent.click(screen.getByRole("link", { name: "Bericht" }));
+
     expect(openSubItems()).toBeInTheDocument();
   });
 
   it("keeps every destination reachable by name while collapsed", async () => {
     render(<TeacherNav />);
 
-    await userEvent.click(screen.getByRole("link", { name: "Bericht" }));
+    await userEvent.click(logo());
 
-    for (const label of ["Bericht", "Zuteilung", "\u00dcbersicht"]) {
+    for (const label of ["Bericht", "Zuteilung", "\u00dcbersicht", "Stammdaten"]) {
       expect(screen.getByRole("link", { name: label })).toBeInTheDocument();
     }
   });
 
   // The bar is collapsed because the teacher wants the width, so going somewhere else must not
-  // take that decision back — only asking for something the rail has no room for may.
+  // take that decision back.
   it("stays collapsed when another destination is chosen", async () => {
     render(<TeacherNav />);
 
-    await userEvent.click(screen.getByRole("link", { name: "Bericht" }));
+    await userEvent.click(logo());
     await userEvent.click(screen.getByRole("link", { name: "\u00dcbersicht" }));
 
     expect(openSubItems()).not.toBeInTheDocument();
-  });
-
-  it("opens the bar when the sub-items are asked for, there being no width to read them in", async () => {
-    render(<TeacherNav />);
-
-    await userEvent.click(screen.getByRole("link", { name: "Bericht" }));
-    await userEvent.click(screen.getByRole("button", { name: /stammdaten/i }));
-
-    expect(openSubItems()).toBeInTheDocument();
   });
 });

--- a/src/components/layout/teacher-nav.test.tsx
+++ b/src/components/layout/teacher-nav.test.tsx
@@ -8,8 +8,10 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const pathname = vi.fn(() => "/app/s1/report");
+const eventSeries = vi.fn<() => { eventSeries: unknown[] }>(() => ({ eventSeries: [] }));
 
 vi.mock("next/navigation", () => ({ usePathname: () => pathname() }));
+vi.mock("@/lib/event-series/use-event-series", () => ({ useEventSeries: () => eventSeries() }));
 
 // The bar carries it at its foot, and it reaches Firebase, which no test here has cause to start.
 vi.mock("@/components/auth/sign-out-button", () => ({
@@ -28,10 +30,21 @@ const SUB_ITEMS = [
   "Verpflegung",
 ];
 
+const series = (id: string, overrides = {}) => ({
+  id,
+  isTemplate: false,
+  isArchived: false,
+  ...overrides,
+});
+
+const showing = (...list: ReturnType<typeof series>[]) =>
+  eventSeries.mockReturnValue({ eventSeries: list });
+
 describe("TeacherNav", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     pathname.mockReturnValue("/app/s1/report");
+    showing(series("s1"), series("s2"), series("s7"));
   });
 
   it("lists the top-level items in order", () => {
@@ -62,22 +75,46 @@ describe("TeacherNav", () => {
     ).toBeInTheDocument();
   });
 
-  /** The section has no view of its own, so it opens on the first list the bar offers under it. */
-  it("opens the section on its first list when Stammdaten is pressed", () => {
+  /** Moving into the section is not a change of series, so it opens on the one already selected. */
+  it("opens Stammdaten on the selected series, at its first list", () => {
     render(<TeacherNav />);
 
     expect(screen.getByRole("link", { name: /stammdaten/i })).toHaveAttribute(
       "href",
-      "/app/event-series",
+      "/app/s1/master-data/events",
     );
   });
 
+  /** Master data can be about a template, so it is where a selected one is kept (US-22). */
+  it("opens Stammdaten on the first template when nothing is selected", () => {
+    pathname.mockReturnValue("/app/event-series");
+    showing(series("s1"), series("t1", { isTemplate: true }));
+
+    render(<TeacherNav />);
+
+    expect(screen.getByRole("link", { name: /stammdaten/i })).toHaveAttribute(
+      "href",
+      "/app/t1/master-data/events",
+    );
+  });
+
+  /** A template has no registrations, so the pages that read them take the first series instead. */
+  it("points the other sections past a selected template", () => {
+    pathname.mockReturnValue("/app/t1/master-data/classes");
+    showing(series("t1", { isTemplate: true }), series("s1"));
+
+    render(<TeacherNav />);
+
+    expect(screen.getByRole("link", { name: "Bericht" })).toHaveAttribute("href", "/app/s1/report");
+  });
+
   /**
-   * Every page but the event series list is about one series, so with none selected there is
+   * Every page but the event series list is about one series, so with none at all there is
    * nowhere for the other entries to point (US-20).
    */
-  it("offers only the event series list while nothing is selected", () => {
+  it("offers only the event series list while there is no series to be about", () => {
     pathname.mockReturnValue("/app/event-series");
+    showing();
 
     render(<TeacherNav />);
 
@@ -163,6 +200,7 @@ describe("TeacherNav — always open", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     pathname.mockReturnValue("/app/s1/report");
+    showing(series("s1"), series("s2"), series("s7"));
   });
 
   const openSubItems = () => screen.queryByRole("link", { name: "Klassen" });

--- a/src/components/layout/teacher-nav.test.tsx
+++ b/src/components/layout/teacher-nav.test.tsx
@@ -145,87 +145,65 @@ describe("TeacherNav", () => {
   });
 });
 
+/**
+ * There is no control of its own for this. Pressing the page you are already on folds the bar
+ * away and pressing it again brings it back, as an activity bar does — a second press of what
+ * you are already looking at has nowhere else to take you, so it is free to mean this.
+ */
 describe("TeacherNav — collapsing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     pathname.mockReturnValue("/app/s1/report");
   });
 
-  const toggle = () => screen.getByRole("button", { name: /navigation (ein|aus)klappen/i });
+  const openSubItems = () => screen.queryByRole("link", { name: "Klassen" });
 
-  it("starts open, and says which way its control goes", () => {
+  it("offers no control of its own", () => {
     render(<TeacherNav />);
 
-    expect(toggle()).toHaveAccessibleName("Navigation einklappen");
-    expect(toggle()).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.queryByRole("button", { name: /navigation (ein|aus)klappen/i }),
+    ).not.toBeInTheDocument();
   });
 
-  /** It is about the bar rather than a place to go, so it sits below everything that is. */
-  it("puts its own control below every destination", () => {
+  it("folds away when the page it is on is pressed, and comes back when it is pressed again", async () => {
     render(<TeacherNav />);
+    const here = () => screen.getByRole("link", { name: "Bericht" });
 
-    const last = screen.getByRole("navigation").querySelectorAll("a, button");
+    await userEvent.click(here());
+    expect(openSubItems()).not.toBeInTheDocument();
 
-    expect(last[last.length - 1]).toBe(toggle());
-  });
-
-  it("collapses and opens again", async () => {
-    render(<TeacherNav />);
-
-    await userEvent.click(toggle());
-    expect(toggle()).toHaveAccessibleName("Navigation ausklappen");
-    expect(toggle()).toHaveAttribute("aria-expanded", "false");
-
-    await userEvent.click(toggle());
-    expect(toggle()).toHaveAccessibleName("Navigation einklappen");
+    await userEvent.click(here());
+    expect(openSubItems()).toBeInTheDocument();
   });
 
   it("keeps every destination reachable by name while collapsed", async () => {
     render(<TeacherNav />);
 
-    await userEvent.click(toggle());
+    await userEvent.click(screen.getByRole("link", { name: "Bericht" }));
 
     for (const label of ["Bericht", "Zuteilung", "\u00dcbersicht"]) {
       expect(screen.getByRole("link", { name: label })).toBeInTheDocument();
     }
   });
 
-  it("folds the sub-items away with the bar, since there is no width left to read them in", async () => {
-    pathname.mockReturnValue("/app/s1/master-data/classes");
+  // The bar is collapsed because the teacher wants the width, so going somewhere else must not
+  // take that decision back — only asking for something the rail has no room for may.
+  it("stays collapsed when another destination is chosen", async () => {
     render(<TeacherNav />);
 
-    await userEvent.click(toggle());
-
-    expect(screen.queryByRole("link", { name: "Klassen" })).not.toBeInTheDocument();
-  });
-
-  // The bar is collapsed because the teacher wants the width, so going somewhere must not take
-  // that decision back — only asking for something the rail has no room for may.
-  it("stays collapsed when a destination is chosen", async () => {
-    render(<TeacherNav />);
-
-    await userEvent.click(toggle());
+    await userEvent.click(screen.getByRole("link", { name: "Bericht" }));
     await userEvent.click(screen.getByRole("link", { name: "\u00dcbersicht" }));
 
-    expect(toggle()).toHaveAccessibleName("Navigation ausklappen");
+    expect(openSubItems()).not.toBeInTheDocument();
   });
 
   it("opens the bar when the sub-items are asked for, there being no width to read them in", async () => {
     render(<TeacherNav />);
 
-    await userEvent.click(toggle());
+    await userEvent.click(screen.getByRole("link", { name: "Bericht" }));
     await userEvent.click(screen.getByRole("button", { name: /stammdaten/i }));
 
-    expect(toggle()).toHaveAccessibleName("Navigation einklappen");
-    expect(screen.getByRole("link", { name: "Klassen" })).toBeInTheDocument();
-  });
-
-  it("brings the sub-items back with the bar", async () => {
-    render(<TeacherNav />);
-
-    await userEvent.click(toggle());
-    await userEvent.click(toggle());
-
-    expect(screen.getByRole("link", { name: "Klassen" })).toBeInTheDocument();
+    expect(openSubItems()).toBeInTheDocument();
   });
 });

--- a/src/components/layout/teacher-nav.tsx
+++ b/src/components/layout/teacher-nav.tsx
@@ -59,23 +59,13 @@ export function TeacherNav({
     pathname === ROUTES.eventSeries ||
     pathname.startsWith(`${ROUTES.eventSeries}/`) ||
     (masterData !== null && pathname.startsWith(masterData));
-  const [collapsed, setCollapsed] = useState(false);
-
   const sections = masterDataSections(eventSeriesId);
-  // Collapsing is offered where the bar is a column; on a narrow screen it is a strip across the
-  // top, which is why the labels only go away from the same breakpoint the toggle appears at.
-  const labelClasses = cn(collapsed && "md:sr-only");
 
   return (
-    <nav
-      aria-label="Hauptnavigation"
-      // Collapsed, the rail is exactly one row wide — its own padding, the row's, and the icon —
-      // so the icon keeps the position it had and its highlight has the same margin either side.
-      className={cn("flex h-full flex-col gap-1 p-2", collapsed ? "md:w-14" : "md:w-56")}
-    >
+    <nav aria-label="Hauptnavigation" className="flex h-full flex-col gap-1 p-2 md:w-56">
       {/* Heads the bar rather than the header, because the bar runs to the top of the window and
           the column beside it is where a page begins. */}
-      <Brand nameHidden={collapsed} onToggle={() => setCollapsed((on) => !on)} />
+      <Brand />
 
       {(eventSeriesId === null ? [] : topLevel(eventSeriesId)).map(({ href, label, Icon }) => {
         const active = pathname === href || pathname.startsWith(`${href}/`);
@@ -84,51 +74,40 @@ export function TeacherNav({
             key={href}
             href={href}
             aria-current={active ? "page" : undefined}
-            title={collapsed ? label : undefined}
             className={itemClasses(active)}
           >
             <Icon aria-hidden className="size-6 shrink-0" />
-            <span className={labelClasses}>{label}</span>
+            <span>{label}</span>
           </Link>
         );
       })}
 
       {/* The section has no view of its own, so it opens on the first list beneath it. */}
-      <Link
-        href={sections[0].href}
-        title={collapsed ? "Stammdaten" : undefined}
-        className={itemClasses(inMasterData)}
-      >
+      <Link href={sections[0].href} className={itemClasses(inMasterData)}>
         <Database aria-hidden className="size-6 shrink-0" />
-        <span className={labelClasses}>Stammdaten</span>
+        <span>Stammdaten</span>
       </Link>
 
-      {collapsed ? null : (
-        <ul className="flex flex-col gap-1">
-          {sections.map(({ href, label }) => (
-            <li key={href}>
-              <Link
-                href={href}
-                aria-current={pathname === href ? "page" : undefined}
-                className={itemClasses(pathname === href)}
-              >
-                {/* Stands in for the icon above it, so the text lines up by being laid out the
-                    same way rather than by a padding that has to add up to the same number. */}
-                <span aria-hidden className="size-6 shrink-0" />
-                {label}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
+      <ul className="flex flex-col gap-1">
+        {sections.map(({ href, label }) => (
+          <li key={href}>
+            <Link
+              href={href}
+              aria-current={pathname === href ? "page" : undefined}
+              className={itemClasses(pathname === href)}
+            >
+              {/* Stands in for the icon above it, so the text lines up by being laid out the
+                  same way rather than by a padding that has to add up to the same number. */}
+              <span aria-hidden className="size-6 shrink-0" />
+              {label}
+            </Link>
+          </li>
+        ))}
+      </ul>
 
       {/* The foot of the bar: who is signed in. */}
       <div className="mt-auto">
-        <SignOutButton
-          className="min-h-9 w-full justify-start px-2 py-2"
-          labelHidden={collapsed}
-          photo={photo}
-        />
+        <SignOutButton className="min-h-9 w-full justify-start px-2 py-2" photo={photo} />
       </div>
     </nav>
   );

--- a/src/components/layout/teacher-nav.tsx
+++ b/src/components/layout/teacher-nav.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ChartColumn, ChevronLeft, ChevronRight, Database, FileText, Shuffle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Brand } from "@/components/layout/brand";
 import { masterDataSections } from "@/lib/master-data/categories";
 import { selectedEventSeriesIdFrom } from "@/lib/event-series/event-series-selection";
 import { eventSeriesRoutes, ROUTES } from "@/lib/routes";
@@ -64,8 +65,12 @@ export function TeacherNav({
   return (
     <nav
       aria-label="Hauptnavigation"
-      className={cn("flex flex-col gap-1 p-3", collapsed ? "md:w-16" : "md:w-56")}
+      className={cn("flex h-full flex-col gap-1 p-3", collapsed ? "md:w-16" : "md:w-56")}
     >
+      {/* Heads the bar rather than the header, because the bar runs to the top of the window and
+          the column beside it is where a page begins. */}
+      <Brand nameHidden={collapsed} />
+
       {(eventSeriesId === null ? [] : topLevel(eventSeriesId)).map(({ href, label, Icon }) => {
         const active = pathname === href || pathname.startsWith(`${href}/`);
         return (
@@ -76,7 +81,7 @@ export function TeacherNav({
             title={collapsed ? label : undefined}
             className={itemClasses(active)}
           >
-            <Icon aria-hidden className="size-4 shrink-0" />
+            <Icon aria-hidden className="size-6 shrink-0" />
             <span className={labelClasses}>{label}</span>
           </Link>
         );
@@ -90,7 +95,7 @@ export function TeacherNav({
         title={collapsed ? "Stammdaten" : undefined}
         className={cn(itemClasses(inMasterData), "text-left")}
       >
-        <Database aria-hidden className="size-4 shrink-0" />
+        <Database aria-hidden className="size-6 shrink-0" />
         <span className={labelClasses}>Stammdaten</span>
       </button>
 
@@ -105,7 +110,7 @@ export function TeacherNav({
               >
                 {/* Stands in for the icon above it, so the text lines up by being laid out the
                     same way rather than by a padding that has to add up to the same number. */}
-                <span aria-hidden className="size-4 shrink-0" />
+                <span aria-hidden className="size-6 shrink-0" />
                 {label}
               </Link>
             </li>
@@ -122,9 +127,9 @@ export function TeacherNav({
       >
         {/* Points the way the bar is about to move. */}
         {collapsed ? (
-          <ChevronRight aria-hidden className="size-4 shrink-0" />
+          <ChevronRight aria-hidden className="size-6 shrink-0" />
         ) : (
-          <ChevronLeft aria-hidden className="size-4 shrink-0" />
+          <ChevronLeft aria-hidden className="size-6 shrink-0" />
         )}
       </button>
     </nav>

--- a/src/components/layout/teacher-nav.tsx
+++ b/src/components/layout/teacher-nav.tsx
@@ -122,7 +122,7 @@ export function TeacherNav({
       {/* The foot of the bar: who is signed in, and the bar's own control. Stacked rather than
           side by side, because a collapsed rail is one icon wide. */}
       <div className="mt-auto flex flex-col gap-1">
-        <SignOutButton labelHidden={collapsed} />
+        <SignOutButton className="min-h-9 w-full justify-start px-2 py-2" labelHidden={collapsed} />
 
         <button
           type="button"

--- a/src/components/layout/teacher-nav.tsx
+++ b/src/components/layout/teacher-nav.tsx
@@ -59,6 +59,7 @@ export function TeacherNav({
     (masterData !== null && pathname.startsWith(masterData));
   const [collapsed, setCollapsed] = useState(false);
 
+  const sections = masterDataSections(eventSeriesId);
   // Collapsing is offered where the bar is a column; on a narrow screen it is a strip across the
   // top, which is why the labels only go away from the same breakpoint the toggle appears at.
   const labelClasses = cn(collapsed && "md:sr-only");
@@ -66,11 +67,13 @@ export function TeacherNav({
   return (
     <nav
       aria-label="Hauptnavigation"
-      className={cn("flex h-full flex-col gap-1 p-2", collapsed ? "md:w-16" : "md:w-56")}
+      // Collapsed, the rail is exactly one row wide — its own padding, the row's, and the icon —
+      // so the icon keeps the position it had and its highlight has the same margin either side.
+      className={cn("flex h-full flex-col gap-1 p-2", collapsed ? "md:w-14" : "md:w-56")}
     >
       {/* Heads the bar rather than the header, because the bar runs to the top of the window and
           the column beside it is where a page begins. */}
-      <Brand nameHidden={collapsed} />
+      <Brand nameHidden={collapsed} onToggle={() => setCollapsed((on) => !on)} />
 
       {(eventSeriesId === null ? [] : topLevel(eventSeriesId)).map(({ href, label, Icon }) => {
         const active = pathname === href || pathname.startsWith(`${href}/`);
@@ -80,16 +83,6 @@ export function TeacherNav({
             href={href}
             aria-current={active ? "page" : undefined}
             title={collapsed ? label : undefined}
-            // A second press of the page you are already looking at has nowhere to take you, so
-            // it folds the bar away instead — which is what saves the bar a control of its own.
-            onClick={
-              active
-                ? (event) => {
-                    event.preventDefault();
-                    setCollapsed((on) => !on);
-                  }
-                : undefined
-            }
             className={itemClasses(active)}
           >
             <Icon aria-hidden className="size-6 shrink-0" />
@@ -98,21 +91,19 @@ export function TeacherNav({
         );
       })}
 
-      <button
-        type="button"
-        // Its own section never folds, so the only thing left to ask of it is the width to read
-        // that section in.
-        onClick={() => setCollapsed(false)}
+      {/* The section has no view of its own, so it opens on the first list beneath it. */}
+      <Link
+        href={sections[0].href}
         title={collapsed ? "Stammdaten" : undefined}
-        className={cn(itemClasses(inMasterData), "text-left")}
+        className={itemClasses(inMasterData)}
       >
         <Database aria-hidden className="size-6 shrink-0" />
         <span className={labelClasses}>Stammdaten</span>
-      </button>
+      </Link>
 
       {collapsed ? null : (
         <ul className="flex flex-col gap-1">
-          {masterDataSections(eventSeriesId).map(({ href, label }) => (
+          {sections.map(({ href, label }) => (
             <li key={href}>
               <Link
                 href={href}

--- a/src/components/layout/teacher-nav.tsx
+++ b/src/components/layout/teacher-nav.tsx
@@ -12,8 +12,12 @@ import { ChartColumn, Database, FileText, Shuffle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Brand } from "@/components/layout/brand";
 import { SignOutButton } from "@/components/auth/sign-out-button";
-import { masterDataSections } from "@/lib/master-data/categories";
-import { selectedEventSeriesIdFrom } from "@/lib/event-series/event-series-selection";
+import { masterDataSections, firstMasterDataPath } from "@/lib/master-data/categories";
+import { useEventSeries } from "@/lib/event-series/use-event-series";
+import {
+  sectionSelection,
+  selectedEventSeriesIdFrom,
+} from "@/lib/event-series/event-series-selection";
 import { eventSeriesRoutes, ROUTES } from "@/lib/routes";
 
 function topLevel(eventSeriesId: string) {
@@ -59,7 +63,13 @@ export function TeacherNav({
     pathname === ROUTES.eventSeries ||
     pathname.startsWith(`${ROUTES.eventSeries}/`) ||
     (masterData !== null && pathname.startsWith(masterData));
-  const sections = masterDataSections(eventSeriesId);
+
+  // Each section keeps the selection where it can be about it, and takes the first it can show
+  // where it cannot: master data can be about a template, the pages of registrations cannot.
+  const { eventSeries } = useEventSeries();
+  const seriesId = sectionSelection(eventSeries, eventSeriesId, "series");
+  const masterDataId = sectionSelection(eventSeries, eventSeriesId, "masterData");
+  const sections = masterDataSections(masterDataId);
 
   return (
     <nav aria-label="Hauptnavigation" className="flex h-full flex-col gap-1 p-2 md:w-56">
@@ -67,7 +77,7 @@ export function TeacherNav({
           the column beside it is where a page begins. */}
       <Brand />
 
-      {(eventSeriesId === null ? [] : topLevel(eventSeriesId)).map(({ href, label, Icon }) => {
+      {(seriesId === null ? [] : topLevel(seriesId)).map(({ href, label, Icon }) => {
         const active = pathname === href || pathname.startsWith(`${href}/`);
         return (
           <Link
@@ -83,7 +93,10 @@ export function TeacherNav({
       })}
 
       {/* The section has no view of its own, so it opens on the first list beneath it. */}
-      <Link href={sections[0].href} className={itemClasses(inMasterData)}>
+      <Link
+        href={masterDataId === null ? ROUTES.eventSeries : firstMasterDataPath(masterDataId)}
+        className={itemClasses(inMasterData)}
+      >
         <Database aria-hidden className="size-6 shrink-0" />
         <span>Stammdaten</span>
       </Link>

--- a/src/components/layout/teacher-nav.tsx
+++ b/src/components/layout/teacher-nav.tsx
@@ -8,7 +8,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ChartColumn, ChevronLeft, ChevronRight, Database, FileText, Shuffle } from "lucide-react";
+import { ChartColumn, Database, FileText, Shuffle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Brand } from "@/components/layout/brand";
 import { SignOutButton } from "@/components/auth/sign-out-button";
@@ -80,6 +80,16 @@ export function TeacherNav({
             href={href}
             aria-current={active ? "page" : undefined}
             title={collapsed ? label : undefined}
+            // A second press of the page you are already looking at has nowhere to take you, so
+            // it folds the bar away instead — which is what saves the bar a control of its own.
+            onClick={
+              active
+                ? (event) => {
+                    event.preventDefault();
+                    setCollapsed((on) => !on);
+                  }
+                : undefined
+            }
             className={itemClasses(active)}
           >
             <Icon aria-hidden className="size-6 shrink-0" />
@@ -119,25 +129,9 @@ export function TeacherNav({
         </ul>
       )}
 
-      {/* The foot of the bar: who is signed in, and the bar's own control. Stacked rather than
-          side by side, because a collapsed rail is one icon wide. */}
-      <div className="mt-auto flex flex-col gap-1">
+      {/* The foot of the bar: who is signed in. */}
+      <div className="mt-auto">
         <SignOutButton className="min-h-9 w-full justify-start px-2 py-2" labelHidden={collapsed} />
-
-        <button
-          type="button"
-          onClick={() => setCollapsed((on) => !on)}
-          aria-expanded={!collapsed}
-          aria-label={collapsed ? "Navigation ausklappen" : "Navigation einklappen"}
-          className={cn(itemClasses(false), "hidden justify-end md:flex")}
-        >
-          {/* Points the way the bar is about to move. */}
-          {collapsed ? (
-            <ChevronRight aria-hidden className="size-6 shrink-0" />
-          ) : (
-            <ChevronLeft aria-hidden className="size-6 shrink-0" />
-          )}
-        </button>
       </div>
     </nav>
   );

--- a/src/components/layout/teacher-nav.tsx
+++ b/src/components/layout/teacher-nav.tsx
@@ -41,8 +41,10 @@ function itemClasses(active: boolean) {
  */
 export function TeacherNav({
   fallbackEventSeriesId = null,
+  photo = null,
 }: {
   fallbackEventSeriesId?: string | null;
+  photo?: string | null;
 }) {
   const pathname = usePathname();
   const inUrl = selectedEventSeriesIdFrom(pathname);
@@ -122,7 +124,11 @@ export function TeacherNav({
 
       {/* The foot of the bar: who is signed in. */}
       <div className="mt-auto">
-        <SignOutButton className="min-h-9 w-full justify-start px-2 py-2" labelHidden={collapsed} />
+        <SignOutButton
+          className="min-h-9 w-full justify-start px-2 py-2"
+          labelHidden={collapsed}
+          photo={photo}
+        />
       </div>
     </nav>
   );

--- a/src/components/layout/teacher-nav.tsx
+++ b/src/components/layout/teacher-nav.tsx
@@ -11,6 +11,7 @@ import { usePathname } from "next/navigation";
 import { ChartColumn, ChevronLeft, ChevronRight, Database, FileText, Shuffle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Brand } from "@/components/layout/brand";
+import { SignOutButton } from "@/components/auth/sign-out-button";
 import { masterDataSections } from "@/lib/master-data/categories";
 import { selectedEventSeriesIdFrom } from "@/lib/event-series/event-series-selection";
 import { eventSeriesRoutes, ROUTES } from "@/lib/routes";
@@ -28,7 +29,7 @@ function itemClasses(active: boolean) {
   return cn(
     // A fixed height, because collapsing takes the label out of the flow: without it every row
     // would shrink to its icon and the whole bar would shift as it closes.
-    "flex min-h-9 w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors",
+    "flex min-h-9 w-full items-center gap-3 rounded-md px-2 py-2 text-sm transition-colors",
     active ? "bg-accent text-accent-foreground font-medium" : "hover:bg-muted",
   );
 }
@@ -65,7 +66,7 @@ export function TeacherNav({
   return (
     <nav
       aria-label="Hauptnavigation"
-      className={cn("flex h-full flex-col gap-1 p-3", collapsed ? "md:w-16" : "md:w-56")}
+      className={cn("flex h-full flex-col gap-1 p-2", collapsed ? "md:w-16" : "md:w-56")}
     >
       {/* Heads the bar rather than the header, because the bar runs to the top of the window and
           the column beside it is where a page begins. */}
@@ -118,20 +119,26 @@ export function TeacherNav({
         </ul>
       )}
 
-      <button
-        type="button"
-        onClick={() => setCollapsed((on) => !on)}
-        aria-expanded={!collapsed}
-        aria-label={collapsed ? "Navigation ausklappen" : "Navigation einklappen"}
-        className={cn(itemClasses(false), "mt-auto hidden justify-end md:flex")}
-      >
-        {/* Points the way the bar is about to move. */}
-        {collapsed ? (
-          <ChevronRight aria-hidden className="size-6 shrink-0" />
-        ) : (
-          <ChevronLeft aria-hidden className="size-6 shrink-0" />
-        )}
-      </button>
+      {/* The foot of the bar: who is signed in, and the bar's own control. Stacked rather than
+          side by side, because a collapsed rail is one icon wide. */}
+      <div className="mt-auto flex flex-col gap-1">
+        <SignOutButton labelHidden={collapsed} />
+
+        <button
+          type="button"
+          onClick={() => setCollapsed((on) => !on)}
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? "Navigation ausklappen" : "Navigation einklappen"}
+          className={cn(itemClasses(false), "hidden justify-end md:flex")}
+        >
+          {/* Points the way the bar is about to move. */}
+          {collapsed ? (
+            <ChevronRight aria-hidden className="size-6 shrink-0" />
+          ) : (
+            <ChevronLeft aria-hidden className="size-6 shrink-0" />
+          )}
+        </button>
+      </div>
     </nav>
   );
 }

--- a/src/components/master-data/crud-list.tsx
+++ b/src/components/master-data/crud-list.tsx
@@ -260,7 +260,7 @@ function ItemList({
                   <span className="inline-flex">
                     <Button
                       variant="ghost"
-                      size="icon-sm"
+                      size="icon"
                       disabled={locked || busy}
                       aria-label={`${singular} ${item.name} bearbeiten`}
                       aria-describedby={locked ? hintId : undefined}
@@ -275,7 +275,7 @@ function ItemList({
                   <span className="inline-flex">
                     <Button
                       variant="ghost"
-                      size="icon-sm"
+                      size="icon"
                       disabled={undeletable || busy}
                       aria-label={`${singular} ${item.name} löschen`}
                       aria-describedby={undeletable ? hintId : undefined}

--- a/src/components/master-data/programs-view.tsx
+++ b/src/components/master-data/programs-view.tsx
@@ -33,11 +33,11 @@ export function ProgramsView({ eventSeriesId }: { eventSeriesId: string }) {
             tabIndex={disabled ? -1 : undefined}
             onClick={disabled ? (clicked) => clicked.preventDefault() : undefined}
             className={cn(
-              buttonVariants({ variant: "ghost", size: "icon-sm" }),
+              buttonVariants({ variant: "ghost", size: "icon" }),
               disabled && "pointer-events-none opacity-50",
             )}
           >
-            <Package aria-hidden className="size-3.5" />
+            <Package aria-hidden className="size-4" />
           </Link>
         </Tooltip>
       )}

--- a/src/components/overview/class-cards.tsx
+++ b/src/components/overview/class-cards.tsx
@@ -6,10 +6,10 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronRight, Copy, Link, QrCode } from "lucide-react";
+import { Copy, Link, QrCode } from "lucide-react";
 import { FilterTagList } from "@/components/filters/filter-tag-list";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeading, CardTitle } from "@/components/ui/card";
 import { Dialog } from "@/components/ui/dialog";
 import { Tooltip } from "@/components/ui/tooltip";
 import { ApiRequestError } from "@/lib/api/client";
@@ -28,7 +28,6 @@ import {
 } from "@/lib/filters/student-filter";
 import { ATTENDANCE_LABELS } from "@/lib/registration/answer-labels";
 import type { RosterStudent } from "@/lib/students/roster";
-import { cn } from "@/lib/utils";
 import { AREA, AREAS, AreaTitle, FilteredTag } from "@/components/assignment/card-areas";
 import { GenderTable } from "@/components/assignment/gender-table";
 import { SkillMatrix } from "@/components/assignment/skill-matrix";
@@ -127,26 +126,10 @@ function ClassCard({
   return (
     <Card size="sm" role="group" aria-label={row.class}>
       <CardContent className="flex flex-col gap-4">
-        <CardTitle className="flex items-center justify-between gap-3">
-          <span className="flex items-center gap-1.5">
-            <button
-              type="button"
-              aria-label={`Details zu ${row.class}`}
-              aria-expanded={expanded}
-              onClick={() => setExpanded((open) => !open)}
-              className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 rounded-md p-0.5 transition-colors outline-none focus-visible:ring-3"
-            >
-              <ChevronRight
-                aria-hidden
-                className={cn("size-4 transition-transform", expanded && "rotate-90")}
-              />
-            </button>
-            {`${row.class}: ${row.total}`}
-          </span>
-          {/* At the card's edge, so they line up down the page rather than moving with the
-              length of each class's name and count. */}
-          <div className="flex shrink-0 items-center gap-1">
-            {invitations === null ? null : (
+        <CardHeading
+          fold={{ open: expanded, label: `Details zu ${row.class}`, onOpenChange: setExpanded }}
+          control={
+            invitations === null ? null : (
               <>
                 <Tooltip label={`${INVITATION_LINK_LABEL} kopieren`}>
                   <Button
@@ -185,9 +168,11 @@ function ClassCard({
                   </Tooltip>
                 )}
               </>
-            )}
-          </div>
-        </CardTitle>
+            )
+          }
+        >
+          <CardTitle className="truncate">{`${row.class}: ${row.total}`}</CardTitle>
+        </CardHeading>
 
         {linkError !== null && (
           <p role="alert" className="text-destructive text-sm">

--- a/src/components/overview/class-cards.tsx
+++ b/src/components/overview/class-cards.tsx
@@ -151,7 +151,7 @@ function ClassCard({
                 <Tooltip label={`${INVITATION_LINK_LABEL} kopieren`}>
                   <Button
                     variant="ghost"
-                    size="icon-sm"
+                    size="icon"
                     aria-label={`${INVITATION_LINK_LABEL} für ${row.class} kopieren`}
                     onClick={() => handOut(() => invitations.linkFor(row.class))}
                   >
@@ -162,7 +162,7 @@ function ClassCard({
                 <Tooltip label={`${INVITATION_QR_LABEL} anzeigen`}>
                   <Button
                     variant="ghost"
-                    size="icon-sm"
+                    size="icon"
                     aria-label={`${INVITATION_QR_LABEL} für ${row.class} anzeigen`}
                     onClick={() => withLink(() => invitations.linkFor(row.class), setShownCode)}
                   >
@@ -176,7 +176,7 @@ function ClassCard({
                   <Tooltip label={`${INVITATION_LINK_LABEL} neu erstellen`}>
                     <Button
                       variant="ghost"
-                      size="icon-sm"
+                      size="icon"
                       aria-label={`${INVITATION_LINK_LABEL} für ${row.class} neu erstellen`}
                       onClick={() => setConfirmingRegenerate(true)}
                     >

--- a/src/components/overview/overview-view.test.tsx
+++ b/src/components/overview/overview-view.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { INVITATION_LINK_LABEL } from "@/lib/invitations/invitation-link";
 import type { RosterStudent } from "@/lib/students/roster";
@@ -34,9 +33,7 @@ vi.mock("@/lib/api/client", async (importOriginal) => ({
 }));
 
 const { OverviewView: ScopedOverviewView } = await import("./overview-view");
-const { NO_EVENT_SERIES_HINT, EVENT_SERIES_STATE_LABELS } =
-  await import("@/lib/event-series/event-series-state");
-const { ApiRequestError } = await import("@/lib/api/client");
+const { NO_EVENT_SERIES_HINT } = await import("@/lib/event-series/event-series-state");
 
 // Which series the view is about comes from the page (Q8); the data hooks are mocked, so the id
 // only has to be present.
@@ -130,91 +127,24 @@ describe("OverviewView", () => {
 });
 
 /**
- * Pressing this tag is the whole of opening and closing registration (US-19, US-29). There is no
- * second control anywhere else — two controls for one decision would be two answers to it.
+ * Opening and closing registration is done on the series' own tag in the header (US-19, US-29).
+ * This page offers no control for it: two controls for one decision would be two answers to it.
  */
-describe("OverviewView — the registration tag", () => {
-  const tag = () => screen.getByRole("button", { name: EVENT_SERIES_STATE_LABELS.open });
+describe("OverviewView — no second registration control", () => {
+  it.each([{}, { isOpenToStudents: false }, { isTemplate: true }, { isArchived: true }])(
+    "offers nothing that opens or closes the series, whatever state %o it is in",
+    (state) => {
+      useEventSeries.mockReturnValue({
+        eventSeries: [{ ...eventSeries, ...state }],
+        loading: false,
+        error: null,
+      });
 
-  it("reads that the series is open and shows the tag pressed", () => {
-    render(<OverviewView />);
+      render(<OverviewView />);
 
-    expect(tag()).toHaveAttribute("aria-pressed", "true");
-  });
-
-  it("reads that a closed series is closed, and is not pressed", () => {
-    useEventSeries.mockReturnValue({
-      eventSeries: [{ ...eventSeries, isOpenToStudents: false }],
-      loading: false,
-      error: null,
-    });
-
-    render(<OverviewView />);
-
-    const closed = screen.getByRole("button", { name: EVENT_SERIES_STATE_LABELS.closed });
-    expect(closed).toHaveAttribute("aria-pressed", "false");
-  });
-
-  it("opens the series when pressed", async () => {
-    useEventSeries.mockReturnValue({
-      eventSeries: [{ ...eventSeries, isOpenToStudents: false }],
-      loading: false,
-      error: null,
-    });
-    render(<OverviewView />);
-
-    await userEvent.click(screen.getByRole("button", { name: EVENT_SERIES_STATE_LABELS.closed }));
-
-    expect(apiRequest).toHaveBeenCalledWith("/api/event-series/s1", {
-      method: "PATCH",
-      body: { isOpenToStudents: true },
-    });
-  });
-
-  it("closes it again when pressed while open", async () => {
-    render(<OverviewView />);
-
-    await userEvent.click(tag());
-
-    expect(apiRequest).toHaveBeenCalledWith("/api/event-series/s1", {
-      method: "PATCH",
-      body: { isOpenToStudents: false },
-    });
-  });
-
-  it("says what the server said when the change is refused", async () => {
-    apiRequest.mockRejectedValue(new ApiRequestError("Eine Vorlage geht nicht."));
-    render(<OverviewView />);
-
-    await userEvent.click(tag());
-
-    expect(await screen.findByRole("alert")).toHaveTextContent("Eine Vorlage geht nicht.");
-  });
-
-  /** A page that offers to open what cannot be opened is a page explaining a refusal it need not make. */
-  it("offers no tag at all for a template, which can never be opened", () => {
-    useEventSeries.mockReturnValue({
-      eventSeries: [{ ...eventSeries, isTemplate: true, isOpenToStudents: false }],
-      loading: false,
-      error: null,
-    });
-
-    render(<OverviewView />);
-
-    expect(screen.queryByRole("button", { name: /Anmeldung/ })).not.toBeInTheDocument();
-  });
-
-  it("offers no tag for an archived series, which cannot even be selected", () => {
-    useEventSeries.mockReturnValue({
-      eventSeries: [{ ...eventSeries, isArchived: true, isOpenToStudents: false }],
-      loading: false,
-      error: null,
-    });
-
-    render(<OverviewView />);
-
-    expect(screen.queryByRole("button", { name: /Anmeldung/ })).not.toBeInTheDocument();
-  });
+      expect(screen.queryByRole("button", { name: /Anmeldung/ })).not.toBeInTheDocument();
+    },
+  );
 });
 
 describe("OverviewView — handing out links", () => {

--- a/src/components/overview/overview-view.tsx
+++ b/src/components/overview/overview-view.tsx
@@ -5,79 +5,36 @@
  */
 "use client";
 
-import { useState } from "react";
 import { classOverview } from "@/lib/assignment/statistics";
 import { useEventSeriesRoster } from "@/lib/assignment/use-event-series-roster";
-import { ApiRequestError, apiRequest } from "@/lib/api/client";
 import { useBusyWhile } from "@/lib/api/busy";
-import {
-  EVENT_SERIES_STATE_LABELS,
-  NO_EVENT_SERIES_HINT,
-} from "@/lib/event-series/event-series-state";
+import { NO_EVENT_SERIES_HINT } from "@/lib/event-series/event-series-state";
 import { PageHeading } from "@/components/layout/page-heading";
-import { Tag } from "@/components/ui/tag";
 import { useInvitations } from "@/lib/invitations/use-invitations";
 import { ClassCards } from "./class-cards";
 
 /**
  * Where an event series is run from (US-29): one card per class of the selected series, the
- * students in it attending and not, and that class's figures. It is where a series is opened to
- * students and where its classes are invited, which is why it is a page rather than a header on
- * the board — setting a series up and assigning a week are done at different times.
+ * students in it attending and not, and that class's figures. Opening it to students is done on
+ * its tag in the header, which names the series it concerns and is on screen from every page.
  */
 export function OverviewView({ eventSeriesId }: { eventSeriesId: string }) {
   const { eventSeries, loading, error, students, classes, columns, programNames, skillLevelNames, filterGroups } = useEventSeriesRoster(eventSeriesId); // prettier-ignore
-  const [actionError, setActionError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
   const invitations = useInvitations(eventSeriesId);
 
   // Answered by the one spinner in the header, so this view places none of its own.
-  useBusyWhile(loading || saving);
+  useBusyWhile(loading);
 
-  // Neither can ever be open, so neither is offered the control: a page that offers to open what
-  // cannot be opened is a page explaining a refusal it did not have to make (US-19, US-22).
+  // Neither can ever be open, so neither has anyone to invite (US-19, US-22).
   const openable = eventSeries !== null && !eventSeries.isTemplate && !eventSeries.isArchived;
-
-  async function setOpenToStudents(isOpenToStudents: boolean) {
-    setActionError(null);
-    setSaving(true);
-    try {
-      await apiRequest(`/api/event-series/${eventSeriesId}`, {
-        method: "PATCH",
-        body: { isOpenToStudents },
-      });
-    } catch (caught) {
-      setActionError(
-        caught instanceof ApiRequestError ? caught.message : "Das hat leider nicht geklappt.",
-      );
-    } finally {
-      setSaving(false);
-    }
-  }
 
   return (
     <div className="flex flex-col gap-4 p-4 md:p-6">
-      <PageHeading
-        actions={
-          openable ? (
-            <Tag
-              label={
-                eventSeries.isOpenToStudents
-                  ? EVENT_SERIES_STATE_LABELS.open
-                  : EVENT_SERIES_STATE_LABELS.closed
-              }
-              pressed={eventSeries.isOpenToStudents}
-              onPress={() => setOpenToStudents(!eventSeries.isOpenToStudents)}
-            />
-          ) : undefined
-        }
-      >
-        Übersicht
-      </PageHeading>
+      <PageHeading>Übersicht</PageHeading>
 
-      {(error ?? actionError ?? invitations.error) !== null && (
+      {(error ?? invitations.error) !== null && (
         <p role="alert" className="text-destructive text-sm">
-          {error ?? actionError ?? invitations.error}
+          {error ?? invitations.error}
         </p>
       )}
 

--- a/src/components/report/field-tag-list.tsx
+++ b/src/components/report/field-tag-list.tsx
@@ -6,7 +6,7 @@
 "use client";
 
 import { REPORT_FIELD_TAGS } from "@/lib/report/report-fields";
-import { Tag } from "@/components/ui/tag";
+import { Tag, TagName } from "@/components/ui/tag";
 
 type FieldTagListProps = {
   value: readonly string[];
@@ -26,16 +26,18 @@ export function FieldTagList({ value, onChange }: FieldTagListProps) {
     <div role="group" aria-label="Datenfelder" className="flex flex-wrap gap-1.5">
       {/* What the filter row's "Alle" is to students, this is to detail lines: the report as it
           stands with nothing added. */}
-      <Tag label="Keine" pressed={value.length === 0} onPress={() => onChange([])} />
+      <Tag pressed={value.length === 0}>
+        <TagName label="Keine" onPress={() => onChange([])} />
+      </Tag>
       {REPORT_FIELD_TAGS.map((tag) => (
-        <Tag
-          key={tag.key}
-          // The row carries no heading, so each tag says which of the two rows it belongs to.
-          label={`Feld: ${tag.label}`}
-          text={tag.label}
-          pressed={value.includes(tag.key)}
-          onPress={() => toggle(tag.key)}
-        />
+        <Tag key={tag.key} pressed={value.includes(tag.key)}>
+          <TagName
+            // The row carries no heading, so each tag says which of the two rows it belongs to.
+            label={`Feld: ${tag.label}`}
+            text={tag.label}
+            onPress={() => toggle(tag.key)}
+          />
+        </Tag>
       ))}
     </div>
   );

--- a/src/components/report/report-view.test.tsx
+++ b/src/components/report/report-view.test.tsx
@@ -453,7 +453,7 @@ describe("the saved reports", () => {
     await userEvent.type(screen.getByRole("textbox", { name: "Name des Berichts" }), "Nur 5BHIF");
     await userEvent.click(screen.getByRole("button", { name: "Speichern" }));
 
-    expect(apiRequest).toHaveBeenCalledWith("/api/saved-reports", {
+    expect(apiRequest).toHaveBeenCalledWith("/api/event-series/s1/saved-reports", {
       method: "POST",
       body: {
         name: "Nur 5BHIF",
@@ -478,7 +478,7 @@ describe("the saved reports", () => {
     await userEvent.type(field, "5BHIF");
     await userEvent.click(screen.getByRole("button", { name: "Umbenennen" }));
 
-    expect(apiRequest).toHaveBeenCalledWith("/api/saved-reports/r1", {
+    expect(apiRequest).toHaveBeenCalledWith("/api/event-series/s1/saved-reports/r1", {
       method: "PATCH",
       body: {
         name: "5BHIF",
@@ -490,7 +490,9 @@ describe("the saved reports", () => {
     await userEvent.click(screen.getByRole("button", { name: "Bericht Nur 5BHIF löschen" }));
     await userEvent.click(screen.getByRole("button", { name: "Löschen von Nur 5BHIF bestätigen" }));
 
-    expect(apiRequest).toHaveBeenCalledWith("/api/saved-reports/r1", { method: "DELETE" });
+    expect(apiRequest).toHaveBeenCalledWith("/api/event-series/s1/saved-reports/r1", {
+      method: "DELETE",
+    });
   });
 
   it("brings the opened report up to date with the report as it now stands", async () => {
@@ -502,7 +504,7 @@ describe("the saved reports", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Bericht Nur 5BHIF aktualisieren" }));
 
-    expect(apiRequest).toHaveBeenCalledWith("/api/saved-reports/r1", {
+    expect(apiRequest).toHaveBeenCalledWith("/api/event-series/s1/saved-reports/r1", {
       method: "PATCH",
       body: {
         name: saved.name,

--- a/src/components/report/report-view.tsx
+++ b/src/components/report/report-view.tsx
@@ -32,8 +32,6 @@ import { SavedReportTagList } from "./saved-report-tag-list";
 
 const FILTER_LABEL = "Bericht";
 
-const reportUrl = (id: string) => `/api/saved-reports/${encodeURIComponent(id)}`;
-
 /** Two tag rows sit under each other and decide different things, so each says which it is. */
 function CardHeading({ children }: { children: string }) {
   return (
@@ -60,7 +58,7 @@ export function ReportView({ eventSeriesId }: { eventSeriesId: string }) {
       events: true,
     },
   );
-  const { reports: savedReports } = useSavedReports();
+  const { reports: savedReports } = useSavedReports(eventSeriesId);
   const [filter, setFilter] = useState(EMPTY_FILTER);
   const [activeFields, setActiveFields] = useState<string[]>([]);
   const [outputError, setOutputError] = useState<string | null>(null);
@@ -86,8 +84,11 @@ export function ReportView({ eventSeriesId }: { eventSeriesId: string }) {
 
   // Writes go through handlers because the author is the session's, not the request's (US-13);
   // the list itself comes back from the subscription rather than from these answers.
+  const row = `/api/event-series/${encodeURIComponent(eventSeriesId)}/saved-reports`;
+  const reportUrl = (id: string) => `${row}/${encodeURIComponent(id)}`;
+
   async function saveReport(name: string, saved: ReportSelection) {
-    const answer = await apiRequest<{ report: SavedReport }>("/api/saved-reports", {
+    const answer = await apiRequest<{ report: SavedReport }>(row, {
       method: "POST",
       body: { name, ...saved },
     });
@@ -104,7 +105,7 @@ export function ReportView({ eventSeriesId }: { eventSeriesId: string }) {
   }
 
   async function reorderReports(order: string[]) {
-    await apiRequest("/api/saved-reports", { method: "PATCH", body: { order } });
+    await apiRequest(row, { method: "PATCH", body: { order } });
   }
 
   /**

--- a/src/components/report/report-view.tsx
+++ b/src/components/report/report-view.tsx
@@ -148,7 +148,6 @@ export function ReportView({ eventSeriesId }: { eventSeriesId: string }) {
             <Button
               type="button"
               variant="outline"
-              size="sm"
               onClick={() => exportReport(downloadReportPdf)}
               disabled={eventSeries === null || exporting}
             >
@@ -158,7 +157,6 @@ export function ReportView({ eventSeriesId }: { eventSeriesId: string }) {
             <Button
               type="button"
               variant="outline"
-              size="sm"
               onClick={() => exportReport(downloadReportWorkbook)}
               disabled={eventSeries === null || exporting}
             >

--- a/src/components/report/saved-report-tag-list.test.tsx
+++ b/src/components/report/saved-report-tag-list.test.tsx
@@ -202,7 +202,7 @@ describe("telling an untouched saved report from a changed one", () => {
     change({ ...CURRENT, fields: [] });
 
     expect(tagBox("5AHIF")).not.toHaveClass("bg-primary");
-    expect(tagBox("5AHIF")).toHaveClass("bg-secondary");
+    expect(tagBox("5AHIF")).toHaveClass("bg-neutral");
   });
 
   /** Colour alone says nothing to a screen reader, so the tag is described as well. */

--- a/src/components/report/saved-report-tag-list.tsx
+++ b/src/components/report/saved-report-tag-list.tsx
@@ -25,10 +25,9 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Check, GripVertical, Pencil, Plus, Save, Trash2, X } from "lucide-react";
-import { Button, buttonVariants } from "@/components/ui/button";
-import { TAG_ICON_CLASSES } from "@/components/ui/tag";
+import { Button } from "@/components/ui/button";
+import { Tag, TagAction, TagField, TagName } from "@/components/ui/tag";
 import { DraggingCursor } from "@/components/ui/dragging-cursor";
-import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { useRowAction } from "@/lib/api/use-row-action";
 import { useDroppedOrder } from "@/lib/ui/use-dropped-order";
@@ -229,9 +228,6 @@ type SavedReportTagProps = {
   onCancel: () => void;
 };
 
-// The tag carries the colour, so an icon in it neither repaints itself nor its background.
-const ICON_CLASSES = TAG_ICON_CLASSES;
-
 function SavedReportTag({
   report,
   marked,
@@ -252,23 +248,20 @@ function SavedReportTag({
   });
 
   return (
-    <div
+    <Tag
       ref={setNodeRef}
       style={{ transform: CSS.Translate.toString(transform), transition }}
-      className={cn(
-        // Three states, and the middle one is the point: opened, and since changed (US-13).
-        buttonVariants({
-          variant: marked ? (changed ? "secondary" : "default") : "outline",
-        }),
-        "gap-0.5 px-1",
-        // The handle offers the grab; the tag itself is pressed, and only says so once a drag is
-        // really under way.
-        isDragging && "relative z-10 cursor-grabbing opacity-80",
-      )}
+      pressed={marked}
+      // Three states, and the middle one is the point: opened, and since changed (US-13).
+      variant={changed ? "neutral" : "default"}
+      disabled={pending}
+      // Both the grip and the tag start a pointer drag; the grip also carries the keyboard one.
+      // The tag's own press opens the report — a drag only starts once the pointer has moved,
+      // and the click that would follow one is swallowed by the sensor.
+      onPointerDown={listeners?.onPointerDown as React.PointerEventHandler | undefined}
+      // The handle offers the grab; the tag itself only says so once a drag is really under way.
+      className={cn("touch-none", isDragging && "relative z-10 cursor-grabbing opacity-80")}
     >
-      {/* Both the grip and the tag start a pointer drag; the grip also carries the keyboard one.
-          The tag's own press opens the report — a drag only starts once the pointer has moved,
-          and the click that would follow one is swallowed by the sensor. */}
       <button
         type="button"
         aria-label={`${report.name} verschieben`}
@@ -284,19 +277,12 @@ function SavedReportTag({
         <GripVertical aria-hidden className="size-3.5" />
       </button>
 
-      <button
-        type="button"
-        aria-pressed={marked}
-        aria-label={`Gespeicherter Bericht: ${report.name}`}
-        aria-describedby={changed ? hintId : undefined}
-        disabled={pending}
-        onPointerDown={listeners?.onPointerDown as React.PointerEventHandler | undefined}
-        onClick={onOpen}
-        className="focus-visible:ring-ring/50 max-w-60 touch-none truncate rounded-md px-1.5 outline-none focus-visible:ring-3 disabled:opacity-50"
-      >
-        {report.name}
-      </button>
-
+      <TagName
+        label={`Gespeicherter Bericht: ${report.name}`}
+        text={report.name}
+        describedBy={changed ? hintId : undefined}
+        onPress={onOpen}
+      />
       {/* The colour says it to everybody who can see it; this says it to everybody else. */}
       {changed ? (
         <span id={hintId} className="sr-only">
@@ -307,70 +293,30 @@ function SavedReportTag({
       {/* Only the marked tag is managed, so there is nothing on the others to press by accident. */}
       {!marked ? null : confirming ? (
         <>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label={`Löschen von ${report.name} bestätigen`}
-            disabled={pending}
-            onClick={onDelete}
-            className={ICON_CLASSES}
-          >
+          <TagAction label={`Löschen von ${report.name} bestätigen`} onClick={onDelete}>
             <Check aria-hidden />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label={`Löschen von ${report.name} abbrechen`}
-            disabled={pending}
-            onClick={onCancel}
-            className={ICON_CLASSES}
-          >
+          </TagAction>
+          <TagAction label={`Löschen von ${report.name} abbrechen`} onClick={onCancel}>
             <X aria-hidden />
-          </Button>
+          </TagAction>
         </>
       ) : (
         <>
           {/* Nothing to store while the report on screen still is the one this tag holds. */}
           {changed ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label={`Bericht ${report.name} aktualisieren`}
-              disabled={pending}
-              onClick={onUpdate}
-              className={ICON_CLASSES}
-            >
+            <TagAction label={`Bericht ${report.name} aktualisieren`} onClick={onUpdate}>
               <Save aria-hidden />
-            </Button>
+            </TagAction>
           ) : null}
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label={`Bericht ${report.name} umbenennen`}
-            disabled={pending}
-            onClick={onStartRename}
-            className={ICON_CLASSES}
-          >
+          <TagAction label={`Bericht ${report.name} umbenennen`} onClick={onStartRename}>
             <Pencil aria-hidden />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label={`Bericht ${report.name} löschen`}
-            disabled={pending}
-            onClick={onStartDelete}
-            className={ICON_CLASSES}
-          >
+          </TagAction>
+          <TagAction label={`Bericht ${report.name} löschen`} onClick={onStartDelete}>
             <Trash2 aria-hidden />
-          </Button>
+          </TagAction>
         </>
       )}
-    </div>
+    </Tag>
   );
 }
 
@@ -414,39 +360,22 @@ function NameForm({ initialName = "", submitLabel, pending, onSubmit, onCancel }
   return (
     <form onSubmit={submit} className="flex flex-wrap items-center gap-1.5" noValidate>
       {/* Shaped as a tag, with its controls inside it, exactly as a tag being deleted is. */}
-      <div className={cn(buttonVariants({ variant: "outline" }), "gap-0.5 px-1")}>
-        <Input
+      <Tag disabled={pending}>
+        <TagField
           autoFocus
           aria-label={NAME_LABEL}
           aria-invalid={error !== null}
           placeholder={NAME_LABEL}
           value={name}
-          disabled={pending}
           onChange={(event) => setName(event.target.value)}
-          className="h-7 w-40 rounded-md border-0 bg-transparent px-1.5 shadow-none focus-visible:ring-0 dark:bg-transparent"
         />
-        <Button
-          type="submit"
-          variant="ghost"
-          size="icon"
-          aria-label={submitLabel}
-          disabled={pending}
-          className={ICON_CLASSES}
-        >
+        <TagAction type="submit" label={submitLabel}>
           <Check aria-hidden />
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="Abbrechen"
-          disabled={pending}
-          onClick={onCancel}
-          className={ICON_CLASSES}
-        >
+        </TagAction>
+        <TagAction label="Abbrechen" onClick={onCancel}>
           <X aria-hidden />
-        </Button>
-      </div>
+        </TagAction>
+      </Tag>
       {error ? <p className="text-destructive text-sm">{error}</p> : null}
     </form>
   );

--- a/src/components/report/saved-report-tag-list.tsx
+++ b/src/components/report/saved-report-tag-list.tsx
@@ -26,6 +26,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { Check, GripVertical, Pencil, Plus, Save, Trash2, X } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { TAG_ICON_CLASSES } from "@/components/ui/tag";
 import { DraggingCursor } from "@/components/ui/dragging-cursor";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -229,7 +230,7 @@ type SavedReportTagProps = {
 };
 
 // The tag carries the colour, so an icon in it neither repaints itself nor its background.
-const ICON_CLASSES = "hover:bg-transparent hover:text-inherit hover:opacity-70";
+const ICON_CLASSES = TAG_ICON_CLASSES;
 
 function SavedReportTag({
   report,

--- a/src/components/report/saved-report-tag-list.tsx
+++ b/src/components/report/saved-report-tag-list.tsx
@@ -196,7 +196,6 @@ export function SavedReportTagList({
             <Button
               type="button"
               variant="outline"
-              size="sm"
               disabled={pending}
               onClick={() => {
                 setConfirming(null);
@@ -259,7 +258,6 @@ function SavedReportTag({
         // Three states, and the middle one is the point: opened, and since changed (US-13).
         buttonVariants({
           variant: marked ? (changed ? "secondary" : "default") : "outline",
-          size: "sm",
         }),
         "gap-0.5 px-1",
         // The handle offers the grab; the tag itself is pressed, and only says so once a drag is
@@ -311,7 +309,7 @@ function SavedReportTag({
           <Button
             type="button"
             variant="ghost"
-            size="icon-sm"
+            size="icon"
             aria-label={`Löschen von ${report.name} bestätigen`}
             disabled={pending}
             onClick={onDelete}
@@ -322,7 +320,7 @@ function SavedReportTag({
           <Button
             type="button"
             variant="ghost"
-            size="icon-sm"
+            size="icon"
             aria-label={`Löschen von ${report.name} abbrechen`}
             disabled={pending}
             onClick={onCancel}
@@ -338,7 +336,7 @@ function SavedReportTag({
             <Button
               type="button"
               variant="ghost"
-              size="icon-sm"
+              size="icon"
               aria-label={`Bericht ${report.name} aktualisieren`}
               disabled={pending}
               onClick={onUpdate}
@@ -350,7 +348,7 @@ function SavedReportTag({
           <Button
             type="button"
             variant="ghost"
-            size="icon-sm"
+            size="icon"
             aria-label={`Bericht ${report.name} umbenennen`}
             disabled={pending}
             onClick={onStartRename}
@@ -361,7 +359,7 @@ function SavedReportTag({
           <Button
             type="button"
             variant="ghost"
-            size="icon-sm"
+            size="icon"
             aria-label={`Bericht ${report.name} löschen`}
             disabled={pending}
             onClick={onStartDelete}
@@ -415,7 +413,7 @@ function NameForm({ initialName = "", submitLabel, pending, onSubmit, onCancel }
   return (
     <form onSubmit={submit} className="flex flex-wrap items-center gap-1.5" noValidate>
       {/* Shaped as a tag, with its controls inside it, exactly as a tag being deleted is. */}
-      <div className={cn(buttonVariants({ variant: "outline", size: "lg" }), "gap-0.5 px-1")}>
+      <div className={cn(buttonVariants({ variant: "outline" }), "gap-0.5 px-1")}>
         <Input
           autoFocus
           aria-label={NAME_LABEL}
@@ -429,7 +427,7 @@ function NameForm({ initialName = "", submitLabel, pending, onSubmit, onCancel }
         <Button
           type="submit"
           variant="ghost"
-          size="icon-sm"
+          size="icon"
           aria-label={submitLabel}
           disabled={pending}
           className={ICON_CLASSES}
@@ -439,7 +437,7 @@ function NameForm({ initialName = "", submitLabel, pending, onSubmit, onCancel }
         <Button
           type="button"
           variant="ghost"
-          size="icon-sm"
+          size="icon"
           aria-label="Abbrechen"
           disabled={pending}
           onClick={onCancel}

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -15,6 +15,7 @@ const VARIANTS = [
   "open-soft",
   "neutral",
   "template",
+  "template-soft",
   "ghost",
   "destructive",
   "link",

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -7,7 +7,17 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { Button, buttonVariants } from "@/components/ui/button";
 
-const VARIANTS = ["default", "outline", "secondary", "ghost", "destructive", "link"] as const;
+const VARIANTS = [
+  "default",
+  "outline",
+  "secondary",
+  "open",
+  "open-soft",
+  "neutral",
+  "ghost",
+  "destructive",
+  "link",
+] as const;
 
 describe("Button design tokens", () => {
   it("renders the default variant from the accent-backed primary token", () => {

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -33,4 +33,13 @@ describe("Button design tokens", () => {
   it.each(VARIANTS)("gives the %s variant pressed feedback", (variant) => {
     expect(buttonVariants({ variant })).toMatch(/active:[\w[\]()/.,-]*(bg-|text-)/);
   });
+
+  /**
+   * One height for everything that can be pressed, and it is not this component's to choose: it
+   * comes from the shared token, so a button, a field and a select cannot disagree about it.
+   */
+  it("takes its height from the shared control token", () => {
+    expect(buttonVariants({ size: "default" })).toContain("h-(--control-height)");
+    expect(buttonVariants({ size: "icon" })).toContain("size-(--control-height)");
+  });
 });

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -14,6 +14,7 @@ const VARIANTS = [
   "open",
   "open-soft",
   "neutral",
+  "template",
   "ghost",
   "destructive",
   "link",

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -11,6 +11,8 @@ const VARIANTS = [
   "default",
   "outline",
   "secondary",
+  "series",
+  "series-soft",
   "open",
   "open-soft",
   "neutral",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -22,9 +22,10 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] active:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_10%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         open: "bg-open text-open-foreground hover:bg-[color-mix(in_oklch,var(--open),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--open),var(--foreground)_20%)]",
-        // The same thing said quietly: still green, but plainly not the one chosen.
+        // The same thing said quietly: still green, but plainly not the one chosen. The border
+        // stays the ordinary one, as `accent` keeps it — nothing else in the palette tints one.
         "open-soft":
-          "border-open/40 bg-open-subtle hover:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_5%)] active:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_10%)]",
+          "border-border bg-open-subtle hover:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_5%)] active:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_10%)]",
         // Greyscale that a white surface can still be told from, which `secondary` at 0.97 cannot.
         neutral:
           "bg-neutral text-neutral-foreground hover:bg-[color-mix(in_oklch,var(--neutral),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--neutral),var(--foreground)_20%)]",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -34,18 +34,13 @@ const buttonVariants = cva(
           "bg-destructive/10 text-destructive hover:bg-destructive/20 active:bg-destructive/30 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline active:text-primary/70",
       },
+      // One height, and a square of it, both from the shared token. A button that could be
+      // another size is a decision every call site has to make again, and the answers stop
+      // agreeing — which is what left tags at 28px in rows of 32.
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
+          "h-(--control-height) gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        icon: "size-(--control-height)",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -32,6 +32,8 @@ const buttonVariants = cva(
           "bg-neutral text-neutral-foreground hover:bg-[color-mix(in_oklch,var(--neutral),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--neutral),var(--foreground)_20%)]",
         template:
           "bg-template text-template-foreground hover:bg-[color-mix(in_oklch,var(--template),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--template),var(--foreground)_20%)]",
+        "template-soft":
+          "bg-template-subtle text-template-foreground border-transparent hover:bg-[color-mix(in_oklch,var(--template-subtle),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--template-subtle),var(--foreground)_20%)]",
         ghost:
           "hover:bg-muted hover:text-foreground active:bg-accent aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,6 +21,11 @@ const buttonVariants = cva(
           "border-border bg-background hover:bg-muted hover:text-foreground active:bg-accent aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] active:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_10%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        // An event series tag: the accent when it is the chosen one, and the same blue a weight
+        // back when it is not — which is the only place an unpressed tag is filled at all.
+        series: "bg-primary text-primary-foreground hover:bg-primary/80 active:bg-primary/70",
+        "series-soft":
+          "bg-brand-subtle text-primary-foreground border-transparent hover:bg-[color-mix(in_oklch,var(--brand-subtle),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--brand-subtle),var(--foreground)_20%)]",
         open: "bg-open text-open-foreground hover:bg-[color-mix(in_oklch,var(--open),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--open),var(--foreground)_20%)]",
         // The same green said quietly — brighter, since it is not the chosen one — wearing the
         // same white, because a tag that changed both its fill and its ink would read as another

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -22,10 +22,10 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] active:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_10%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         open: "bg-open text-open-foreground hover:bg-[color-mix(in_oklch,var(--open),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--open),var(--foreground)_20%)]",
-        // The same thing said quietly: still green, but plainly not the one chosen. The border
-        // stays the ordinary one, as `accent` keeps it — nothing else in the palette tints one.
+        // The same thing said quietly: still green, and wearing the same text as the solid one,
+        // because a tag that changed both its fill and its ink would read as another kind again.
         "open-soft":
-          "border-border bg-open-subtle hover:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_5%)] active:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_10%)]",
+          "bg-open-subtle text-open-foreground border-transparent hover:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_20%)]",
         // Greyscale that a white surface can still be told from, which `secondary` at 0.97 cannot.
         neutral:
           "bg-neutral text-neutral-foreground hover:bg-[color-mix(in_oklch,var(--neutral),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--neutral),var(--foreground)_20%)]",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -30,6 +30,8 @@ const buttonVariants = cva(
         // Greyscale that a white surface can still be told from, which `secondary` at 0.97 cannot.
         neutral:
           "bg-neutral text-neutral-foreground hover:bg-[color-mix(in_oklch,var(--neutral),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--neutral),var(--foreground)_20%)]",
+        template:
+          "bg-template text-template-foreground hover:bg-[color-mix(in_oklch,var(--template),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--template),var(--foreground)_20%)]",
         ghost:
           "hover:bg-muted hover:text-foreground active:bg-accent aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -22,8 +22,9 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] active:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_10%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         open: "bg-open text-open-foreground hover:bg-[color-mix(in_oklch,var(--open),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--open),var(--foreground)_20%)]",
-        // The same thing said quietly: still green, and wearing the same text as the solid one,
-        // because a tag that changed both its fill and its ink would read as another kind again.
+        // The same green said quietly — brighter, since it is not the chosen one — wearing the
+        // same white, because a tag that changed both its fill and its ink would read as another
+        // kind of tag rather than the same one unpressed.
         "open-soft":
           "bg-open-subtle text-open-foreground border-transparent hover:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_20%)]",
         // Greyscale that a white surface can still be told from, which `secondary` at 0.97 cannot.

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,6 +21,13 @@ const buttonVariants = cva(
           "border-border bg-background hover:bg-muted hover:text-foreground active:bg-accent aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] active:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_10%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        open: "bg-open text-open-foreground hover:bg-[color-mix(in_oklch,var(--open),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--open),var(--foreground)_20%)]",
+        // The same thing said quietly: still green, but plainly not the one chosen.
+        "open-soft":
+          "border-open/40 bg-open-subtle hover:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_5%)] active:bg-[color-mix(in_oklch,var(--open-subtle),var(--foreground)_10%)]",
+        // Greyscale that a white surface can still be told from, which `secondary` at 0.97 cannot.
+        neutral:
+          "bg-neutral text-neutral-foreground hover:bg-[color-mix(in_oklch,var(--neutral),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--neutral),var(--foreground)_20%)]",
         ghost:
           "hover:bg-muted hover:text-foreground active:bg-accent aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,6 +7,7 @@
  * See LICENSE and THIRD-PARTY-NOTICES.md in the repository root for details.
  */
 import * as React from "react";
+import { ChevronRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -80,6 +81,51 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
+type CardHeadingProps = {
+  /** The title, in whatever type the level calls for: a card's heading, an area's label. */
+  children: React.ReactNode;
+  /** At the card's edge, so controls line up down the page rather than after the title. */
+  control?: React.ReactNode;
+  /** Given this, the heading grows a fold control. A chevron alone says nothing, hence a name. */
+  fold?: { open: boolean; label: string; onOpenChange: (open: boolean) => void };
+  className?: string;
+};
+
+/**
+ * The line a card is headed by, whether it is a card of its own or an area within one: a fold,
+ * a title, and whatever the card offers, at its edge.
+ *
+ * Floored at the height of a control, so a title with one beside it sits where a title without
+ * one does — otherwise a row carrying a tag stands taller than its neighbours and the headings
+ * across a card stop lining up.
+ */
+function CardHeading({ children, control, fold, className }: CardHeadingProps) {
+  return (
+    <div
+      className={cn("flex min-h-(--control-height) items-center justify-between gap-3", className)}
+    >
+      <span className="flex min-w-0 items-center gap-1.5">
+        {fold ? (
+          <button
+            type="button"
+            aria-label={fold.label}
+            aria-expanded={fold.open}
+            onClick={() => fold.onOpenChange(!fold.open)}
+            className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 shrink-0 rounded-md p-0.5 transition-colors outline-none focus-visible:ring-3"
+          >
+            <ChevronRight
+              aria-hidden
+              className={cn("size-4 transition-transform", fold.open && "rotate-90")}
+            />
+          </button>
+        ) : null}
+        {children}
+      </span>
+      {control ? <div className="flex shrink-0 items-center gap-1">{control}</div> : null}
+    </div>
+  );
+}
+
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -93,4 +139,13 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };
+export {
+  Card,
+  CardHeader,
+  CardHeading,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -98,13 +98,18 @@ type CardHeadingProps = {
  * Floored at the height of a control, so a title with one beside it sits where a title without
  * one does — otherwise a row carrying a tag stands taller than its neighbours and the headings
  * across a card stop lining up.
+ *
+ * What the line aligns on follows from what is in it. A heading with a fold has an icon on its
+ * line and nothing to sit a baseline on, so it centres; one without is text throughout, and text
+ * is aligned by its baseline. Centring text instead leaves small uppercase sitting high, its
+ * glyphs filling only the part of the line box that has no descenders to make room for.
  */
 function CardHeading({ children, control, fold, className }: CardHeadingProps) {
+  const align = fold ? "items-center" : "items-baseline";
+
   return (
-    <div
-      className={cn("flex min-h-(--control-height) items-center justify-between gap-3", className)}
-    >
-      <span className="flex min-w-0 items-center gap-1.5">
+    <div className={cn("flex min-h-(--control-height) justify-between gap-3", align, className)}>
+      <span className={cn("flex min-w-0 gap-1.5", align)}>
         {fold ? (
           <button
             type="button"
@@ -121,7 +126,7 @@ function CardHeading({ children, control, fold, className }: CardHeadingProps) {
         ) : null}
         {children}
       </span>
-      {control ? <div className="flex shrink-0 items-center gap-1">{control}</div> : null}
+      {control ? <div className={cn("flex shrink-0 gap-1", align)}>{control}</div> : null}
     </div>
   );
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -21,6 +21,17 @@ type DialogProps = {
 };
 
 /**
+ * The dialog a popup has to be rendered into. `showModal()` puts the dialog in the top layer and
+ * makes everything outside it inert, so a listbox portalled to the body opens dead: visible,
+ * unclickable, and empty of anything the pointer can reach.
+ */
+const DialogContainerContext = React.createContext<HTMLElement | null>(null);
+
+export function useDialogContainer() {
+  return React.use(DialogContainerContext);
+}
+
+/**
  * Built on the native <dialog> element: the browser supplies the top layer, the focus trap
  * and Escape-to-close, so none of that has to be re-implemented (US-4).
  */
@@ -34,22 +45,22 @@ export function Dialog({
   tone = "default",
   className,
 }: DialogProps) {
-  const ref = React.useRef<HTMLDialogElement>(null);
+  // State rather than a ref, because what is portalled into it has to render again once it exists.
+  const [element, setElement] = React.useState<HTMLDialogElement | null>(null);
   const titleId = React.useId();
 
   React.useEffect(() => {
-    const dialog = ref.current;
-    if (!dialog) return;
+    if (!element) return;
 
-    if (open && !dialog.open) dialog.showModal();
-    if (!open && dialog.open) dialog.close();
-  }, [open]);
+    if (open && !element.open) element.showModal();
+    if (!open && element.open) element.close();
+  }, [open, element]);
 
   if (!open) return null;
 
   return (
     <dialog
-      ref={ref}
+      ref={setElement}
       aria-labelledby={titleId}
       onClose={onClose}
       onCancel={onClose}
@@ -82,7 +93,9 @@ export function Dialog({
         <div className="text-muted-foreground px-4 pt-2 text-sm">{description}</div>
       ) : null}
 
-      <div className="p-4">{children}</div>
+      <div className="p-4">
+        <DialogContainerContext value={element}>{children}</DialogContainerContext>
+      </div>
 
       {footer ? (
         <div className="bg-muted/50 flex items-center justify-end gap-2 border-t p-4">{footer}</div>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -17,7 +17,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "border-input file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-8 w-full min-w-0 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 md:text-sm",
+        "border-input file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-(--control-height) w-full min-w-0 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 md:text-sm",
         className,
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -36,20 +36,12 @@ function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
   );
 }
 
-function SelectTrigger({
-  className,
-  size = "default",
-  children,
-  ...props
-}: SelectPrimitive.Trigger.Props & {
-  size?: "sm" | "default";
-}) {
+function SelectTrigger({ className, children, ...props }: SelectPrimitive.Trigger.Props) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
-      data-size={size}
       className={cn(
-        "border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 flex w-fit items-center justify-between gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 flex h-(--control-height) w-fit items-center justify-between gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import { Select as SelectPrimitive } from "@base-ui/react/select";
 
 import { cn } from "@/lib/utils";
+import { useDialogContainer } from "@/components/ui/dialog";
 import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react";
 
 const Select = SelectPrimitive.Root;
@@ -68,8 +69,11 @@ function SelectContent({
     SelectPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
   >) {
+  // Inside a native modal dialog the body is inert, so the list has to be rendered within it.
+  const container = useDialogContainer();
+
   return (
-    <SelectPrimitive.Portal>
+    <SelectPrimitive.Portal container={container ?? undefined}>
       <SelectPrimitive.Positioner
         side={side}
         sideOffset={sideOffset}

--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -51,7 +51,7 @@ const TagContext = createContext<TagState>({ pressed: false, disabled: false });
  * is not, which is what makes five states out of three: an open series stays green either way,
  * because whether students can register is worth seeing whether or not you are working in it.
  */
-export type TagVariant = "default" | "open" | "neutral";
+export type TagVariant = "default" | "open" | "neutral" | "template";
 
 /** Green survives being unpressed; nothing else has anything to say once it is not chosen. */
 const unpressed = (variant: TagVariant) => (variant === "open" ? "open-soft" : "outline");

--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -20,7 +20,6 @@ export function Tag({ label, text = label, pressed, onPress }: TagProps) {
   return (
     <Button
       type="button"
-      size="sm"
       variant={pressed ? "default" : "outline"}
       aria-label={label}
       aria-pressed={pressed}

--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -15,6 +15,12 @@ type TagProps = {
   onPress: () => void;
 };
 
+/**
+ * An icon control living inside a filled tag. The tag owns the surface, so the control takes
+ * none of its own — a second fill inside the first would read as a tag within a tag.
+ */
+export const TAG_ICON_CLASSES = "hover:bg-transparent hover:text-inherit hover:opacity-70";
+
 /** One tag of a wrapping tag row — the report has two of them, and they look alike (US-13). */
 export function Tag({ label, text = label, pressed, onPress }: TagProps) {
   return (

--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -53,8 +53,11 @@ const TagContext = createContext<TagState>({ pressed: false, disabled: false });
  */
 export type TagVariant = "default" | "open" | "neutral" | "template";
 
-/** Green survives being unpressed; nothing else has anything to say once it is not chosen. */
-const unpressed = (variant: TagVariant) => (variant === "open" ? "open-soft" : "outline");
+/** Green and amber survive being unpressed; nothing else has anything to say once it is not chosen. */
+const SOFT = { open: "open-soft", template: "template-soft" } as const;
+
+const unpressed = (variant: TagVariant) =>
+  variant in SOFT ? SOFT[variant as keyof typeof SOFT] : ("outline" as const);
 
 type TagProps = {
   pressed?: boolean;

--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -5,33 +5,178 @@
  */
 "use client";
 
-import { Button } from "@/components/ui/button";
+import {
+  createContext,
+  use,
+  type ComponentProps,
+  type CSSProperties,
+  type PointerEventHandler,
+  type ReactNode,
+  type Ref,
+} from "react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+/**
+ * A tag: a pill naming one thing, and carrying whatever can be done to it. Every row of them is
+ * built from these — the report's filters and fields, the saved reports, the event series in the
+ * header — so a tag looks and behaves alike wherever it is (US-13, US-19, US-20).
+ *
+ * Three parts, in this order, and a tag may leave any of them out. The plainest has only a name:
+ *
+ *   <Tag pressed variant="open">
+ *     <DoorOpen aria-label="offen" />          the lead: what it is, or a grip to move it by
+ *     <TagName label="Wintersportwoche" … />   the name, and the button the tag is pressed by
+ *     <TagAction label="schließen">…</…>       what it offers, once it is the pressed one
+ *   </Tag>
+ *
+ * A box rather than a button, because a tag carries controls of its own and a button may not
+ * contain one.
+ */
+
+/**
+ * Whether the tag is pressed, and whether the row it sits in is waiting on a write. Its parts
+ * read this rather than being told it again: the fill and `aria-pressed` are one fact, and a tag
+ * whose colour disagreed with its name would be saying two things at once.
+ */
+type TagState = { pressed: boolean; disabled: boolean };
+
+const TagContext = createContext<TagState>({ pressed: false, disabled: false });
+
+/**
+ * How a tag is filled. Green is the one state worth spotting across the room, blue is simply
+ * the chosen one, grey is chosen but standing apart from the rest — a template among series, a
+ * report edited since it was opened. Each is filled when the tag is pressed and outlined when it
+ * is not, which is what makes five states out of three: an open series stays green either way,
+ * because whether students can register is worth seeing whether or not you are working in it.
+ */
+export type TagVariant = "default" | "open" | "neutral";
+
+/** Green survives being unpressed; nothing else has anything to say once it is not chosen. */
+const unpressed = (variant: TagVariant) => (variant === "open" ? "open-soft" : "outline");
 
 type TagProps = {
+  pressed?: boolean;
+  variant?: TagVariant;
+  /** Held while a write of the row's is out, so a second press cannot follow the first. */
+  disabled?: boolean;
+  children: ReactNode;
+  className?: string;
+  /** A tag in a sortable list is positioned by its box rather than by the name inside it. */
+  ref?: Ref<HTMLDivElement>;
+  style?: CSSProperties;
+  onPointerDown?: PointerEventHandler;
+};
+
+export function Tag({
+  pressed = false,
+  variant = "default",
+  disabled = false,
+  children,
+  className,
+  ref,
+  style,
+  onPointerDown,
+}: TagProps) {
+  return (
+    <TagContext value={{ pressed, disabled }}>
+      <div
+        ref={ref}
+        style={style}
+        onPointerDown={onPointerDown}
+        className={cn(
+          buttonVariants({ variant: pressed ? variant : unpressed(variant) }),
+          "gap-1 px-1.5",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </TagContext>
+  );
+}
+
+type TagNameProps = {
   /** The accessible name, which says which row the tag belongs to; the row carries no heading. */
   label: string;
   text?: string;
-  pressed: boolean;
+  describedBy?: string;
   onPress: () => void;
+  onPointerDown?: PointerEventHandler;
+};
+
+export function TagName({
+  label,
+  text = label,
+  describedBy,
+  onPress,
+  onPointerDown,
+}: TagNameProps) {
+  const { pressed, disabled } = use(TagContext);
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={pressed}
+      aria-describedby={describedBy}
+      disabled={disabled}
+      onPointerDown={onPointerDown}
+      onClick={onPress}
+      className="focus-visible:ring-ring/50 max-w-60 truncate rounded-md px-0.5 outline-none focus-visible:ring-3 disabled:opacity-50"
+    >
+      {text}
+    </button>
+  );
+}
+
+/**
+ * The name while it is being typed, standing where the name button stood. The tag draws the
+ * border and the surface, so the field draws neither: two borders one inside the other read as
+ * two fields.
+ */
+export function TagField({ className, ...props }: ComponentProps<typeof Input>) {
+  const { disabled } = use(TagContext);
+
+  return (
+    <Input
+      disabled={disabled}
+      className={cn(
+        "h-7 w-40 rounded-md border-0 bg-transparent px-1.5 shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type TagActionProps = {
+  /** What pressing it does, in words: the icon says it only to those who can see it. */
+  label: string;
+  type?: "button" | "submit";
+  onClick?: () => void;
+  children: ReactNode;
 };
 
 /**
- * An icon control living inside a filled tag. The tag owns the surface, so the control takes
- * none of its own — a second fill inside the first would read as a tag within a tag.
+ * One of the things the tag offers. The tag owns the surface and the colour on it, so the
+ * control takes neither — a second fill inside the first would read as a tag within a tag.
  */
-export const TAG_ICON_CLASSES = "hover:bg-transparent hover:text-inherit hover:opacity-70";
+export function TagAction({ label, type = "button", onClick, children }: TagActionProps) {
+  const { disabled } = use(TagContext);
 
-/** One tag of a wrapping tag row — the report has two of them, and they look alike (US-13). */
-export function Tag({ label, text = label, pressed, onPress }: TagProps) {
   return (
     <Button
-      type="button"
-      variant={pressed ? "default" : "outline"}
+      type={type}
+      variant="ghost"
+      size="icon"
       aria-label={label}
-      aria-pressed={pressed}
-      onClick={onPress}
+      disabled={disabled}
+      onClick={onClick}
+      className="hover:bg-transparent hover:text-inherit hover:opacity-70"
     >
-      {text}
+      {children}
     </Button>
   );
 }

--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -51,10 +51,14 @@ const TagContext = createContext<TagState>({ pressed: false, disabled: false });
  * is not, which is what makes five states out of three: an open series stays green either way,
  * because whether students can register is worth seeing whether or not you are working in it.
  */
-export type TagVariant = "default" | "open" | "neutral" | "template";
+export type TagVariant = "default" | "series" | "open" | "neutral" | "template";
 
-/** Green and amber survive being unpressed; nothing else has anything to say once it is not chosen. */
-const SOFT = { open: "open-soft", template: "template-soft" } as const;
+/**
+ * The event series colours survive being unpressed — which series exist, and which of them is
+ * taking registrations, is worth seeing whether or not you are working in one. Every other tag
+ * has nothing to say once it is not the chosen one, and goes back to the outline.
+ */
+const SOFT = { series: "series-soft", open: "open-soft", template: "template-soft" } as const;
 
 const unpressed = (variant: TagVariant) =>
   variant in SOFT ? SOFT[variant as keyof typeof SOFT] : ("outline" as const);

--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -143,7 +143,7 @@ export function TagField({ className, ...props }: ComponentProps<typeof Input>) 
     <Input
       disabled={disabled}
       className={cn(
-        "h-7 w-40 rounded-md border-0 bg-transparent px-1.5 shadow-none focus-visible:ring-0 dark:bg-transparent",
+        "h-[calc(var(--control-height)-var(--spacing))] w-40 rounded-md border-0 bg-transparent px-1.5 shadow-none focus-visible:ring-0 dark:bg-transparent",
         className,
       )}
       {...props}

--- a/src/lib/auth/graph.test.ts
+++ b/src/lib/auth/graph.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchEntraName } from "@/lib/auth/graph";
+import { fetchEntraName, fetchEntraPhoto, MAX_PHOTO_BYTES } from "@/lib/auth/graph";
 
 function respondWith(status: number, body: unknown) {
   const fetchMock = vi.fn().mockResolvedValue({
@@ -77,5 +77,88 @@ describe("fetchEntraName", () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
 
     expect(await fetchEntraName("token")).toBeNull();
+  });
+});
+
+function respondWithPhoto(status: number, type: string, bytes: Uint8Array) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name: string) => (name.toLowerCase() === "content-type" ? type : null) },
+    arrayBuffer: async () => bytes.buffer,
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+const JPEG = new Uint8Array([255, 216, 255, 224]);
+
+describe("fetchEntraPhoto", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /** Stored rather than linked, so what comes back has to be the bytes and not an address. */
+  it("returns the photo as a data URL, Graph serving it to a token and not to a browser", async () => {
+    respondWithPhoto(200, "image/jpeg", JPEG);
+
+    expect(await fetchEntraPhoto("token")).toBe("data:image/jpeg;base64,/9j/4A==");
+  });
+
+  it("asks for a size, not the original, which is as large as the tenant ever uploaded", async () => {
+    const fetchMock = respondWithPhoto(200, "image/jpeg", JPEG);
+
+    await fetchEntraPhoto("token");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("graph.microsoft.com");
+    expect(url).toMatch(/photos\/\d+x\d+\/\$value$/);
+    expect(init.headers.Authorization).toBe("Bearer token");
+  });
+
+  /** Most tenants store no photo at all, so this is the ordinary answer rather than a fault. */
+  it("returns null when the account has no photo", async () => {
+    respondWithPhoto(404, "application/json", new Uint8Array());
+
+    expect(await fetchEntraPhoto("token")).toBeNull();
+  });
+
+  it.each([401, 403, 500])("returns null for %d", async (status) => {
+    respondWithPhoto(status, "application/json", new Uint8Array());
+
+    expect(await fetchEntraPhoto("token")).toBeNull();
+  });
+
+  /** The type is written into a URL the browser will parse, so only known image types go in. */
+  it.each(["text/html", "image/svg+xml", "application/octet-stream", ""])(
+    "refuses a %s body rather than putting it in a data URL",
+    async (type) => {
+      respondWithPhoto(200, type, JPEG);
+
+      expect(await fetchEntraPhoto("token")).toBeNull();
+    },
+  );
+
+  it("takes the type without the parameters a header may carry", async () => {
+    respondWithPhoto(200, "image/png; charset=binary", JPEG);
+
+    expect(await fetchEntraPhoto("token")).toBe("data:image/png;base64,/9j/4A==");
+  });
+
+  /** It is stored in a document, and a document has a ceiling the whole write is refused at. */
+  it("refuses a photo too large for the record it is kept in", async () => {
+    respondWithPhoto(200, "image/jpeg", new Uint8Array(MAX_PHOTO_BYTES + 1));
+
+    expect(await fetchEntraPhoto("token")).toBeNull();
+  });
+
+  it("refuses an empty body, which is not a photo", async () => {
+    respondWithPhoto(200, "image/jpeg", new Uint8Array());
+
+    expect(await fetchEntraPhoto("token")).toBeNull();
+  });
+
+  it("returns null instead of throwing when the request fails outright", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    expect(await fetchEntraPhoto("token")).toBeNull();
   });
 });

--- a/src/lib/auth/graph.ts
+++ b/src/lib/auth/graph.ts
@@ -47,3 +47,55 @@ export async function fetchEntraName(accessToken: string): Promise<EntraName | n
     return null;
   }
 }
+
+// Twice the 24px the mark is drawn at, so it stays sharp on a dense screen without carrying a
+// photo nothing will ever use. Graph resizes; the original is whatever the tenant uploaded.
+const PHOTO_SIZE = 48;
+const GRAPH_PHOTO_URL = `https://graph.microsoft.com/v1.0/me/photos/${PHOTO_SIZE}x${PHOTO_SIZE}/$value`;
+
+/** Well inside the 1 MiB a Firestore document holds, this being kept in one. */
+export const MAX_PHOTO_BYTES = 64 * 1024;
+
+/** What may be named in the data URL. Graph sends JPEG; the rest is what a browser can decode. */
+const PHOTO_TYPES: readonly string[] = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+
+/**
+ * Reads the signed-in user's Entra photo, as a data URL.
+ *
+ * The bytes rather than an address, because Graph serves the photo to a bearer token and the
+ * browser has none — the token belongs to the sign-in in progress and is not kept (US-1).
+ * Null is the ordinary answer: most accounts have no photo, and a decorative mark is not worth
+ * failing a sign-in over.
+ */
+export async function fetchEntraPhoto(accessToken: string): Promise<string | null> {
+  try {
+    const response = await fetch(GRAPH_PHOTO_URL, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      console.error(`Microsoft Graph /me/photo returned ${response.status}`);
+      return null;
+    }
+
+    // Named in a URL the browser will parse, so it is chosen from a list here rather than
+    // repeated from the header, whatever the header happens to say.
+    const type = (response.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
+    if (!PHOTO_TYPES.includes(type)) {
+      console.error(`Microsoft Graph /me/photo answered with ${type || "no type"}`);
+      return null;
+    }
+
+    const bytes = Buffer.from(await response.arrayBuffer());
+    if (bytes.byteLength === 0 || bytes.byteLength > MAX_PHOTO_BYTES) {
+      console.error(`Microsoft Graph /me/photo answered with ${bytes.byteLength} bytes`);
+      return null;
+    }
+
+    return `data:${type};base64,${bytes.toString("base64")}`;
+  } catch (err) {
+    console.error("Microsoft Graph /me/photo request failed:", err);
+    return null;
+  }
+}

--- a/src/lib/auth/guards.ts
+++ b/src/lib/auth/guards.ts
@@ -8,7 +8,7 @@ import { redirect } from "next/navigation";
 import { adminDb } from "@/lib/firebase/admin";
 import { getSessionUser, type SessionUser } from "@/lib/session";
 import { COLLECTIONS } from "@/lib/schemas/collections";
-import { userRoleSchema, type UserRole } from "@/lib/schemas/user";
+import { userRoleSchema, userSchema, type UserRole } from "@/lib/schemas/user";
 import { ROUTES } from "@/lib/routes";
 
 export type AuthenticatedUser = SessionUser & { role: UserRole };
@@ -58,4 +58,16 @@ export async function requireStudent(): Promise<AuthenticatedUser> {
   const user = await requireUser();
   if (user.role !== "student") redirect(ROUTES.appRoot);
   return user;
+}
+
+/**
+ * The Entra photo kept on the record at sign-in (US-1), for the mark the person is shown by.
+ * Null for most accounts, which have none, and for anything that fails to parse as one.
+ */
+export async function fetchUserPhoto(email: string | null): Promise<string | null> {
+  if (!email) return null;
+
+  const snapshot = await adminDb.collection(COLLECTIONS.users).doc(email.toLowerCase()).get();
+  const parsed = userSchema.shape.photo.safeParse(snapshot.data()?.photo);
+  return parsed.success ? (parsed.data ?? null) : null;
 }

--- a/src/lib/auth/provision-user.test.ts
+++ b/src/lib/auth/provision-user.test.ts
@@ -14,6 +14,7 @@ const doc = vi.fn(() => ({ get: docGet, set: docSet, update: docUpdate }));
 const collection = vi.fn(() => ({ doc }));
 const setCustomUserClaims = vi.fn();
 const fetchEntraName = vi.fn();
+const fetchEntraPhoto = vi.fn();
 
 /**
  * The user record stays a mock, so the tests below can stage a login that finds one or does
@@ -31,7 +32,7 @@ vi.mock("@/lib/firebase/admin", () => ({
   adminAuth: { setCustomUserClaims },
 }));
 
-vi.mock("@/lib/auth/graph", () => ({ fetchEntraName }));
+vi.mock("@/lib/auth/graph", () => ({ fetchEntraName, fetchEntraPhoto }));
 
 // Whatever else a deployment refuses. Production refuses nothing, so the tests below say so
 // explicitly rather than leaning on which module the build happens to resolve.
@@ -129,6 +130,7 @@ describe("provisionUser", () => {
         lastName: "Doe",
         email: "jane.doe@htldornbirn.at",
         role: "teacher",
+        photo: null,
       },
     });
     expect(collection).toHaveBeenCalledWith("users");
@@ -199,6 +201,7 @@ describe("provisionUser", () => {
       firstName: "Jane",
       lastName: "Doe",
       email: "jane.doe@htldornbirn.at",
+      photo: null,
     });
   });
 
@@ -321,6 +324,73 @@ describe("provisionUser", () => {
     await provisionUser({ ...teacherClaims, email: "jane@gmail.com" }, "graph-token");
 
     expect(fetchEntraName).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Sign-in is the one moment the Graph token is held, so it is the one moment the photo can be
+ * read — the token is not kept afterwards, and the browser never had one of its own (US-1).
+ */
+describe("provisionUser — the Entra photo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    refuseSignIn.mockReturnValue(null);
+    docGet.mockResolvedValue({ exists: false, data: () => undefined });
+    fetchEntraName.mockResolvedValue(null);
+    fetchEntraPhoto.mockResolvedValue(null);
+  });
+
+  it("stores the photo Graph holds", async () => {
+    fetchEntraPhoto.mockResolvedValue("data:image/jpeg;base64,AAA");
+
+    const result = await provisionUser(teacherClaims, "graph-token");
+
+    expect(fetchEntraPhoto).toHaveBeenCalledWith("graph-token");
+    expect(docSet).toHaveBeenCalledWith(
+      expect.objectContaining({ photo: "data:image/jpeg;base64,AAA" }),
+    );
+    expect(result).toMatchObject({ ok: true, user: { photo: "data:image/jpeg;base64,AAA" } });
+  });
+
+  /** An account with no photo stores none, rather than a key holding nothing. */
+  it("stores null when there is no photo to store", async () => {
+    const result = await provisionUser(teacherClaims, "graph-token");
+
+    expect(docSet).toHaveBeenCalledWith(expect.objectContaining({ photo: null }));
+    expect(result).toMatchObject({ ok: true, user: { photo: null } });
+  });
+
+  /** Removing it in Entra removes it here, which only a write on every login can do. */
+  it("clears a photo that Entra no longer has", async () => {
+    existingRecord({ role: "teacher", photo: "data:image/jpeg;base64,OLD" });
+
+    await provisionUser(teacherClaims, "graph-token");
+
+    expect(docUpdate).toHaveBeenCalledWith(expect.objectContaining({ photo: null }));
+  });
+
+  it("does not ask for one without a token to ask with", async () => {
+    await provisionUser(teacherClaims);
+
+    expect(fetchEntraPhoto).not.toHaveBeenCalled();
+    expect(docSet).toHaveBeenCalledWith(expect.objectContaining({ photo: null }));
+  });
+
+  /** Two independent reads of the same profile; one waiting for the other only slows sign-in. */
+  it("asks for the name and the photo at the same time", async () => {
+    let namePending = false;
+    fetchEntraName.mockImplementation(async () => {
+      namePending = true;
+      return null;
+    });
+    fetchEntraPhoto.mockImplementation(async () => {
+      expect(namePending).toBe(true);
+      return null;
+    });
+
+    await provisionUser(teacherClaims, "graph-token");
+
+    expect(fetchEntraPhoto).toHaveBeenCalled();
   });
 });
 

--- a/src/lib/auth/provision-user.ts
+++ b/src/lib/auth/provision-user.ts
@@ -10,7 +10,7 @@ import { commitInChunks, type BatchOperation } from "@/lib/firebase/batch";
 import { COLLECTIONS } from "@/lib/schemas/collections";
 import type { Registration } from "@/lib/schemas/registration";
 import { userRoleSchema, userSchema, type User } from "@/lib/schemas/user";
-import { fetchEntraName } from "./graph";
+import { fetchEntraName, fetchEntraPhoto } from "./graph";
 import { refuseSignIn } from "./sign-in-policy";
 import { roleFromUpn } from "./upn";
 
@@ -132,7 +132,9 @@ export async function provisionUser(
   // Graph is the authoritative source, field by field: its `givenName` is the first name and
   // its `surname` the last one, so neither can be mistaken for the other. Whichever it cannot
   // supply falls back below.
-  const fromGraph = graphAccessToken ? await fetchEntraName(graphAccessToken) : null;
+  const [fromGraph, photo] = graphAccessToken
+    ? await Promise.all([fetchEntraName(graphAccessToken), fetchEntraPhoto(graphAccessToken)])
+    : [null, null];
   const fallback = resolveName(claims, localPart);
   const firstName = fromGraph?.firstName ?? fallback.firstName;
   const lastName = fromGraph?.lastName ?? fallback.lastName;
@@ -144,12 +146,13 @@ export async function provisionUser(
     // The role is assigned once, at creation; a later login never recomputes it (US-3).
     const stored = userSchema.shape.role.safeParse(snapshot.data()?.role);
     if (stored.success) role = stored.data;
-    await ref.update({ firstName, lastName, email: upn });
+    // The photo is written even when there is none, so removing it in Entra removes it here.
+    await ref.update({ firstName, lastName, email: upn, photo });
   } else {
-    await ref.set({ firstName, lastName, email: upn, role });
+    await ref.set({ firstName, lastName, email: upn, role, photo });
   }
 
-  const user = userSchema.parse({ id: upn, firstName, lastName, email: upn, role });
+  const user = userSchema.parse({ id: upn, firstName, lastName, email: upn, role, photo });
 
   // Only a student holds registrations: a teacher keeps none of their own (US-15).
   if (role === userRoleSchema.enum.student) {

--- a/src/lib/event-series/event-series-selection.test.ts
+++ b/src/lib/event-series/event-series-selection.test.ts
@@ -87,4 +87,22 @@ describe("rescopedPath", () => {
   it("encodes the id it puts in the path", () => {
     expect(rescopedPath("/app/s1/report", "a/b")).toBe("/app/a%2Fb/report");
   });
+
+  /**
+   * A template holds lists and no registrations (US-22), so an overview, an assignment or a
+   * report has nothing to show for one — and the row offering the tag is gone from those pages,
+   * so pressing it would take the tag away with it.
+   */
+  it.each(["/app/event-series", "/app/s1/overview", "/app/s1/report", "/app/s1/assignment"])(
+    "opens the master data of a template rather than a page it has nothing for, from %s",
+    (pathname) => {
+      expect(rescopedPath(pathname, "t1", true)).toBe("/app/t1/master-data/events");
+    },
+  );
+
+  it("keeps the list open when re-scoping it to a template, that being what a template has", () => {
+    expect(rescopedPath("/app/s1/master-data/classes", "t1", true)).toBe(
+      "/app/t1/master-data/classes",
+    );
+  });
 });

--- a/src/lib/event-series/event-series-selection.test.ts
+++ b/src/lib/event-series/event-series-selection.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   isMasterDataPath,
   rescopedPath,
+  sectionSelection,
   selectedEventSeriesIdFrom,
 } from "@/lib/event-series/event-series-selection";
 
@@ -104,5 +105,61 @@ describe("rescopedPath", () => {
     expect(rescopedPath("/app/s1/master-data/classes", "t1", true)).toBe(
       "/app/t1/master-data/classes",
     );
+  });
+});
+
+/**
+ * Moving between sections keeps the selection where the section can be about it. Master data can
+ * be about a template; an overview, an assignment and a report cannot (US-22), so leaving master
+ * data with a template selected has to land on something those pages can show.
+ */
+describe("sectionSelection", () => {
+  const live = [
+    { id: "t1", isTemplate: true, isArchived: false },
+    { id: "s1", isTemplate: false, isArchived: false },
+    { id: "s2", isTemplate: false, isArchived: false },
+  ];
+
+  it.each(["masterData", "series"] as const)("keeps the selected series in %s", (section) => {
+    expect(sectionSelection(live, "s2", section)).toBe("s2");
+  });
+
+  it("keeps a selected template in master data, which is what a template has", () => {
+    expect(sectionSelection(live, "t1", "masterData")).toBe("t1");
+  });
+
+  it("leaves a template behind on the way out of master data", () => {
+    expect(sectionSelection(live, "t1", "series")).toBe("s1");
+  });
+
+  it.each([null, "gone", "archived"])(
+    "falls back to the first template in master data when %s is selected",
+    (wanted) => {
+      const withArchived = [...live, { id: "archived", isTemplate: false, isArchived: true }];
+
+      expect(sectionSelection(withArchived, wanted, "masterData")).toBe("t1");
+    },
+  );
+
+  it.each([null, "gone"])(
+    "falls back to the first series outside master data when %s",
+    (wanted) => {
+      expect(sectionSelection(live, wanted, "series")).toBe("s1");
+    },
+  );
+
+  /** Archiving is what takes a series off every screen, this one included (US-19). */
+  it("never selects an archived series, however it was asked for", () => {
+    const archived = [{ id: "old", isTemplate: false, isArchived: true }];
+
+    expect(sectionSelection(archived, "old", "series")).toBeNull();
+    expect(sectionSelection(archived, "old", "masterData")).toBeNull();
+  });
+
+  it("selects nothing outside master data when only templates are left", () => {
+    const templates = [{ id: "t1", isTemplate: true, isArchived: false }];
+
+    expect(sectionSelection(templates, null, "series")).toBeNull();
+    expect(sectionSelection(templates, null, "masterData")).toBe("t1");
   });
 });

--- a/src/lib/event-series/event-series-selection.test.ts
+++ b/src/lib/event-series/event-series-selection.test.ts
@@ -4,7 +4,34 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { describe, expect, it } from "vitest";
-import { rescopedPath, selectedEventSeriesIdFrom } from "@/lib/event-series/event-series-selection";
+import {
+  isMasterDataPath,
+  rescopedPath,
+  selectedEventSeriesIdFrom,
+} from "@/lib/event-series/event-series-selection";
+
+/**
+ * Where a teacher is maintaining what a series is made of, as against looking at what its
+ * students answered. Only there is a template worth offering: it holds lists and no
+ * registrations, so it has nothing to show an overview, an assignment or a report (US-22).
+ */
+describe("isMasterDataPath", () => {
+  it.each([
+    "/app/event-series",
+    "/app/event-series/s1",
+    "/app/s1/master-data/classes",
+    "/app/s1/master-data/programs",
+  ])("counts %s as maintaining master data", (pathname) => {
+    expect(isMasterDataPath(pathname)).toBe(true);
+  });
+
+  it.each(["/app/s1/overview", "/app/s1/assignment", "/app/s1/report", "/app/my-registration"])(
+    "counts %s as looking at students",
+    (pathname) => {
+      expect(isMasterDataPath(pathname)).toBe(false);
+    },
+  );
+});
 
 describe("selectedEventSeriesIdFrom", () => {
   it.each([

--- a/src/lib/event-series/event-series-selection.ts
+++ b/src/lib/event-series/event-series-selection.ts
@@ -32,6 +32,19 @@ export function selectedEventSeriesIdFrom(pathname: string): string | null {
 }
 
 /**
+ * Whether the page is about what a series is made of rather than what its students answered.
+ * The navigation marks its own section by it, and the header offers the templates only here:
+ * a template holds lists and no registrations, so it has nothing an overview, an assignment or
+ * a report could show (US-22).
+ */
+export function isMasterDataPath(pathname: string): boolean {
+  if (pathname === ROUTES.eventSeries || pathname.startsWith(`${ROUTES.eventSeries}/`)) return true;
+
+  const selected = selectedEventSeriesIdFrom(pathname);
+  return selected !== null && pathname.startsWith(`${eventSeriesRoutes(selected).masterData}`);
+}
+
+/**
  * Where pressing a header tag goes. Selecting another series re-scopes the page that is open
  * rather than navigating away from it (US-20) — the teacher asked a different question about the
  * same view. From a page that is about no series there is no view to keep, so the overview opens:

--- a/src/lib/event-series/event-series-selection.ts
+++ b/src/lib/event-series/event-series-selection.ts
@@ -45,6 +45,33 @@ export function isMasterDataPath(pathname: string): boolean {
   return selected !== null && pathname.startsWith(`${eventSeriesRoutes(selected).masterData}`);
 }
 
+/** What choosing a section needs to know about a series, and no more. */
+type Selectable = { id: string; isTemplate: boolean; isArchived: boolean };
+
+/**
+ * Which series a section opens on when the teacher moves into it. The selection is kept wherever
+ * the section can be about it — master data can be about a template, an overview, an assignment
+ * and a report cannot (US-22) — and otherwise the section takes the first it can show, in the
+ * teacher's own order.
+ *
+ * Null means the section has nothing to be about, which the caller answers with the series list.
+ */
+export function sectionSelection(
+  eventSeries: readonly Selectable[],
+  wanted: string | null,
+  section: "masterData" | "series",
+): string | null {
+  const live = eventSeries.filter((one) => !one.isArchived);
+  const current = live.find((one) => one.id === wanted) ?? null;
+
+  if (section === "masterData") {
+    return (current ?? live.find((one) => one.isTemplate) ?? live[0])?.id ?? null;
+  }
+
+  if (current !== null && !current.isTemplate) return current.id;
+  return live.find((one) => !one.isTemplate)?.id ?? null;
+}
+
 /**
  * Where pressing a header tag goes. Selecting another series re-scopes the page that is open
  * rather than navigating away from it (US-20) — the teacher asked a different question about the

--- a/src/lib/event-series/event-series-selection.ts
+++ b/src/lib/event-series/event-series-selection.ts
@@ -4,6 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { eventSeriesRoutes, ROUTES } from "@/lib/routes";
+import { firstMasterDataPath } from "@/lib/master-data/categories";
 
 /**
  * Which event series a teacher is working in lives in the URL (Q8), so a report can be linked to
@@ -49,14 +50,17 @@ export function isMasterDataPath(pathname: string): boolean {
  * rather than navigating away from it (US-20) — the teacher asked a different question about the
  * same view. From a page that is about no series there is no view to keep, so the overview opens:
  * it is where a series is run from (US-29).
+ *
+ * A template is the exception: it holds lists and no registrations (US-22), so it is only ever
+ * scoped to the master data, which is also the only place its tag is offered.
  */
-export function rescopedPath(pathname: string, eventSeriesId: string): string {
+export function rescopedPath(pathname: string, eventSeriesId: string, isTemplate = false): string {
   const scope = `${ROUTES.appRoot}/${encodeURIComponent(eventSeriesId)}`;
-  if (selectedEventSeriesIdFrom(pathname) === null)
-    return eventSeriesRoutes(eventSeriesId).overview;
+  const rest = selectedEventSeriesIdFrom(pathname) === null ? [] : pathname.split("/").slice(3);
+  const kept =
+    rest.length === 0 ? eventSeriesRoutes(eventSeriesId).overview : `${scope}/${rest.join("/")}`;
 
-  const rest = pathname.split("/").slice(3);
-  return rest.length === 0 ? `${scope}/overview` : `${scope}/${rest.join("/")}`;
+  return isTemplate && !isMasterDataPath(kept) ? firstMasterDataPath(eventSeriesId) : kept;
 }
 
 /**

--- a/src/lib/event-series/event-series-service.test.ts
+++ b/src/lib/event-series/event-series-service.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeFirestore } from "@/test/fake-firestore";
 import { storedEventSeries } from "@/test/event-series";
 import { registrationPath } from "@/lib/registration/registration";
+import { savedReportPath } from "@/lib/report/saved-reports";
 
 const firestore = new FakeFirestore();
 
@@ -303,16 +304,46 @@ describe("deleteEventSeries", () => {
     expect(firestore.count(registrationPath("s1"))).toBe(0);
   });
 
+  /**
+   * A token names its series by a field, so nothing about the series' own removal reaches it.
+   * Left behind it resolves to a series that is not there, which is a link that looks live.
+   */
+  it("deletes every invitation of the event series", async () => {
+    seedEventSeries("s1", { isArchived: true });
+    firestore.seed("invitations", "tok1", { eventSeriesId: "s1", class: "5AHIF" });
+    firestore.seed("invitations", "tok2", { eventSeriesId: "s1", class: "5BHIF" });
+
+    await deleteEventSeries("s1");
+
+    expect(firestore.count("invitations")).toBe(0);
+  });
+
+  /** Firestore deletes no subcollection with its parent, so the reports have to be taken too. */
+  it("deletes every saved report of the event series", async () => {
+    seedEventSeries("s1", { isArchived: true });
+    firestore.seed(savedReportPath("s1"), "r1", { name: "5AHIF" });
+
+    await deleteEventSeries("s1");
+
+    expect(firestore.count(savedReportPath("s1"))).toBe(0);
+  });
+
   it("leaves documents of other event series untouched", async () => {
     seedEventSeries("s1", { isArchived: true, events: ["Montafon"] });
     seedEventSeries("s2", { events: ["Behalten"] });
     firestore.seed(registrationPath("s1"), "m1", { studentUpn: "u1" });
     firestore.seed(registrationPath("s2"), "keep", { studentUpn: "u2" });
+    firestore.seed("invitations", "tok1", { eventSeriesId: "s1", class: "5AHIF" });
+    firestore.seed("invitations", "keep", { eventSeriesId: "s2", class: "5AHIF" });
+    firestore.seed(savedReportPath("s1"), "r1", { name: "5AHIF" });
+    firestore.seed(savedReportPath("s2"), "keep", { name: "5AHIF" });
 
     await deleteEventSeries("s1");
 
     expect(firestore.get("eventSeries", "s2")).toMatchObject({ events: ["Behalten"] });
     expect(Object.keys(firestore.docs(registrationPath("s2")))).toEqual(["keep"]);
+    expect(Object.keys(firestore.docs("invitations"))).toEqual(["keep"]);
+    expect(Object.keys(firestore.docs(savedReportPath("s2")))).toEqual(["keep"]);
   });
 
   it("chunks the cascade into batches no larger than the Firestore limit", async () => {

--- a/src/lib/event-series/event-series-service.test.ts
+++ b/src/lib/event-series/event-series-service.test.ts
@@ -328,6 +328,32 @@ describe("deleteEventSeries", () => {
     expect(firestore.count(savedReportPath("s1"))).toBe(0);
   });
 
+  /**
+   * A teacher may save a report right up to the moment the series goes, and that save reads a
+   * series still standing, so it succeeds. Sweeping once before the parent leaves it behind;
+   * sweeping again after, when nothing further can be written, is what makes the delete total.
+   */
+  it("sweeps again after the series is gone, catching what was written while it ran", async () => {
+    seedEventSeries("s1", { isArchived: true });
+    const removeDoc = firestore.deleteDoc.bind(firestore);
+    const spy = vi.spyOn(firestore, "deleteDoc").mockImplementation((path: string, id: string) => {
+      if (path === "eventSeries" && id === "s1") {
+        firestore.seed(savedReportPath("s1"), "late", { name: "Spät" });
+        firestore.seed("invitations", "late", { eventSeriesId: "s1", class: "5AHIF" });
+      }
+      removeDoc(path, id);
+    });
+
+    try {
+      await deleteEventSeries("s1");
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(firestore.count(savedReportPath("s1"))).toBe(0);
+    expect(firestore.count("invitations")).toBe(0);
+  });
+
   it("leaves documents of other event series untouched", async () => {
     seedEventSeries("s1", { isArchived: true, events: ["Montafon"] });
     seedEventSeries("s2", { events: ["Behalten"] });

--- a/src/lib/event-series/event-series-service.test.ts
+++ b/src/lib/event-series/event-series-service.test.ts
@@ -4,6 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_FILTER, toggleTag } from "@/lib/filters/student-filter";
 import { FakeFirestore } from "@/test/fake-firestore";
 import { storedEventSeries } from "@/test/event-series";
 import { registrationPath } from "@/lib/registration/registration";
@@ -81,6 +82,138 @@ describe("createEventSeries", () => {
   it("rejects a blank name", async () => {
     await expect(createEventSeries({ name: "   " })).rejects.toBeInstanceOf(ServiceError);
     expect(firestore.count("eventSeries")).toBe(0);
+  });
+
+  /** The kind is answered on its own, so it follows neither the source nor a default (US-22). */
+  it("makes a template when asked for one", async () => {
+    const template = await createEventSeries({ name: "Wintersportwochen", isTemplate: true });
+
+    expect(template.isTemplate).toBe(true);
+    expect(template.isOpenToStudents).toBe(false);
+  });
+});
+
+/**
+ * A new series begins with the setup a teacher keeps for exactly that purpose (US-22). Which of
+ * the four combinations it is — series or template, blank or copied — is answered by two
+ * questions that decide nothing about each other.
+ */
+describe("createEventSeries — from a source", () => {
+  const lists = {
+    events: ["Woche 1", "Woche 2"],
+    classOptions: ["5AHIF", "5BHIF"],
+    programs: [
+      { name: "Ski", requiredEquipment: ["Ski", "Helm"] },
+      { name: "Snowboard", requiredEquipment: [] },
+    ],
+    skillLevels: ["Anfänger:in", "Profi"],
+    seasonPassOptions: ["Kein Skipass"],
+    busPickupPoints: ["HTL Dornbirn"],
+    foodOptions: ["Esse alles"],
+  };
+
+  beforeEach(() => firestore.seed("eventSeries", "source", storedEventSeries({ ...lists })));
+
+  it("takes the seven lists whole, in their order, with each program's equipment", async () => {
+    const copy = await createEventSeries({ name: "Wintersportwoche 2027", sourceId: "source" });
+
+    expect(copy).toMatchObject(lists);
+  });
+
+  it("takes no registrations, no archive state and no invitation link", async () => {
+    firestore.seed("eventSeries", "archived", storedEventSeries({ name: "Alt", isArchived: true }));
+    firestore.seed(registrationPath("archived"), "m1", { studentUpn: "u1" });
+    firestore.seed("invitations", "tok", { eventSeriesId: "archived", class: "5AHIF" });
+
+    const copy = await createEventSeries({ name: "Wintersportwoche 2027", sourceId: "archived" });
+
+    expect(copy).toMatchObject({ isArchived: false, hasRegistrations: false });
+    expect(firestore.count(registrationPath(copy.id))).toBe(0);
+    expect(firestore.docs("invitations").tok).toMatchObject({ eventSeriesId: "archived" });
+  });
+
+  /** Archiving would be a one-way door otherwise: its master data could never come back. */
+  it("copies from an archived series, which is how its lists come back into a live one", async () => {
+    firestore.seed(
+      "eventSeries",
+      "old",
+      storedEventSeries({ name: "Alt", isArchived: true, classOptions: ["4AHIF"] }),
+    );
+
+    const copy = await createEventSeries({ name: "Wintersportwoche 2027", sourceId: "old" });
+
+    expect(copy.classOptions).toEqual(["4AHIF"]);
+  });
+
+  it("is a series copied from a template unless a template was asked for", async () => {
+    firestore.seed("eventSeries", "tpl", storedEventSeries({ name: "Vorlage", isTemplate: true }));
+
+    const asSeries = await createEventSeries({ name: "Winter 2027", sourceId: "tpl" });
+    const asTemplate = await createEventSeries({
+      name: "Sommer",
+      sourceId: "tpl",
+      isTemplate: true,
+    });
+
+    expect(asSeries.isTemplate).toBe(false);
+    expect(asTemplate.isTemplate).toBe(true);
+  });
+
+  it("refuses a source that is not there rather than making a blank one", async () => {
+    await expect(
+      createEventSeries({ name: "Wintersportwoche 2027", sourceId: "gone" }),
+    ).rejects.toBeInstanceOf(ServiceError);
+    expect(firestore.count("eventSeries")).toBe(1);
+  });
+
+  it("takes the saved reports of its source", async () => {
+    firestore.seed(savedReportPath("source"), "r1", {
+      name: "5AHIF",
+      filter: toggleTag(EMPTY_FILTER, "class", "5AHIF"),
+      fields: ["class"],
+      createdByUserId: "jane.doe@htldornbirn.at",
+      position: 0,
+    });
+
+    const copy = await createEventSeries({ name: "Wintersportwoche 2027", sourceId: "source" });
+
+    const reports = Object.values(firestore.docs(savedReportPath(copy.id)));
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({ name: "5AHIF", position: 0 });
+  });
+
+  /**
+   * A tag the copied lists do not offer is dropped as it is copied, exactly as US-25 drops one
+   * when an item is removed — so the copy is consistent with its own lists from the moment it
+   * exists, rather than opening as changed the first time anybody looks at it.
+   */
+  it("drops a tag its own lists do not offer, in the same write", async () => {
+    firestore.seed(savedReportPath("source"), "r1", {
+      name: "Alte Klasse",
+      filter: toggleTag(toggleTag(EMPTY_FILTER, "class", "5AHIF"), "class", "4AHIF"),
+      fields: ["class"],
+      createdByUserId: "jane.doe@htldornbirn.at",
+      position: 0,
+    });
+
+    const copy = await createEventSeries({ name: "Wintersportwoche 2027", sourceId: "source" });
+
+    const [report] = Object.values(firestore.docs(savedReportPath(copy.id)));
+    expect(report.filter).toMatchObject({ tags: expect.objectContaining({ class: ["5AHIF"] }) });
+  });
+
+  it("leaves the source's own reports where they are", async () => {
+    firestore.seed(savedReportPath("source"), "r1", {
+      name: "5AHIF",
+      filter: EMPTY_FILTER,
+      fields: [],
+      createdByUserId: "jane.doe@htldornbirn.at",
+      position: 0,
+    });
+
+    await createEventSeries({ name: "Wintersportwoche 2027", sourceId: "source" });
+
+    expect(firestore.count(savedReportPath("source"))).toBe(1);
   });
 });
 

--- a/src/lib/event-series/event-series-service.test.ts
+++ b/src/lib/event-series/event-series-service.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/lib/firebase/admin", () => ({
   adminDb: firestore,
 }));
 
-const { createEventSeries, updateEventSeries, deleteEventSeries } =
+const { createEventSeries, updateEventSeries, deleteEventSeries, resolveSelectedEventSeriesId } =
   await import("./event-series-service");
 const { ServiceError } = await import("@/lib/service-error");
 
@@ -690,5 +690,48 @@ describe("updateEventSeries — opening needs a class to invite", () => {
     await updateEventSeries("s1", { isOpenToStudents: false });
 
     expect(firestore.get("eventSeries", "s1")).toMatchObject({ isOpenToStudents: false });
+  });
+});
+
+/**
+ * What `/app` opens on, and what the navigation points at from a page that names no series (Q8).
+ * Both are pages about registrations, which is exactly what a template has none of (US-22).
+ */
+describe("resolveSelectedEventSeriesId", () => {
+  it("takes the remembered series when it is still selectable", async () => {
+    seedEventSeries("s1", { position: 0 });
+    seedEventSeries("s2", { position: 1 });
+
+    expect(await resolveSelectedEventSeriesId("s2")).toBe("s2");
+  });
+
+  it("falls back to the first in the teacher's order", async () => {
+    seedEventSeries("s2", { position: 1 });
+    seedEventSeries("s1", { position: 0 });
+
+    expect(await resolveSelectedEventSeriesId()).toBe("s1");
+  });
+
+  it.each([{ isArchived: true }, { isTemplate: true }])(
+    "passes over a remembered %o, which no longer has the pages that would be opened",
+    async (state) => {
+      seedEventSeries("remembered", { position: 0, ...state });
+      seedEventSeries("s1", { position: 1 });
+
+      expect(await resolveSelectedEventSeriesId("remembered")).toBe("s1");
+    },
+  );
+
+  it("skips a template when picking the first, however early it sorts", async () => {
+    seedEventSeries("t1", { position: 0, isTemplate: true });
+    seedEventSeries("s1", { position: 1 });
+
+    expect(await resolveSelectedEventSeriesId()).toBe("s1");
+  });
+
+  it("selects nothing when only templates remain, there being no series to run", async () => {
+    seedEventSeries("t1", { position: 0, isTemplate: true });
+
+    expect(await resolveSelectedEventSeriesId()).toBeNull();
   });
 });

--- a/src/lib/event-series/event-series-service.ts
+++ b/src/lib/event-series/event-series-service.ts
@@ -225,6 +225,27 @@ export async function resolveSelectedEventSeriesId(preferredId?: string): Promis
 }
 
 /**
+ * Everything belonging to one event series that Firestore will not take with the document.
+ * A subcollection outlives its parent, and a token names its series by a field rather than by
+ * its path, since a link carries the token and nothing else (US-23).
+ */
+async function sweepDependants(id: string): Promise<void> {
+  const [registrations, savedReports, invitations] = await Promise.all([
+    adminDb.collection(registrationPath(id)).get(),
+    adminDb.collection(savedReportPath(id)).get(),
+    adminDb.collection(COLLECTIONS.invitations).where("eventSeriesId", "==", id).get(),
+  ]);
+
+  const operations: BatchOperation[] = [
+    ...registrations.docs,
+    ...savedReports.docs,
+    ...invitations.docs,
+  ].map((doomed) => (batch) => batch.delete(doomed.ref));
+
+  await commitInChunks(operations);
+}
+
+/**
  * Firestore has no cascading delete, so removal is explicit (US-4). Dependants go first and
  * the event series itself last: if the run fails midway the event series is still there, so simply calling
  * this again finishes the job. An event series is only ever unremovable while it still holds student
@@ -258,27 +279,16 @@ export async function deleteEventSeries(id: string): Promise<void> {
     );
   }
 
-  // A registration carries its emergency contact and rentals in its own fields, so
-  // deleting it takes them along — there is nothing hanging off it to clean up separately.
-  // The lists the series maintained, its events among them, are fields of the document itself
-  // and go with it (US-21).
-  //
-  // The other two are named rather than implied. Firestore deletes no subcollection with its
-  // parent, so the saved reports have to be asked for; and a token names its series by a field
-  // rather than by its path, since a link carries the token and nothing else (US-23) — so a link
-  // left behind would go on resolving to a series that is not there.
-  const savedReportsSnapshot = await adminDb.collection(savedReportPath(id)).get();
-  const invitationsSnapshot = await adminDb
-    .collection(COLLECTIONS.invitations)
-    .where("eventSeriesId", "==", id)
-    .get();
-
-  const operations: BatchOperation[] = [
-    ...registrationsSnapshot.docs,
-    ...savedReportsSnapshot.docs,
-    ...invitationsSnapshot.docs,
-  ].map((doomed) => (batch) => batch.delete(doomed.ref));
-  await commitInChunks(operations);
+  // A registration carries its emergency contact and rentals in its own fields, so deleting it
+  // takes them along, and the lists the series maintained are fields of the document itself and
+  // go with it (US-21). What sweepDependants exists for is everything Firestore leaves standing.
+  await sweepDependants(id);
 
   await reference.delete();
+
+  // Again, because a write that began before this ran read a series that was still there and so
+  // succeeded. Only now can nothing further be written: every such write reads the series first,
+  // and it is gone. Children first and the series last is what keeps a failed run re-runnable,
+  // and this second pass is what keeps a successful one total.
+  await sweepDependants(id);
 }

--- a/src/lib/event-series/event-series-service.ts
+++ b/src/lib/event-series/event-series-service.ts
@@ -265,24 +265,30 @@ export async function updateEventSeries(
 }
 
 /**
- * Which event series `/app` sends a teacher into (Q8). An archived one is not selectable, so a
- * remembered id that has since been archived or deleted falls back to the first series in the
- * teacher's order rather than to a page that would refuse to render.
+ * Which event series `/app` sends a teacher into (Q8). Both that page and the navigation built
+ * from this answer are about registrations, so neither an archived series nor a template is
+ * selectable — a remembered id that has become either falls back to the first that is.
  *
  * Null means there is nothing to select, which the caller answers with the event series list.
  */
 export async function resolveSelectedEventSeriesId(preferredId?: string): Promise<string | null> {
+  const selectable = (data: Record<string, unknown> | undefined) =>
+    data?.isArchived !== true && data?.isTemplate !== true;
+
   if (preferredId) {
     const preferred = await eventSeriesDoc(preferredId).get();
-    if (preferred.exists && preferred.data()?.isArchived !== true) return preferred.id;
+    if (preferred.exists && selectable(preferred.data())) return preferred.id;
   }
 
-  const selectable = await adminDb
+  const unarchived = await adminDb
     .collection(COLLECTIONS.eventSeries)
     .where("isArchived", "==", false)
     .get();
 
-  const first = selectable.docs
+  // Templates are sieved out here rather than in the query, which would need an index of its own
+  // for a collection already read whole and ordered in memory.
+  const first = unarchived.docs
+    .filter((doc) => selectable(doc.data()))
     .map((doc) => ({ id: doc.id, position: Number(doc.data().position ?? 0) }))
     .sort((a, b) => a.position - b.position)[0];
 

--- a/src/lib/event-series/event-series-service.ts
+++ b/src/lib/event-series/event-series-service.ts
@@ -14,7 +14,10 @@ import {
   NO_SUCH_EVENT_SERIES,
 } from "@/lib/event-series/event-series-state";
 import { normalizeName } from "@/lib/firebase/name-key";
+import { prunedToLists } from "@/lib/filters/student-filter";
 import { savedReportPath } from "@/lib/report/saved-reports";
+import { savedReportSchema } from "@/lib/schemas/saved-report";
+import type { EventSeriesListField } from "@/lib/master-data/categories";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
 import { COLLECTIONS } from "@/lib/schemas/collections";
@@ -62,35 +65,95 @@ async function assertNameIsFree(
   return nameKey;
 }
 
-export async function createEventSeries(input: { name: string }): Promise<EventSeries> {
+/** The seven maintained lists, which is the whole of what a copy takes from its source (US-22). */
+const BLANK_LISTS = {
+  events: [],
+  classOptions: [],
+  programs: [],
+  skillLevels: [],
+  seasonPassOptions: [],
+  busPickupPoints: [],
+  foodOptions: [],
+} satisfies Pick<EventSeries, EventSeriesListField>;
+
+type CreateEventSeries = {
+  name: string;
+  /** Answered on its own: a copy is no more a template for having come from one (US-22). */
+  isTemplate?: boolean;
+  /** Any series or template, archived ones included — which is what keeps archiving reversible. */
+  sourceId?: string | null;
+};
+
+/**
+ * Creating is one atomic write, whichever of the four combinations it is: a blank series, a
+ * series from a template, a series from last year's, or a template from a series (US-22).
+ *
+ * What a copy takes is the seven lists and the saved reports. What it never takes is the
+ * registrations, the archive state and the invitation link — a link that still pointed at the
+ * source would enrol students into the wrong series (US-23).
+ */
+export async function createEventSeries(input: CreateEventSeries): Promise<EventSeries> {
   const name = parseName(input.name);
+  const sourceId = input.sourceId ?? null;
 
   // A new event series goes to the end of the teacher's order (see Ordering).
   const position = (await adminDb.collection(COLLECTIONS.eventSeries).count().get()).data().count;
 
   return adminDb.runTransaction(async (transaction) => {
     const reference = adminDb.collection(COLLECTIONS.eventSeries).doc();
+
+    // Every read first: a transaction refuses one issued after its first write.
+    const source = sourceId === null ? null : await transaction.get(eventSeriesDoc(sourceId));
+    if (source !== null && !source.exists) {
+      throw new ServiceError(ErrorCode.NotFound, NO_SUCH_EVENT_SERIES);
+    }
+    const sourceReports =
+      source === null
+        ? null
+        : await transaction.get(adminDb.collection(savedReportPath(source.id)));
     const nameKey = await assertNameIsFree(transaction, { name });
 
-    // Blank rather than seeded: the application cannot know whether this is a Wintersportwoche or
-    // a Kulturwoche, and an empty list is simply a question the student is never asked (US-21).
+    // Blank where nothing was named as a source: the application cannot know whether this is a
+    // Wintersportwoche or a Kulturwoche, and an empty list is a question nobody is asked (US-21).
+    const lists =
+      source === null
+        ? BLANK_LISTS
+        : (eventSeriesSchema.parse({ id: source.id, ...source.data() }) as Pick<
+            EventSeries,
+            EventSeriesListField
+          >);
+
     const data = {
       name,
       nameKey,
-      isTemplate: false,
+      isTemplate: input.isTemplate ?? false,
       isArchived: false,
       isOpenToStudents: false,
       hasRegistrations: false,
       position,
-      events: [],
-      classOptions: [],
-      programs: [],
-      skillLevels: [],
-      seasonPassOptions: [],
-      busPickupPoints: [],
-      foodOptions: [],
+      events: lists.events,
+      classOptions: lists.classOptions,
+      programs: lists.programs,
+      skillLevels: lists.skillLevels,
+      seasonPassOptions: lists.seasonPassOptions,
+      busPickupPoints: lists.busPickupPoints,
+      foodOptions: lists.foodOptions,
     };
     transaction.set(reference, data);
+
+    // Pruned as they are copied rather than overlooked on opening, so a copied report is
+    // consistent with its own lists from the moment it exists (Q10).
+    for (const report of sourceReports?.docs ?? []) {
+      const parsed = savedReportSchema.safeParse({ id: report.id, ...report.data() });
+      if (!parsed.success) continue;
+
+      const { id: _id, filter, ...rest } = parsed.data;
+      transaction.set(adminDb.collection(savedReportPath(reference.id)).doc(), {
+        ...rest,
+        filter: prunedToLists(filter, data),
+      });
+    }
+
     return { id: reference.id, ...data };
   });
 }

--- a/src/lib/event-series/event-series-service.ts
+++ b/src/lib/event-series/event-series-service.ts
@@ -11,6 +11,7 @@ import { reorderCollection } from "@/lib/firebase/reorder";
 import {
   ARCHIVED_IS_READ_ONLY_HINT,
   LAST_TEMPLATE_HINT,
+  NO_SUCH_EVENT_SERIES,
 } from "@/lib/event-series/event-series-state";
 import { normalizeName } from "@/lib/firebase/name-key";
 import { savedReportPath } from "@/lib/report/saved-reports";
@@ -122,7 +123,7 @@ export async function updateEventSeries(
     const reference = eventSeriesDoc(id);
     const snapshot = await transaction.get(reference);
     if (!snapshot.exists) {
-      throw new ServiceError(ErrorCode.NotFound, "Diese Eventreihe gibt es nicht.");
+      throw new ServiceError(ErrorCode.NotFound, NO_SUCH_EVENT_SERIES);
     }
 
     const current = eventSeriesSchema.parse({ id, ...snapshot.data() });
@@ -234,7 +235,7 @@ export async function deleteEventSeries(id: string): Promise<void> {
   const reference = eventSeriesDoc(id);
   const snapshot = await reference.get();
   if (!snapshot.exists) {
-    throw new ServiceError(ErrorCode.NotFound, "Diese Eventreihe gibt es nicht.");
+    throw new ServiceError(ErrorCode.NotFound, NO_SUCH_EVENT_SERIES);
   }
 
   const eventSeries = eventSeriesSchema.parse({ id, ...snapshot.data() });

--- a/src/lib/event-series/event-series-service.ts
+++ b/src/lib/event-series/event-series-service.ts
@@ -26,6 +26,9 @@ import { eventSeriesSchema, type EventSeries } from "@/lib/schemas/event-series"
 
 const nameSchema = eventSeriesSchema.shape.name;
 
+/** A report as the document holds it — the id lives in the path, so a copy never carries one. */
+const storedSavedReportSchema = savedReportSchema.omit({ id: true });
+
 function parseName(value: string): string {
   const parsed = nameSchema.safeParse(value);
   if (!parsed.success) {
@@ -144,13 +147,12 @@ export async function createEventSeries(input: CreateEventSeries): Promise<Event
     // Pruned as they are copied rather than overlooked on opening, so a copied report is
     // consistent with its own lists from the moment it exists (Q10).
     for (const report of sourceReports?.docs ?? []) {
-      const parsed = savedReportSchema.safeParse({ id: report.id, ...report.data() });
+      const parsed = storedSavedReportSchema.safeParse(report.data());
       if (!parsed.success) continue;
 
-      const { id: _id, filter, ...rest } = parsed.data;
       transaction.set(adminDb.collection(savedReportPath(reference.id)).doc(), {
-        ...rest,
-        filter: prunedToLists(filter, data),
+        ...parsed.data,
+        filter: prunedToLists(parsed.data.filter, data),
       });
     }
 

--- a/src/lib/event-series/event-series-service.ts
+++ b/src/lib/event-series/event-series-service.ts
@@ -13,6 +13,7 @@ import {
   LAST_TEMPLATE_HINT,
 } from "@/lib/event-series/event-series-state";
 import { normalizeName } from "@/lib/firebase/name-key";
+import { savedReportPath } from "@/lib/report/saved-reports";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
 import { COLLECTIONS } from "@/lib/schemas/collections";
@@ -260,9 +261,22 @@ export async function deleteEventSeries(id: string): Promise<void> {
   // deleting it takes them along — there is nothing hanging off it to clean up separately.
   // The lists the series maintained, its events among them, are fields of the document itself
   // and go with it (US-21).
-  const operations: BatchOperation[] = registrationsSnapshot.docs.map(
-    (record) => (batch) => batch.delete(record.ref),
-  );
+  //
+  // The other two are named rather than implied. Firestore deletes no subcollection with its
+  // parent, so the saved reports have to be asked for; and a token names its series by a field
+  // rather than by its path, since a link carries the token and nothing else (US-23) — so a link
+  // left behind would go on resolving to a series that is not there.
+  const savedReportsSnapshot = await adminDb.collection(savedReportPath(id)).get();
+  const invitationsSnapshot = await adminDb
+    .collection(COLLECTIONS.invitations)
+    .where("eventSeriesId", "==", id)
+    .get();
+
+  const operations: BatchOperation[] = [
+    ...registrationsSnapshot.docs,
+    ...savedReportsSnapshot.docs,
+    ...invitationsSnapshot.docs,
+  ].map((doomed) => (batch) => batch.delete(doomed.ref));
   await commitInChunks(operations);
 
   await reference.delete();

--- a/src/lib/event-series/event-series-state.ts
+++ b/src/lib/event-series/event-series-state.ts
@@ -22,6 +22,9 @@ export const NO_EVENT_SERIES_HINT =
 export const ARCHIVED_IS_READ_ONLY_HINT =
   "Eine archivierte Eventreihe kann nicht bearbeitet werden. Bitte zuerst aus dem Archiv holen.";
 
+/** What every write refuses with when the series it names has been deleted meanwhile. */
+export const NO_SUCH_EVENT_SERIES = "Diese Eventreihe gibt es nicht.";
+
 /**
  * Why the last template stays. Everything a teacher sees is scoped to a selection, so a school
  * with no event series at all has a header offering nothing and a navigation bar pointing nowhere.

--- a/src/lib/filters/student-filter.test.ts
+++ b/src/lib/filters/student-filter.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/registration/answer-labels";
 import { REPORT_FIELD_TAGS } from "@/lib/report/report-fields";
 import { FOOD_OPTION_OTHER, FOOD_OPTION_OTHER_LABEL } from "@/lib/schemas/master-data";
+import { storedEventSeries } from "@/test/event-series";
 import {
   ATTENDANCE_VALUES,
   COMPLETENESS_VALUES,
@@ -27,6 +28,7 @@ import {
   filterSummary,
   hasNoTags,
   matchesFilter,
+  prunedToLists,
   sameFilter,
   scopeFilterToGroups,
   toggleTag,
@@ -557,6 +559,65 @@ describe("scopeFilterToGroups", () => {
     const filter = { ...withTags(["class", "3AHME"]), name: "Muster" };
 
     expect(scopeFilterToGroups(filter, GROUPS).name).toBe("Muster");
+  });
+});
+
+/**
+ * What a report copied into a new series keeps (US-22, Q10). Unlike the read-time scoping above,
+ * this is told which lists exist rather than which categories a view offers, so a category no
+ * list backs is never in question.
+ */
+describe("prunedToLists", () => {
+  const series = storedEventSeries({
+    events: ["Woche 1"],
+    classOptions: ["5AHIF"],
+    programs: [{ name: "Ski", requiredEquipment: [] }],
+    skillLevels: ["Profi"],
+    seasonPassOptions: ["Kein Skipass"],
+    busPickupPoints: ["HTL Dornbirn"],
+    foodOptions: ["Esse alles"],
+  });
+
+  it("keeps a tag the lists still offer", () => {
+    const filter = toggleTag(EMPTY_FILTER, "class", "5AHIF");
+
+    expect(prunedToLists(filter, series).tags.class).toEqual(["5AHIF"]);
+  });
+
+  it("drops a tag naming something the lists do not offer", () => {
+    const filter = toggleTag(EMPTY_FILTER, "class", "4AHIF");
+
+    expect(prunedToLists(filter, series).tags.class).toEqual([]);
+  });
+
+  it("reads a program by its name, which is what the tag holds", () => {
+    const filter = toggleTag(toggleTag(EMPTY_FILTER, "program", "Ski"), "program", "Rodeln");
+
+    expect(prunedToLists(filter, series).tags.program).toEqual(["Ski"]);
+  });
+
+  it("drops every tag of a list the copy left empty", () => {
+    const filter = toggleTag(EMPTY_FILTER, "skillLevel", "Profi");
+
+    expect(prunedToLists(filter, storedEventSeries()).tags.skillLevel).toEqual([]);
+  });
+
+  /** Attendance, gender, health and completeness are answers, not list entries. */
+  it("leaves a category no list backs alone", () => {
+    const filter = toggleTag(
+      toggleTag(EMPTY_FILTER, "attendance", ATTENDANCE_VALUES.attending),
+      "health",
+      HEALTH_VALUES.noted,
+    );
+
+    const pruned = prunedToLists(filter, storedEventSeries());
+
+    expect(pruned.tags.attendance).toEqual([ATTENDANCE_VALUES.attending]);
+    expect(pruned.tags.health).toEqual([HEALTH_VALUES.noted]);
+  });
+
+  it("leaves the name being searched for alone", () => {
+    expect(prunedToLists({ ...EMPTY_FILTER, name: "Muster" }, series).name).toBe("Muster");
   });
 });
 

--- a/src/lib/filters/student-filter.ts
+++ b/src/lib/filters/student-filter.ts
@@ -4,8 +4,13 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { z } from "zod";
-import { ANSWER_LABELS } from "@/lib/master-data/categories";
+import {
+  ANSWER_LABELS,
+  MASTER_DATA_CATEGORIES,
+  type EventSeriesListField,
+} from "@/lib/master-data/categories";
 import { snapshotValueSchema, type Gender } from "@/lib/schemas/common";
+import type { EventSeries } from "@/lib/schemas/event-series";
 import { FOOD_OPTION_OTHER, FOOD_OPTION_OTHER_LABEL } from "@/lib/schemas/master-data";
 import {
   ATTENDANCE_LABELS,
@@ -176,6 +181,34 @@ export function scopeFilterToGroups(
       }),
     ) as StudentFilter["tags"],
   };
+}
+
+/**
+ * The filter with every tag the given series' lists do not offer taken out.
+ *
+ * What a saved report keeps when it is copied into a new series (US-22, Q10). It differs from
+ * `scopeFilterToGroups` in what it is told: the lists themselves rather than the categories a
+ * view happens to offer, so a category no list backs — attendance, gender, health, completeness
+ * — is never in question and its tags always survive.
+ *
+ * Dropping at copy time rather than at read time is what keeps a copied report from opening as
+ * changed before anybody has changed anything: the report on screen would otherwise differ from
+ * the report as stored the very first time it was opened.
+ */
+export function prunedToLists(
+  filter: StudentFilter,
+  eventSeries: Pick<EventSeries, EventSeriesListField>,
+): StudentFilter {
+  const tags = { ...filter.tags };
+
+  for (const category of Object.values(MASTER_DATA_CATEGORIES)) {
+    const items: readonly (string | { name: string })[] = eventSeries[category.field];
+    const offered = new Set(items.map((item) => (typeof item === "string" ? item : item.name)));
+    const answer = category.usage.field;
+    tags[answer] = tags[answer].filter((value) => offered.has(value));
+  }
+
+  return { ...filter, tags };
 }
 
 /**

--- a/src/lib/invitations/invitation-service.ts
+++ b/src/lib/invitations/invitation-service.ts
@@ -9,6 +9,7 @@ import { adminDb } from "@/lib/firebase/admin";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
 import { COLLECTIONS } from "@/lib/schemas/collections";
+import { NO_SUCH_EVENT_SERIES } from "@/lib/event-series/event-series-state";
 import { eventSeriesSchema } from "@/lib/schemas/event-series";
 import { invitationSchema, type Invitation } from "@/lib/schemas/invitation";
 import { normalizeName } from "@/lib/firebase/name-key";
@@ -47,7 +48,7 @@ export async function createInvitation(
     const reference = adminDb.collection(COLLECTIONS.eventSeries).doc(eventSeriesId);
     const stored = await transaction.get(reference);
     if (!stored.exists) {
-      throw new ServiceError(ErrorCode.NotFound, "Diese Eventreihe gibt es nicht.");
+      throw new ServiceError(ErrorCode.NotFound, NO_SUCH_EVENT_SERIES);
     }
 
     const series = eventSeriesSchema.parse({ id: stored.id, ...stored.data() });

--- a/src/lib/master-data/categories.ts
+++ b/src/lib/master-data/categories.ts
@@ -5,6 +5,7 @@
  */
 import { z } from "zod";
 import type { EventSeries } from "@/lib/schemas/event-series";
+import { eventSeriesRoutes } from "@/lib/routes";
 
 /**
  * How an item is recognised as still in use (US-5 to US-10). A registration stores the name it
@@ -194,6 +195,12 @@ export function masterDataSections(eventSeriesId: string | null) {
       label: category.labels.title,
     })),
   ];
+}
+
+/** Where the section opens: its first category, the section itself having no view of its own. */
+export function firstMasterDataPath(eventSeriesId: string): string {
+  const [first] = Object.keys(MASTER_DATA_CATEGORIES);
+  return `${eventSeriesRoutes(eventSeriesId).masterData}/${first}`;
 }
 
 /**

--- a/src/lib/master-data/master-data-service.ts
+++ b/src/lib/master-data/master-data-service.ts
@@ -10,6 +10,7 @@ import { normalizeName } from "@/lib/firebase/name-key";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
 import { COLLECTIONS } from "@/lib/schemas/collections";
+import { NO_SUCH_EVENT_SERIES } from "@/lib/event-series/event-series-state";
 import { eventSeriesSchema, type EventSeries } from "@/lib/schemas/event-series";
 import {
   listItemNameSchema,
@@ -129,7 +130,7 @@ function eventSeriesDoc(eventSeriesId: string) {
 }
 
 function missing(): ServiceError {
-  return new ServiceError(ErrorCode.NotFound, "Diese Eventreihe gibt es nicht.");
+  return new ServiceError(ErrorCode.NotFound, NO_SUCH_EVENT_SERIES);
 }
 
 /**

--- a/src/lib/report/saved-report-service.test.ts
+++ b/src/lib/report/saved-report-service.test.ts
@@ -88,9 +88,9 @@ describe("createSavedReport", () => {
   it("keeps only the categories the report filters by, so a stray one cannot be stored", async () => {
     const filter = { ...selection, tags: { ...selection.tags, nonsense: ["x"] } } as never;
 
-    const saved = await createSavedReport({ name: "5AHIF", filter, fields: [] }, TEACHER);
+    const saved = await createSavedReport(SERIES, { name: "5AHIF", filter, fields: [] }, TEACHER);
 
-    expect(firestore.get("savedReports", saved.id)).toMatchObject({ filter: selection });
+    expect(firestore.get(PATH, saved.id)).toMatchObject({ filter: selection });
   });
 
   it("reads a category that did not exist yet as no restriction from it", async () => {
@@ -99,6 +99,7 @@ describe("createSavedReport", () => {
     );
 
     const saved = await createSavedReport(
+      SERIES,
       { name: "5AHIF", filter: { ...selection, tags } as never, fields: [] },
       TEACHER,
     );
@@ -110,27 +111,27 @@ describe("createSavedReport", () => {
 describe("updateSavedReport", () => {
   const replacement = { name: "5AHIF", filter: EMPTY_FILTER, fields: ["contact"] };
 
-  beforeEach(() => firestore.seed("savedReports", "r1", stored));
+  beforeEach(() => firestore.seed(PATH, "r1", stored));
 
   it("replaces the name and both selections at once, leaving the author as it was", async () => {
     const edit = { ...replacement, name: "5BHIF" };
 
-    const updated = await updateSavedReport("r1", edit);
+    const updated = await updateSavedReport(SERIES, "r1", edit);
 
     expect(updated).toEqual({ id: "r1", ...stored, ...edit });
-    expect(firestore.get("savedReports", "r1")).toEqual({ ...stored, ...edit });
+    expect(firestore.get(PATH, "r1")).toEqual({ ...stored, ...edit });
   });
 
   it("lets any teacher edit one, since saved reports are shared (US-13)", async () => {
-    await expect(updateSavedReport("r1", { ...replacement, name: "Alle" })).resolves.toMatchObject({
-      name: "Alle",
-    });
+    await expect(
+      updateSavedReport(SERIES, "r1", { ...replacement, name: "Alle" }),
+    ).resolves.toMatchObject({ name: "Alle" });
   });
 
   it("keeps only the categories the report filters by, so a stray one cannot be stored", async () => {
     const filter = { ...selection, tags: { ...selection.tags, nonsense: ["x"] } } as never;
 
-    const updated = await updateSavedReport("r1", { ...replacement, filter });
+    const updated = await updateSavedReport(SERIES, "r1", { ...replacement, filter });
 
     expect(updated.filter).toEqual(selection);
   });
@@ -138,51 +139,70 @@ describe("updateSavedReport", () => {
   it("refuses the author, which the session decides and no request may claim", async () => {
     const edit = { ...replacement, createdByUserId: "someone.else@htldornbirn.at" } as never;
 
-    await expect(updateSavedReport("r1", edit)).rejects.toBeInstanceOf(ServiceError);
-    expect(firestore.get("savedReports", "r1")).toEqual(stored);
+    await expect(updateSavedReport(SERIES, "r1", edit)).rejects.toBeInstanceOf(ServiceError);
+    expect(firestore.get(PATH, "r1")).toEqual(stored);
   });
 
   it("rejects a blank name", async () => {
-    await expect(updateSavedReport("r1", { ...replacement, name: " " })).rejects.toBeInstanceOf(
-      ServiceError,
-    );
-    expect(firestore.get("savedReports", "r1")).toMatchObject({ name: "5AHIF" });
+    await expect(
+      updateSavedReport(SERIES, "r1", { ...replacement, name: " " }),
+    ).rejects.toBeInstanceOf(ServiceError);
+    expect(firestore.get(PATH, "r1")).toMatchObject({ name: "5AHIF" });
   });
 
   it("reports a saved report that is not there rather than creating it", async () => {
-    await expect(updateSavedReport("gone", replacement)).rejects.toBeInstanceOf(ServiceError);
-    expect(firestore.count("savedReports")).toBe(1);
+    await expect(updateSavedReport(SERIES, "gone", replacement)).rejects.toBeInstanceOf(
+      ServiceError,
+    );
+    expect(firestore.count(PATH)).toBe(1);
+  });
+
+  /** The id is unique within its own row only, so the series has to decide which row that is. */
+  it("leaves a report of the same id in another series alone", async () => {
+    firestore.seed(savedReportPath("s2"), "r1", stored);
+
+    await updateSavedReport(SERIES, "r1", { ...replacement, name: "5BHIF" });
+
+    expect(firestore.get(savedReportPath("s2"), "r1")).toEqual(stored);
   });
 });
 
 describe("deleteSavedReport", () => {
-  beforeEach(() => firestore.seed("savedReports", "r1", stored));
+  beforeEach(() => firestore.seed(PATH, "r1", stored));
 
   it("removes it", async () => {
-    await deleteSavedReport("r1");
+    await deleteSavedReport(SERIES, "r1");
 
-    expect(firestore.count("savedReports")).toBe(0);
+    expect(firestore.count(PATH)).toBe(0);
   });
 
   it("reports one that is already gone", async () => {
-    await expect(deleteSavedReport("gone")).rejects.toBeInstanceOf(ServiceError);
+    await expect(deleteSavedReport(SERIES, "gone")).rejects.toBeInstanceOf(ServiceError);
+  });
+
+  it("leaves a report of the same id in another series alone", async () => {
+    firestore.seed(savedReportPath("s2"), "r1", stored);
+
+    await deleteSavedReport(SERIES, "r1");
+
+    expect(firestore.count(savedReportPath("s2"))).toBe(1);
   });
 });
 
 describe("reorderSavedReports", () => {
   beforeEach(() => {
-    firestore.seed("savedReports", "r1", { ...stored, position: 0 });
-    firestore.seed("savedReports", "r2", { ...stored, name: "5BHIF", position: 1 });
+    firestore.seed(PATH, "r1", { ...stored, position: 0 });
+    firestore.seed(PATH, "r2", { ...stored, name: "5BHIF", position: 1 });
   });
 
   it("renumbers the row from zero, in the order the tags were dropped into", async () => {
-    await reorderSavedReports(["r2", "r1"]);
+    await reorderSavedReports(SERIES, ["r2", "r1"]);
 
-    expect(firestore.get("savedReports", "r2")?.position).toBe(0);
-    expect(firestore.get("savedReports", "r1")?.position).toBe(1);
+    expect(firestore.get(PATH, "r2")?.position).toBe(0);
+    expect(firestore.get(PATH, "r1")?.position).toBe(1);
   });
 
   it("reports a report that is not there rather than renumbering around it", async () => {
-    await expect(reorderSavedReports(["r1", "gone"])).rejects.toBeInstanceOf(ServiceError);
+    await expect(reorderSavedReports(SERIES, ["r1", "gone"])).rejects.toBeInstanceOf(ServiceError);
   });
 });

--- a/src/lib/report/saved-report-service.test.ts
+++ b/src/lib/report/saved-report-service.test.ts
@@ -13,8 +13,11 @@ vi.mock("@/lib/firebase/admin", () => ({ adminDb: firestore }));
 
 const { createSavedReport, deleteSavedReport, reorderSavedReports, updateSavedReport } =
   await import("./saved-report-service");
+const { savedReportPath } = await import("./saved-reports");
 const { ServiceError } = await import("@/lib/service-error");
 
+const SERIES = "s1";
+const PATH = savedReportPath(SERIES);
 const TEACHER = "jane.doe@htldornbirn.at";
 const selection = toggleTag(EMPTY_FILTER, "class", "5AHIF");
 const FIELDS = ["class", "contact"];
@@ -31,17 +34,33 @@ beforeEach(() => firestore.reset());
 describe("createSavedReport", () => {
   it("stores both selections under its name, attributed to the teacher who saved it", async () => {
     const saved = await createSavedReport(
+      SERIES,
       { name: "5AHIF", filter: selection, fields: FIELDS },
       TEACHER,
     );
 
-    expect(firestore.get("savedReports", saved.id)).toEqual(stored);
+    expect(firestore.get(PATH, saved.id)).toEqual(stored);
+  });
+
+  /** Two series filter on lists of their own, so neither sees what the other saved (US-13). */
+  it("leaves another series' row alone", async () => {
+    firestore.seed(savedReportPath("s2"), "r1", stored);
+
+    const saved = await createSavedReport(
+      SERIES,
+      { name: "5BHIF", filter: selection, fields: [] },
+      TEACHER,
+    );
+
+    expect(saved.position).toBe(0);
+    expect(firestore.count(savedReportPath("s2"))).toBe(1);
   });
 
   it("puts the new report at the end of the row, where the button that made it stands", async () => {
-    firestore.seed("savedReports", "r1", stored);
+    firestore.seed(PATH, "r1", stored);
 
     const saved = await createSavedReport(
+      SERIES,
       { name: "5BHIF", filter: selection, fields: [] },
       TEACHER,
     );
@@ -51,6 +70,7 @@ describe("createSavedReport", () => {
 
   it("trims the name, so two teachers do not read the same report differently", async () => {
     const saved = await createSavedReport(
+      SERIES,
       { name: "  5AHIF  ", filter: selection, fields: [] },
       TEACHER,
     );
@@ -60,9 +80,9 @@ describe("createSavedReport", () => {
 
   it("rejects a blank name rather than storing a report nothing can be opened by", async () => {
     await expect(
-      createSavedReport({ name: "   ", filter: selection, fields: [] }, TEACHER),
+      createSavedReport(SERIES, { name: "   ", filter: selection, fields: [] }, TEACHER),
     ).rejects.toBeInstanceOf(ServiceError);
-    expect(firestore.count("savedReports")).toBe(0);
+    expect(firestore.count(PATH)).toBe(0);
   });
 
   it("keeps only the categories the report filters by, so a stray one cannot be stored", async () => {

--- a/src/lib/report/saved-report-service.test.ts
+++ b/src/lib/report/saved-report-service.test.ts
@@ -5,6 +5,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_FILTER, toggleTag } from "@/lib/filters/student-filter";
+import { storedEventSeries } from "@/test/event-series";
 import { FakeFirestore } from "@/test/fake-firestore";
 
 const firestore = new FakeFirestore();
@@ -29,7 +30,11 @@ const stored = {
   position: 0,
 };
 
-beforeEach(() => firestore.reset());
+beforeEach(() => {
+  firestore.reset();
+  firestore.seed("eventSeries", SERIES, storedEventSeries());
+  firestore.seed("eventSeries", "s2", storedEventSeries({ name: "Wintersportwoche 2027" }));
+});
 
 describe("createSavedReport", () => {
   it("stores both selections under its name, attributed to the teacher who saved it", async () => {
@@ -83,6 +88,17 @@ describe("createSavedReport", () => {
       createSavedReport(SERIES, { name: "   ", filter: selection, fields: [] }, TEACHER),
     ).rejects.toBeInstanceOf(ServiceError);
     expect(firestore.count(PATH)).toBe(0);
+  });
+
+  /**
+   * Firestore writes a subcollection under a document that is not there, so without this a save
+   * into a deleted series leaves a report nothing can reach and no delete will ever sweep.
+   */
+  it("refuses a series that is not there, rather than orphaning the report under it", async () => {
+    await expect(
+      createSavedReport("gone", { name: "5AHIF", filter: selection, fields: [] }, TEACHER),
+    ).rejects.toBeInstanceOf(ServiceError);
+    expect(firestore.count(savedReportPath("gone"))).toBe(0);
   });
 
   it("keeps only the categories the report filters by, so a stray one cannot be stored", async () => {

--- a/src/lib/report/saved-report-service.ts
+++ b/src/lib/report/saved-report-service.ts
@@ -8,7 +8,7 @@ import { adminDb } from "@/lib/firebase/admin";
 import { reorderCollection } from "@/lib/firebase/reorder";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
-import { COLLECTIONS } from "@/lib/schemas/collections";
+import { savedReportPath } from "@/lib/report/saved-reports";
 import {
   savedReportEditSchema,
   savedReportInputSchema,
@@ -18,16 +18,16 @@ import {
   type SavedReportInput,
 } from "@/lib/schemas/saved-report";
 
-function reportDoc(id: string) {
-  return adminDb.collection(COLLECTIONS.savedReports).doc(id);
+function reportDoc(eventSeriesId: string, id: string) {
+  return adminDb.collection(savedReportPath(eventSeriesId)).doc(id);
 }
 
 function reject(message: string): never {
   throw new ServiceError(ErrorCode.ValidationError, message);
 }
 
-async function readReport(id: string): Promise<SavedReport> {
-  const snapshot = await reportDoc(id).get();
+async function readReport(eventSeriesId: string, id: string): Promise<SavedReport> {
+  const snapshot = await reportDoc(eventSeriesId, id).get();
   if (!snapshot.exists) {
     throw new ServiceError(ErrorCode.NotFound, "Diesen Bericht gibt es nicht.");
   }
@@ -46,6 +46,7 @@ async function readReport(id: string): Promise<SavedReport> {
  * who may open, rename or remove it (US-13).
  */
 export async function createSavedReport(
+  eventSeriesId: string,
   input: SavedReportInput,
   createdByUserId: string,
 ): Promise<SavedReport> {
@@ -54,11 +55,12 @@ export async function createSavedReport(
     reject(parsed.error.issues[0]?.message ?? "Dieser Bericht lässt sich nicht speichern.");
   }
 
-  const reference = adminDb.collection(COLLECTIONS.savedReports).doc();
+  const row = adminDb.collection(savedReportPath(eventSeriesId));
+  const reference = row.doc();
   // A new report's tag goes to the end of the row, where the button that made it stands, and
   // stays there (see Ordering). Two simultaneous saves would tie, which the name tiebreak
   // absorbs and the next drop renumbers away.
-  const position = (await adminDb.collection(COLLECTIONS.savedReports).count().get()).data().count;
+  const position = (await row.count().get()).data().count;
   const data = { ...parsed.data, createdByUserId, position };
   await reference.set(data);
 
@@ -70,24 +72,31 @@ export async function createSavedReport(
  * write rather than two: the tag a teacher renames is the report they are looking at, and
  * storing the name without the selection is what left it reading as changed afterwards (US-13).
  */
-export async function updateSavedReport(id: string, input: SavedReportEdit): Promise<SavedReport> {
+export async function updateSavedReport(
+  eventSeriesId: string,
+  id: string,
+  input: SavedReportEdit,
+): Promise<SavedReport> {
   const parsed = savedReportEditSchema.safeParse(input);
   if (!parsed.success) {
     reject(parsed.error.issues[0]?.message ?? "Dieser Bericht lässt sich nicht speichern.");
   }
 
-  const current = await readReport(id);
+  const current = await readReport(eventSeriesId, id);
 
-  await reportDoc(id).update(parsed.data);
+  await reportDoc(eventSeriesId, id).update(parsed.data);
   return { ...current, ...parsed.data };
 }
 
-export async function deleteSavedReport(id: string): Promise<void> {
-  await readReport(id);
-  await reportDoc(id).delete();
+export async function deleteSavedReport(eventSeriesId: string, id: string): Promise<void> {
+  await readReport(eventSeriesId, id);
+  await reportDoc(eventSeriesId, id).delete();
 }
 
 /** Ordering changes nothing a report holds, so it is open to any teacher (see Ordering). */
-export async function reorderSavedReports(orderedIds: readonly string[]): Promise<void> {
-  await reorderCollection({ collection: COLLECTIONS.savedReports, orderedIds });
+export async function reorderSavedReports(
+  eventSeriesId: string,
+  orderedIds: readonly string[],
+): Promise<void> {
+  await reorderCollection({ collection: savedReportPath(eventSeriesId), orderedIds });
 }

--- a/src/lib/report/saved-report-service.ts
+++ b/src/lib/report/saved-report-service.ts
@@ -8,6 +8,8 @@ import { adminDb } from "@/lib/firebase/admin";
 import { reorderCollection } from "@/lib/firebase/reorder";
 import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
+import { NO_SUCH_EVENT_SERIES } from "@/lib/event-series/event-series-state";
+import { COLLECTIONS } from "@/lib/schemas/collections";
 import { savedReportPath } from "@/lib/report/saved-reports";
 import {
   savedReportEditSchema,
@@ -44,6 +46,10 @@ async function readReport(eventSeriesId: string, id: string): Promise<SavedRepor
  * is the session's and not the request's — the declarative write path stays closed (see
  * firestore.rules). They are shared among all teachers, so who saved one decides nothing about
  * who may open, rename or remove it (US-13).
+ *
+ * In a transaction that first reads the series, because Firestore writes a subcollection under a
+ * document that is not there: without the read, a save into a series deleted meanwhile would
+ * leave a report no teacher can reach and no delete will ever sweep.
  */
 export async function createSavedReport(
   eventSeriesId: string,
@@ -56,15 +62,23 @@ export async function createSavedReport(
   }
 
   const row = adminDb.collection(savedReportPath(eventSeriesId));
-  const reference = row.doc();
-  // A new report's tag goes to the end of the row, where the button that made it stands, and
-  // stays there (see Ordering). Two simultaneous saves would tie, which the name tiebreak
-  // absorbs and the next drop renumbers away.
-  const position = (await row.count().get()).data().count;
-  const data = { ...parsed.data, createdByUserId, position };
-  await reference.set(data);
 
-  return { id: reference.id, ...data };
+  return adminDb.runTransaction(async (transaction) => {
+    const series = await transaction.get(
+      adminDb.collection(COLLECTIONS.eventSeries).doc(eventSeriesId),
+    );
+    if (!series.exists) throw new ServiceError(ErrorCode.NotFound, NO_SUCH_EVENT_SERIES);
+
+    // A new report's tag goes to the end of the row, where the button that made it stands, and
+    // stays there (see Ordering). Counted in the transaction, so two saves cannot tie.
+    const existing = await transaction.get(row);
+
+    const reference = row.doc();
+    const data = { ...parsed.data, createdByUserId, position: existing.size };
+    transaction.set(reference, data);
+
+    return { id: reference.id, ...data };
+  });
 }
 
 /**

--- a/src/lib/report/saved-reports.test.ts
+++ b/src/lib/report/saved-reports.test.ts
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { describe, expect, it } from "vitest";
+import { savedReportPath } from "./saved-reports";
+
+describe("savedReportPath", () => {
+  it("puts a report beneath the event series it belongs to", () => {
+    expect(savedReportPath("s1")).toBe("eventSeries/s1/savedReports");
+  });
+
+  /** Two series filter on lists of their own, so a report of one is no report of the other. */
+  it("keeps each series' reports apart", () => {
+    expect(savedReportPath("s1")).not.toBe(savedReportPath("s2"));
+  });
+});

--- a/src/lib/report/saved-reports.ts
+++ b/src/lib/report/saved-reports.ts
@@ -4,7 +4,21 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { sameFilter } from "@/lib/filters/student-filter";
+import { COLLECTIONS } from "@/lib/schemas/collections";
 import type { ReportSelection, SavedReport } from "@/lib/schemas/saved-report";
+
+/**
+ * A saved report filters on the lists of one event series, so it lives beneath that series
+ * rather than beside it — which is what keeps a report of a Wintersportwoche out of a
+ * Kulturwoche's tag row, and what lets a copy take its source's reports along (US-22).
+ *
+ * Beneath rather than inside: a rule grants a whole document or none of it, and a student reads
+ * the event series document to be asked its questions (US-11). A field would hand them every
+ * report of every series; a subcollection has a rule of its own.
+ */
+export function savedReportPath(eventSeriesId: string): string {
+  return `${COLLECTIONS.eventSeries}/${eventSeriesId}/${COLLECTIONS.savedReports}`;
+}
 
 /** Which order the tags were pressed in is no part of what a report shows (US-13). */
 function sameFields(left: readonly string[], right: readonly string[]): boolean {

--- a/src/lib/report/use-saved-reports.test.ts
+++ b/src/lib/report/use-saved-reports.test.ts
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const onSnapshot = vi.fn();
+const onAuthStateChanged = vi.fn();
+const collection = vi.fn((_db: unknown, path: string) => path);
+
+vi.mock("firebase/firestore", () => ({
+  collection: (...args: [unknown, string]) => collection(...args),
+  query: vi.fn((...args: unknown[]) => args),
+  onSnapshot,
+}));
+
+vi.mock("firebase/auth", () => ({ onAuthStateChanged }));
+vi.mock("@/lib/firebase/client", () => ({ auth: {}, db: {} }));
+
+const { useSavedReports } = await import("./use-saved-reports");
+
+/** The hook waits for Firebase Auth, so a test has to announce a signed-in user first. */
+function signIn() {
+  act(() =>
+    (onAuthStateChanged.mock.calls.at(-1)![1] as (user: unknown) => void)({ uid: "uid-1" }),
+  );
+}
+
+describe("useSavedReports", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onSnapshot.mockReturnValue(() => {});
+    onAuthStateChanged.mockReturnValue(() => {});
+  });
+
+  /** A report filters on one series' lists, so another series' row is no part of this one. */
+  it("reads the row of the series it was given, and no other", () => {
+    renderHook(() => useSavedReports("s1"));
+    signIn();
+
+    expect(collection).toHaveBeenCalledWith({}, "eventSeries/s1/savedReports");
+  });
+
+  it("subscribes again when the selection moves to another series", () => {
+    const { rerender } = renderHook(({ id }) => useSavedReports(id), {
+      initialProps: { id: "s1" },
+    });
+    signIn();
+
+    rerender({ id: "s2" });
+    signIn();
+
+    expect(collection).toHaveBeenCalledWith({}, "eventSeries/s2/savedReports");
+  });
+});

--- a/src/lib/report/use-saved-reports.ts
+++ b/src/lib/report/use-saved-reports.ts
@@ -9,50 +9,47 @@ import { useEffect, useState } from "react";
 import { collection, query } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
 import { subscribeWithRecovery } from "@/lib/firebase/live-query";
-import { COLLECTIONS } from "@/lib/schemas/collections";
 import { byPosition } from "@/lib/schemas/position";
+import { savedReportPath } from "@/lib/report/saved-reports";
 import { savedReportSchema, type SavedReport } from "@/lib/schemas/saved-report";
 
 /**
- * Every saved report, live. They are shared among all teachers (US-13), so there is nothing to
- * scope the query by — and one teacher's save shows up in another's tag row without either of
- * them reloading.
+ * One event series' saved reports, live. They are shared among all teachers (US-13), so one
+ * teacher's save shows up in another's tag row without either of them reloading — but only in
+ * the series it was saved in, whose lists it filters on.
  *
  * In the order the tags were dragged into (see Ordering): a teacher puts the reports they open
  * every week at the front, which no alphabet would have guessed.
  */
-export function useSavedReports() {
+export function useSavedReports(eventSeriesId: string) {
   const [reports, setReports] = useState<SavedReport[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(
-    () =>
-      subscribeWithRecovery<SavedReport>({
-        label: COLLECTIONS.savedReports,
-        buildQuery: () => query(collection(db, COLLECTIONS.savedReports)),
-        parse: (id, data) => {
-          const parsed = savedReportSchema.safeParse({ id, ...data });
-          if (!parsed.success) {
-            console.error(
-              `${COLLECTIONS.savedReports}/${id} does not match the schema`,
-              parsed.error,
-            );
-            return null;
-          }
-          return parsed.data;
-        },
-        onData: (received) => {
-          setReports([...received].sort(byPosition));
-          setLoading(false);
-        },
-        onError: (message) => {
-          setError(message);
-          if (message !== null) setLoading(false);
-        },
-      }),
-    [],
-  );
+  useEffect(() => {
+    const path = savedReportPath(eventSeriesId);
+
+    return subscribeWithRecovery<SavedReport>({
+      label: path,
+      buildQuery: () => query(collection(db, path)),
+      parse: (id, data) => {
+        const parsed = savedReportSchema.safeParse({ id, ...data });
+        if (!parsed.success) {
+          console.error(`${path}/${id} does not match the schema`, parsed.error);
+          return null;
+        }
+        return parsed.data;
+      },
+      onData: (received) => {
+        setReports([...received].sort(byPosition));
+        setLoading(false);
+      },
+      onError: (message) => {
+        setError(message);
+        if (message !== null) setLoading(false);
+      },
+    });
+  }, [eventSeriesId]);
 
   return { reports, loading, error };
 }

--- a/src/lib/schemas/collections.ts
+++ b/src/lib/schemas/collections.ts
@@ -24,6 +24,13 @@ export const COLLECTIONS = {
    * It lives here instead, where no client may read anything, and is resolved server-side.
    */
   invitations: "invitations",
+  /**
+   * The saved reports (US-13, US-25), beneath the series whose lists they filter on. Beneath
+   * rather than in its document for the reason above: a rule grants a whole document, and any
+   * signed-in user may read an event series — so a field would hand every student every
+   * teacher's reports. Firestore deletes no subcollection with its parent, so removing a series
+   * has to name these as well.
+   */
   savedReports: "savedReports",
 } as const;
 

--- a/src/lib/schemas/user.ts
+++ b/src/lib/schemas/user.ts
@@ -16,6 +16,9 @@ export const userSchema = z.object({
   lastName: requiredText(100),
   email: z.email(),
   role: userRoleSchema,
+  // The Entra photo itself, as a data URL, rather than an address: Graph serves it to a bearer
+  // token, and the token belongs to the sign-in that fetched it. Absent for most accounts.
+  photo: z.string().nullish(),
 });
 export type User = z.infer<typeof userSchema>;
 


### PR DESCRIPTION
Slice 6 of `spec/refactoring-event-series.md`, plus the half of slice 3 that had
never landed.

## The gap this started from

Slice 3 was supposed to move the saved reports beside the lists they filter on.
Only its in-use half shipped (#109), so reports were still a top-level collection
shared by every series — a report saved against a Wintersportwoche appeared in a
Kulturwoche's tag row, filtering on lists that series had never offered. Slice 6
could not copy them, because there was nothing per series to copy.

## Q1 is answered the other way

The spec decided students may read the saved reports, since a report holds a
name, a filter and a set of field keys and nothing about any student. Two things
were wrong with that. The student view subscribes to the **whole** event series
collection, so it was never "the series they registered for" but every series in
the school. And a report name is free text a teacher writes for teachers, while
its filter says who is being looked at — by health flag, by completeness, by
class. Anonymous in content, teacher-only in intent.

So they live at `eventSeries/{id}/savedReports/{reportId}`, where a rule of their
own says `isTeacher()`. A subcollection costs nothing the field was bought for:
the copy stays atomic because a transaction spans collections, the tag row
already spent a subscription, and Q13's 1 MiB budget stops applying.

## Creating from a copy (US-22)

One dialog asks three things — name, kind, source — and answers them in one
write. All four combinations work, and the kind is answered on its own, so a copy
is no more a template for having come from one. Any series may be the source,
archived ones included, which is what stops archiving being a one-way door.

A copy takes the seven lists and the saved reports, each pruned as it is copied.
It takes no registrations, no archive state and no invitation link.

## Three leaks found on the way

- **Deleting a series never deleted its invitation links.** Pre-existing: a token
  names its series by a field, so nothing about the delete reached one. Each
  orphan went on resolving to a series that was not there.
- **Saving a report never checked its series existed.** Firestore writes a
  subcollection under a missing document, so a teacher with the page open when
  somebody else deleted the series could orphan a report a minute later. No race
  needed.
- **A write landing mid-delete outlived the sweep.** Closed by sweeping again
  after the document is gone, when nothing further can be written.

## Checked

- 1642 unit tests, 103 Security Rules tests against the emulator
- `tsc --noEmit`, `eslint`, `prettier --check`, 317 files licence-checked
- `check:production-build`: 657 built files, no trace of the fake login

## Not done

- The report view still offers every field, not only those its series asks for
- Slice 7 (removing a registration) and slice 8 (folding the spec back in)
