### PR TITLE
Let a teacher remove a registration

### DIFF
--- a/firestore-tests/registration.rules.test.ts
+++ b/firestore-tests/registration.rules.test.ts
@@ -163,6 +163,14 @@ describe("/eventSeries/{id}/registrations", () => {
       teacher().collection(REGISTRATIONS).doc(STUDENT_UPN).update({ class: "5BHIF" }),
     );
   });
+
+  /**
+   * A teacher may remove one (US-28), but through the handler: the mirror `hasRegistrations` is
+   * recomputed in the same transaction, which a rule cannot do.
+   */
+  it("denies a teacher deleting a record directly", async () => {
+    await assertFails(teacher().collection(REGISTRATIONS).doc(STUDENT_UPN).delete());
+  });
 });
 
 /**

--- a/src/app/api/event-series/[eventSeriesId]/registrations/[studentUpn]/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/registrations/[studentUpn]/route.test.ts
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getUserWithRole = vi.fn();
+const deleteRegistration = vi.fn();
+
+vi.mock("@/lib/auth/guards", () => ({ getUserWithRole: () => getUserWithRole() }));
+vi.mock("@/lib/registration/registration-service", () => ({
+  deleteRegistration: (...args: unknown[]) => deleteRegistration(...args),
+}));
+
+const { DELETE } = await import("./route");
+const { ServiceError } = await import("@/lib/service-error");
+const { ErrorCode } = await import("@/lib/errors");
+
+const TEACHER = "jane.doe@htldornbirn.at";
+const STUDENT = "max.mustermann@student.htldornbirn.at";
+
+const request = new Request("https://example.com/api/event-series/s1/registrations/max");
+const paramsFor = (studentUpn: string) => Promise.resolve({ eventSeriesId: "s1", studentUpn });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getUserWithRole.mockResolvedValue({ uid: "u1", email: TEACHER, role: "teacher" });
+  deleteRegistration.mockResolvedValue(undefined);
+});
+
+describe("DELETE /api/event-series/[eventSeriesId]/registrations/[studentUpn]", () => {
+  it("removes the registration the address names", async () => {
+    const response = await DELETE(request, { params: paramsFor(STUDENT) });
+
+    expect(response.status).toBe(204);
+    expect(deleteRegistration).toHaveBeenCalledWith("s1", STUDENT);
+  });
+
+  /** A UPN is an address, and an address in a path arrives encoded. */
+  it("decodes the student the path names", async () => {
+    await DELETE(request, { params: paramsFor(encodeURIComponent(STUDENT)) });
+
+    expect(deleteRegistration).toHaveBeenCalledWith("s1", STUDENT);
+  });
+
+  /** A student who is not coming answers "no" (US-11); removing one is a teacher's doing. */
+  it("refuses a student, and writes nothing", async () => {
+    getUserWithRole.mockResolvedValue({ uid: "u2", email: STUDENT, role: "student" });
+
+    const response = await DELETE(request, { params: paramsFor(STUDENT) });
+
+    expect(response.status).toBe(403);
+    expect(deleteRegistration).not.toHaveBeenCalled();
+  });
+
+  it("refuses a caller with no session at all", async () => {
+    getUserWithRole.mockResolvedValue(null);
+
+    const response = await DELETE(request, { params: paramsFor(STUDENT) });
+
+    expect(response.status).toBe(401);
+    expect(deleteRegistration).not.toHaveBeenCalled();
+  });
+
+  it("passes on what the service refused, and its wording", async () => {
+    deleteRegistration.mockRejectedValue(
+      new ServiceError(ErrorCode.Conflict, "Archiviert ist schreibgeschützt."),
+    );
+
+    const response = await DELETE(request, { params: paramsFor(STUDENT) });
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { message: "Archiviert ist schreibgeschützt." },
+    });
+  });
+});

--- a/src/app/api/event-series/[eventSeriesId]/registrations/[studentUpn]/route.ts
+++ b/src/app/api/event-series/[eventSeriesId]/registrations/[studentUpn]/route.ts
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { NextResponse } from "next/server";
+import { handleServiceFailure, requireTeacherOrResponse } from "@/lib/api/handler";
+import { deleteRegistration } from "@/lib/registration/registration-service";
+
+type Context = { params: Promise<{ eventSeriesId: string; studentUpn: string }> };
+
+/**
+ * Removes one registration (US-28). A teacher's doing and never a student's: a student who is
+ * not coming answers "no" (US-11), and this endpoint is closed to them by the guard.
+ */
+export async function DELETE(_request: Request, { params }: Context) {
+  const denied = await requireTeacherOrResponse();
+  if (denied) return denied;
+
+  const { eventSeriesId, studentUpn } = await params;
+
+  try {
+    await deleteRegistration(eventSeriesId, decodeURIComponent(studentUpn));
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    return handleServiceFailure(error, `Deleting registration ${studentUpn}`);
+  }
+}

--- a/src/components/overview/class-cards.test.tsx
+++ b/src/components/overview/class-cards.test.tsx
@@ -41,7 +41,7 @@ function student(overrides: Partial<Omit<RosterStudent, "record">> = {}): Roster
 
 const nameOf = (person: RosterStudent) => `${person.lastName} ${person.firstName}`;
 
-function setup(students: RosterStudent[] = []) {
+function setup(students: RosterStudent[] = [], removableEventSeriesId: string | null = null) {
   render(
     <ClassCards
       rows={classOverview(students, CLASSES, COLUMNS)}
@@ -50,6 +50,7 @@ function setup(students: RosterStudent[] = []) {
       columns={COLUMNS}
       filterGroups={FILTERS}
       invitations={null}
+      removableEventSeriesId={removableEventSeriesId}
       eventSeriesName="Wintersportwoche 2026"
     />,
   );
@@ -262,6 +263,7 @@ describe("ClassCards — a dimension with no list", () => {
         columns={columns}
         filterGroups={FILTERS}
         invitations={null}
+        removableEventSeriesId={null}
         eventSeriesName="Wintersportwoche 2026"
       />,
     );
@@ -333,6 +335,7 @@ describe("ClassCards — the invitation controls", () => {
         columns={COLUMNS}
         filterGroups={FILTERS}
         invitations={controls as never}
+        removableEventSeriesId={null}
         eventSeriesName="Wintersportwoche 2026"
       />,
     );
@@ -430,6 +433,7 @@ describe("ClassCards — showing a link as a QR code", () => {
         columns={COLUMNS}
         filterGroups={FILTERS}
         invitations={controls as never}
+        removableEventSeriesId={null}
         eventSeriesName="Wintersportwoche 2026"
       />,
     );
@@ -515,6 +519,7 @@ describe("ClassCards — regenerating asks first", () => {
         columns={COLUMNS}
         filterGroups={FILTERS}
         invitations={invitations as never}
+        removableEventSeriesId={null}
         eventSeriesName="Wintersportwoche 2026"
       />,
     );
@@ -562,5 +567,64 @@ describe("ClassCards — regenerating asks first", () => {
 
     expect(invitations.regenerate).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * A link names a class rather than a student (US-23), so one can reach somebody it was never
+ * meant for. The control follows the saved report tags (US-13): press a tag to mark it, and the
+ * controls appear on the marked one only, permanently rather than on a hover to be discovered.
+ */
+describe("ClassCards — removing a registration", () => {
+  const jane = student({ class: "5AHIF", firstName: "Jane", lastName: "Doe" });
+  const max = student({ class: "5AHIF", firstName: "Max", lastName: "Mustermann" });
+
+  const removeOn = (person: RosterStudent) =>
+    screen.queryByRole("button", { name: `Anmeldung von ${nameOf(person)} löschen` });
+
+  it("offers nothing until a student is marked", () => {
+    setup([jane, max], "s1");
+
+    expect(removeOn(jane)).not.toBeInTheDocument();
+    expect(removeOn(max)).not.toBeInTheDocument();
+  });
+
+  it("offers it on the marked student, and on no other", async () => {
+    setup([jane, max], "s1");
+
+    await userEvent.click(screen.getByRole("button", { name: nameOf(jane) }));
+
+    expect(removeOn(jane)).toBeInTheDocument();
+    expect(removeOn(max)).not.toBeInTheDocument();
+  });
+
+  it("marks one student at a time, since one is being acted on", async () => {
+    setup([jane, max], "s1");
+
+    await userEvent.click(screen.getByRole("button", { name: nameOf(jane) }));
+    await userEvent.click(screen.getByRole("button", { name: nameOf(max) }));
+
+    expect(removeOn(jane)).not.toBeInTheDocument();
+    expect(removeOn(max)).toBeInTheDocument();
+  });
+
+  /** Somebody else's work, so it is a dialog rather than the inline confirmation a report gets. */
+  it("asks in a dialog naming the student before anything is destroyed", async () => {
+    setup([jane], "s1");
+
+    await userEvent.click(screen.getByRole("button", { name: nameOf(jane) }));
+    await userEvent.click(removeOn(jane)!);
+
+    const dialog = within(screen.getByRole("dialog"));
+    expect(dialog.getByText(nameOf(jane))).toBeInTheDocument();
+  });
+
+  /** An archived series is read-only, and a template has no registrations to remove (US-19). */
+  it("offers nothing at all where the series cannot be written to", async () => {
+    setup([jane], null);
+
+    await userEvent.click(screen.getByRole("button", { name: nameOf(jane) }));
+
+    expect(removeOn(jane)).not.toBeInTheDocument();
   });
 });

--- a/src/components/overview/class-cards.tsx
+++ b/src/components/overview/class-cards.tsx
@@ -6,10 +6,12 @@
 "use client";
 
 import { useState } from "react";
-import { Copy, Link, QrCode } from "lucide-react";
+import { Copy, Link, QrCode, Trash2 } from "lucide-react";
 import { FilterTagList } from "@/components/filters/filter-tag-list";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeading, CardTitle } from "@/components/ui/card";
+import { Tag, TagAction, TagName } from "@/components/ui/tag";
+import { DeleteRegistrationDialog } from "@/components/overview/delete-registration-dialog";
 import { Dialog } from "@/components/ui/dialog";
 import { Tooltip } from "@/components/ui/tooltip";
 import { ApiRequestError } from "@/lib/api/client";
@@ -50,6 +52,8 @@ type ClassCardsProps = {
   columns: readonly SkillColumn[];
   filterGroups: readonly FilterGroup[];
   invitations: InvitationControls | null;
+  /** The series to remove a registration from, or null where it cannot be written to (US-28). */
+  removableEventSeriesId: string | null;
   /** Shown beside the class on the QR surface, so a projected code names what it enrols into. */
   eventSeriesName: string;
 };
@@ -66,6 +70,7 @@ export function ClassCards({
   columns,
   filterGroups,
   invitations,
+  removableEventSeriesId,
   eventSeriesName,
 }: ClassCardsProps) {
   // A card is one class already, so offering the class tags would only let it empty itself.
@@ -82,6 +87,7 @@ export function ClassCards({
           columns={columns}
           filterGroups={groups}
           invitations={invitations}
+          removableEventSeriesId={removableEventSeriesId}
           eventSeriesName={eventSeriesName}
         />
       ))}
@@ -96,6 +102,7 @@ function ClassCard({
   columns,
   filterGroups,
   invitations,
+  removableEventSeriesId,
   eventSeriesName,
 }: Omit<ClassCardsProps, "rows"> & { row: ClassGroup }) {
   const [expanded, setExpanded] = useState(true);
@@ -104,6 +111,9 @@ function ClassCard({
   const [linkError, setLinkError] = useState<string | null>(null);
   const [shownCode, setShownCode] = useState<string | null>(null);
   const [confirmingRegenerate, setConfirmingRegenerate] = useState(false);
+  // One across both clouds, because one student is being acted on at a time.
+  const [markedId, setMarkedId] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<RosterStudent | null>(null);
 
   const shown = filterStudents(row.students, filter);
   const figures = countFiltered ? classFigures(shown, columns) : row;
@@ -255,11 +265,17 @@ function ClassCard({
                   className={row.class}
                   label={ATTENDING_LABEL}
                   students={shown.filter((student) => student.isAttending)}
+                  markedId={markedId}
+                  onMark={setMarkedId}
+                  onRemove={removableEventSeriesId === null ? null : setRemoving}
                 />
                 <Cloud
                   className={row.class}
                   label={NOT_ATTENDING_LABEL}
                   students={shown.filter((student) => !student.isAttending)}
+                  markedId={markedId}
+                  onMark={setMarkedId}
+                  onRemove={removableEventSeriesId === null ? null : setRemoving}
                 />
               </div>
             </section>
@@ -291,6 +307,19 @@ function ClassCard({
             </section>
           </div>
         )}
+
+        {removing !== null && removableEventSeriesId !== null ? (
+          <DeleteRegistrationDialog
+            open
+            eventSeriesId={removableEventSeriesId}
+            student={removing}
+            onClose={() => setRemoving(null)}
+            onDeleted={() => {
+              setRemoving(null);
+              setMarkedId(null);
+            }}
+          />
+        ) : null}
       </CardContent>
     </Card>
   );
@@ -300,10 +329,17 @@ function Cloud({
   className,
   label,
   students,
+  markedId,
+  onMark,
+  onRemove,
 }: {
   className: string;
   label: string;
   students: readonly RosterStudent[];
+  markedId: string | null;
+  onMark: (id: string | null) => void;
+  /** Absent where the series cannot be written to, which is what takes the control away. */
+  onRemove: ((student: RosterStudent) => void) | null;
 }) {
   // A heading over an empty space would say a class answered nothing; the tally already does.
   if (students.length === 0) return null;
@@ -312,14 +348,26 @@ function Cloud({
     <div className="flex flex-col gap-1.5">
       <p className="text-muted-foreground text-xs font-medium">{label}</p>
       <ul aria-label={`${className}: ${label}`} className="flex flex-wrap gap-1.5">
-        {students.map((student) => (
-          <li
-            key={student.id}
-            className="border-border bg-background rounded-md border px-2 py-1 text-sm"
-          >
-            {`${student.lastName} ${student.firstName}`}
-          </li>
-        ))}
+        {students.map((student) => {
+          const name = `${student.lastName} ${student.firstName}`;
+          const marked = student.id === markedId;
+          return (
+            <li key={student.id}>
+              <Tag pressed={marked} variant="neutral">
+                <TagName label={name} onPress={() => onMark(marked ? null : student.id)} />
+                {/* On the marked tag only, as a saved report's controls are (US-13, US-28). */}
+                {marked && onRemove ? (
+                  <TagAction
+                    label={`Anmeldung von ${name} löschen`}
+                    onClick={() => onRemove(student)}
+                  >
+                    <Trash2 aria-hidden />
+                  </TagAction>
+                ) : null}
+              </Tag>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/components/overview/delete-registration-dialog.tsx
+++ b/src/components/overview/delete-registration-dialog.tsx
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+import * as React from "react";
+import { TriangleAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { apiRequest, ApiRequestError } from "@/lib/api/client";
+import type { RosterStudent } from "@/lib/students/roster";
+
+type DeleteRegistrationDialogProps = {
+  open: boolean;
+  eventSeriesId: string;
+  student: RosterStudent;
+  onClose: () => void;
+  onDeleted: () => void;
+};
+
+export const DELETE_REGISTRATION_TITLE = "Anmeldung löschen";
+
+/**
+ * A warning dialog per the Design Guidelines, for one record rather than a whole series (US-28).
+ *
+ * It does not ask for the name to be typed back, as deleting a series does (US-19): the name is
+ * already on the screen in front of the teacher, and one registration is not that much to undo.
+ * It is still a dialog rather than the inline confirmation a saved report gets, because what is
+ * destroyed is somebody else's work.
+ */
+export function DeleteRegistrationDialog({
+  open,
+  eventSeriesId,
+  student,
+  onClose,
+  onDeleted,
+}: DeleteRegistrationDialogProps) {
+  const [error, setError] = React.useState<string | null>(null);
+  const [deleting, setDeleting] = React.useState(false);
+
+  const name = `${student.lastName} ${student.firstName}`;
+
+  async function handleDelete() {
+    setDeleting(true);
+    setError(null);
+    try {
+      await apiRequest(
+        `/api/event-series/${eventSeriesId}/registrations/${encodeURIComponent(student.id)}`,
+        { method: "DELETE" },
+      );
+      onDeleted();
+    } catch (caught) {
+      setError(
+        caught instanceof ApiRequestError ? caught.message : "Das hat leider nicht geklappt.",
+      );
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      tone="destructive"
+      title={DELETE_REGISTRATION_TITLE}
+      onClose={onClose}
+      description={
+        <span className="flex gap-2">
+          <TriangleAlert aria-hidden className="text-destructive mt-0.5 size-4 shrink-0" />
+          <span>
+            Die Anmeldung von <strong className="text-foreground">{name}</strong> wird mit allen
+            Antworten gelöscht. Das kann nicht rückgängig gemacht werden.
+          </span>
+        </span>
+      }
+      footer={
+        <>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Abbrechen
+          </Button>
+          <Button type="button" variant="destructive" disabled={deleting} onClick={handleDelete}>
+            Löschen
+          </Button>
+        </>
+      }
+    >
+      {error ? (
+        <p role="alert" className="text-destructive text-sm">
+          {error}
+        </p>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/src/components/overview/overview-view.tsx
+++ b/src/components/overview/overview-view.tsx
@@ -50,6 +50,7 @@ export function OverviewView({ eventSeriesId }: { eventSeriesId: string }) {
           columns={columns}
           filterGroups={filterGroups}
           invitations={openable ? invitations : null}
+          removableEventSeriesId={openable ? eventSeriesId : null}
           eventSeriesName={eventSeries.name}
         />
       )}

--- a/src/components/report/field-tag-list.tsx
+++ b/src/components/report/field-tag-list.tsx
@@ -5,10 +5,12 @@
  */
 "use client";
 
-import { REPORT_FIELD_TAGS } from "@/lib/report/report-fields";
+import type { ReportFieldTag } from "@/lib/report/report-fields";
 import { Tag, TagName } from "@/components/ui/tag";
 
 type FieldTagListProps = {
+  /** What the series asks for, which is not every field there is (US-21). */
+  tags: readonly ReportFieldTag[];
   value: readonly string[];
   onChange: (next: string[]) => void;
 };
@@ -18,7 +20,7 @@ type FieldTagListProps = {
  * line, and never which students are listed. A tag standing for a group activates every field
  * in it at once.
  */
-export function FieldTagList({ value, onChange }: FieldTagListProps) {
+export function FieldTagList({ tags, value, onChange }: FieldTagListProps) {
   const toggle = (key: string) =>
     onChange(value.includes(key) ? value.filter((entry) => entry !== key) : [...value, key]);
 
@@ -29,7 +31,7 @@ export function FieldTagList({ value, onChange }: FieldTagListProps) {
       <Tag pressed={value.length === 0}>
         <TagName label="Keine" onPress={() => onChange([])} />
       </Tag>
-      {REPORT_FIELD_TAGS.map((tag) => (
+      {tags.map((tag) => (
         <Tag key={tag.key} pressed={value.includes(tag.key)}>
           <TagName
             // The row carries no heading, so each tag says which of the two rows it belongs to.

--- a/src/components/report/report-view.test.tsx
+++ b/src/components/report/report-view.test.tsx
@@ -73,6 +73,14 @@ const eventSeries = {
     isOpenToStudents: true,
     hasRegistrations: true,
     events: ["Woche 1"],
+    // The same lists the hooks below are mocked with: they are fields of this document, and it
+    // is the document the fields row asks what the series wants asking about (US-21).
+    classOptions: ["5AHIF", "5BHIF"],
+    programs: [{ name: "Ski", requiredEquipment: ["Ski", "Stöcke"] }],
+    skillLevels: ["Profi"],
+    seasonPassOptions: ["Keine"],
+    busPickupPoints: ["Dornbirn", "Bregenz"],
+    foodOptions: ["Alles", "Vegetarisch"],
   }),
 };
 
@@ -90,7 +98,7 @@ beforeEach(() => {
     return listOf("Profi");
   });
   usePrograms.mockReturnValue({
-    programs: [{ name: "Ski", requiredEquipment: [] }],
+    programs: [{ name: "Ski", requiredEquipment: ["Ski", "Stöcke"] }],
     loading: false,
     error: null,
   });

--- a/src/components/report/report-view.tsx
+++ b/src/components/report/report-view.tsx
@@ -11,7 +11,7 @@ import { apiRequest } from "@/lib/api/client";
 import { useBusyWhile } from "@/lib/api/busy";
 import { useEventSeriesRoster } from "@/lib/assignment/use-event-series-roster";
 import { EMPTY_FILTER, filterStudents, filterSummary, scopeFilterToGroups } from "@/lib/filters/student-filter"; // prettier-ignore
-import { offeredFieldTags, reportFieldsOf } from "@/lib/report/report-fields";
+import { fieldTagsFor, offeredFieldTags, reportFieldsOf } from "@/lib/report/report-fields";
 import {
   downloadReportPdf,
   downloadReportWorkbook,
@@ -75,11 +75,17 @@ export function ReportView({ eventSeriesId }: { eventSeriesId: string }) {
     [filter, activeFields],
   );
 
+  const offeredTags = useMemo(
+    () => (eventSeries === null ? [] : fieldTagsFor(eventSeries)),
+    [eventSeries],
+  );
+
   function openReport(saved: ReportSelection) {
     // What the lists no longer offer is dropped rather than silently restricting the report to
-    // nobody: a class renamed since the report was saved is a tag nothing can show or unpress.
+    // nobody: a class renamed since the report was saved is a tag nothing can show or unpress,
+    // and a list emptied since is a field that would print "keine Angabe" for everybody (US-21).
     setFilter(scopeFilterToGroups(saved.filter, filterGroups));
-    setActiveFields(offeredFieldTags(saved.fields));
+    setActiveFields(offeredFieldTags(saved.fields, offeredTags));
   }
 
   // Writes go through handlers because the author is the session's, not the request's (US-13);
@@ -217,7 +223,7 @@ export function ReportView({ eventSeriesId }: { eventSeriesId: string }) {
           <Card>
             <CardContent>
               <CardHeading>Datenfelder</CardHeading>
-              <FieldTagList value={activeFields} onChange={setActiveFields} />
+              <FieldTagList tags={offeredTags} value={activeFields} onChange={setActiveFields} />
             </CardContent>
           </Card>
 

--- a/src/components/report/report-view.tsx
+++ b/src/components/report/report-view.tsx
@@ -58,7 +58,7 @@ export function ReportView({ eventSeriesId }: { eventSeriesId: string }) {
       events: true,
     },
   );
-  const { reports: savedReports } = useSavedReports(eventSeriesId);
+  const { reports: savedReports } = useSavedReports(eventSeriesId, eventSeries);
   const [filter, setFilter] = useState(EMPTY_FILTER);
   const [activeFields, setActiveFields] = useState<string[]>([]);
   const [outputError, setOutputError] = useState<string | null>(null);

--- a/src/lib/assignment/use-event-series-roster.ts
+++ b/src/lib/assignment/use-event-series-roster.ts
@@ -101,7 +101,9 @@ export function useEventSeriesRoster(
         {
           attendance,
           completeness,
-          equipmentRental,
+          // Asked only where some program requires something, which is US-21 one step further off.
+          equipmentRental:
+            equipmentRental && programs.some((one) => one.requiredEquipment.length > 0),
           health,
           busPickupPoint: answerLists,
           seasonPassOption: answerLists,

--- a/src/lib/filters/student-filter.ts
+++ b/src/lib/filters/student-filter.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import {
   ANSWER_LABELS,
   MASTER_DATA_CATEGORIES,
+  rentsEquipment,
   type EventSeriesListField,
 } from "@/lib/master-data/categories";
 import { snapshotValueSchema, type Gender } from "@/lib/schemas/common";
@@ -189,7 +190,8 @@ export function scopeFilterToGroups(
  * What a saved report keeps when it is copied into a new series (US-22, Q10). It differs from
  * `scopeFilterToGroups` in what it is told: the lists themselves rather than the categories a
  * view happens to offer, so a category no list backs — attendance, gender, health, completeness
- * — is never in question and its tags always survive.
+ * — is never in question and its tags always survive. Renting is the exception among those: its
+ * list is the equipment the programs require, one step further off than the rest.
  *
  * Dropping at copy time rather than at read time is what keeps a copied report from opening as
  * changed before anybody has changed anything: the report on screen would otherwise differ from
@@ -207,6 +209,9 @@ export function prunedToLists(
     const answer = category.usage.field;
     tags[answer] = tags[answer].filter((value) => offered.has(value));
   }
+
+  // Renting has a list behind it too, one step further off: the equipment the programs require.
+  if (!rentsEquipment(eventSeries)) tags.equipmentRental = [];
 
   return { ...filter, tags };
 }

--- a/src/lib/master-data/categories.ts
+++ b/src/lib/master-data/categories.ts
@@ -164,6 +164,15 @@ export function questionsAsked(
 }
 
 /**
+ * Whether renting is asked at all. It is put to a student whose chosen program requires
+ * something, so a series where no program requires anything never puts the question — which
+ * makes it US-21's rule again, with the list one step further off than the other six.
+ */
+export function rentsEquipment(eventSeries: Pick<EventSeries, "programs">): boolean {
+  return eventSeries.programs.some((program) => program.requiredEquipment.length > 0);
+}
+
+/**
  * What each of those answers is called in German, keyed by the field that stores it. The form
  * asks for it, the report prints it, the filter offers it as a category and the completeness
  * check names it as still owed — one word rather than four that drift apart at the next rename.

--- a/src/lib/registration/registration-service.test.ts
+++ b/src/lib/registration/registration-service.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/lib/firebase/admin", () => ({
   adminDb: firestore,
 }));
 
-const { saveRegistration } = await import("./registration-service");
+const { saveRegistration, deleteRegistration } = await import("./registration-service");
 const { ANSWER_NO_LONGER_OFFERED_HINT, REGISTRATION_NOT_OPEN_HINT, registrationPath } =
   await import("./registration");
 const { FOOD_OPTION_OTHER } = await import("@/lib/schemas/master-data");
@@ -467,5 +467,102 @@ describe("saveRegistration", () => {
     expect(writes.mock.calls.map(([write]) => write.ref.path)).toEqual([
       `${REGISTRATIONS}/${STUDENT}`,
     ]);
+  });
+});
+
+/**
+ * A link names a class rather than a student (US-23), so it can reach somebody it was never meant
+ * for — and without this, one stray registration would stay in the series for good (US-28).
+ */
+describe("deleteRegistration", () => {
+  const OTHER = "max.mustermann@student.htldornbirn.at";
+
+  function seedRegistration(upn: string, eventSeriesId = "s1") {
+    firestore.seed(registrationPath(eventSeriesId), upn, {
+      firstName: "Jane",
+      lastName: "Doe",
+      email: upn,
+      class: "3AHME",
+      isAttendingSportsWeek: true,
+      isIncomplete: false,
+    });
+  }
+
+  it("removes the registration", async () => {
+    seedEventSeries("s1", { hasRegistrations: true });
+    seedRegistration(STUDENT);
+
+    await deleteRegistration("s1", STUDENT);
+
+    expect(firestore.get(REGISTRATIONS, STUDENT)).toBeUndefined();
+  });
+
+  /** The id is derived from the series and the student, so removing one frees it again (US-26). */
+  it("lets the same student register again afterwards", async () => {
+    seedEventSeries("s1", { hasRegistrations: true });
+    seedRegistration(STUDENT);
+
+    await deleteRegistration("s1", STUDENT);
+    await saveRegistration(target(), attending);
+
+    expect(firestore.get(REGISTRATIONS, STUDENT)).toMatchObject({ class: "3AHME" });
+  });
+
+  /** The first time the mirror has ever had to go down (Q5); it is what US-19's controls read. */
+  it("puts the mirror back to false when the last registration goes", async () => {
+    seedEventSeries("s1", { hasRegistrations: true });
+    seedRegistration(STUDENT);
+
+    await deleteRegistration("s1", STUDENT);
+
+    expect(firestore.get("eventSeries", "s1")).toMatchObject({ hasRegistrations: false });
+  });
+
+  it("leaves the mirror true while another registration remains", async () => {
+    seedEventSeries("s1", { hasRegistrations: true });
+    seedRegistration(STUDENT);
+    seedRegistration(OTHER);
+
+    await deleteRegistration("s1", STUDENT);
+
+    expect(firestore.get("eventSeries", "s1")).toMatchObject({ hasRegistrations: true });
+  });
+
+  /** One transaction, or the mirror could be recomputed from a count that has since changed. */
+  it("deletes and recomputes the mirror together", async () => {
+    seedEventSeries("s1", { hasRegistrations: true });
+    seedRegistration(STUDENT);
+
+    await deleteRegistration("s1", STUDENT);
+
+    expect(firestore.transactionCount).toBe(1);
+  });
+
+  /** Closing governs students only, so a teacher may still remove one from a closed series. */
+  it("removes one from a closed series", async () => {
+    seedEventSeries("s1", { hasRegistrations: true, isOpenToStudents: false });
+    seedRegistration(STUDENT);
+
+    await deleteRegistration("s1", STUDENT);
+
+    expect(firestore.get(REGISTRATIONS, STUDENT)).toBeUndefined();
+  });
+
+  it("refuses one in an archived series, which is read-only", async () => {
+    seedEventSeries("s1", { hasRegistrations: true, isArchived: true, isOpenToStudents: false });
+    seedRegistration(STUDENT);
+
+    await expect(deleteRegistration("s1", STUDENT)).rejects.toBeInstanceOf(ServiceError);
+    expect(firestore.get(REGISTRATIONS, STUDENT)).toBeDefined();
+  });
+
+  it("refuses one in a series that does not exist", async () => {
+    await expect(deleteRegistration("gone", STUDENT)).rejects.toBeInstanceOf(ServiceError);
+  });
+
+  it("refuses one that is not there, rather than reporting a deletion it did not make", async () => {
+    seedEventSeries("s1", { hasRegistrations: true });
+
+    await expect(deleteRegistration("s1", STUDENT)).rejects.toBeInstanceOf(ServiceError);
   });
 });

--- a/src/lib/registration/registration-service.ts
+++ b/src/lib/registration/registration-service.ts
@@ -19,6 +19,10 @@ import {
   type RegistrationInput,
 } from "@/lib/schemas/registration";
 import { userSchema } from "@/lib/schemas/user";
+import {
+  ARCHIVED_IS_READ_ONLY_HINT,
+  NO_SUCH_EVENT_SERIES,
+} from "@/lib/event-series/event-series-state";
 import { isRegistrationIncomplete } from "./completeness";
 import {
   ANSWER_NO_LONGER_OFFERED_HINT,
@@ -190,5 +194,42 @@ export async function saveRegistration(
     }
 
     return record;
+  });
+}
+
+export const NO_SUCH_REGISTRATION = "Diese Anmeldung gibt es nicht.";
+
+/**
+ * Removes one registration and everything the student answered with it (US-28).
+ *
+ * A teacher's doing, never a student's: a student who is not coming answers "no" (US-11), which
+ * keeps them in the figures. Closing governs students only, so a closed series still allows it;
+ * an archived one is read-only and does not.
+ *
+ * One transaction, because `hasRegistrations` is recomputed from what is left — the first time
+ * that mirror has ever had to go back down (Q5), and it is what US-19's archive and delete
+ * controls read.
+ */
+export async function deleteRegistration(eventSeriesId: string, studentUpn: string): Promise<void> {
+  const row = adminDb.collection(registrationPath(eventSeriesId));
+  const seriesRef = adminDb.collection(COLLECTIONS.eventSeries).doc(eventSeriesId);
+
+  await adminDb.runTransaction(async (transaction) => {
+    const series = await transaction.get(seriesRef);
+    if (!series.exists) throw new ServiceError(ErrorCode.NotFound, NO_SUCH_EVENT_SERIES);
+    if (series.data()?.isArchived === true) {
+      throw new ServiceError(ErrorCode.Conflict, ARCHIVED_IS_READ_ONLY_HINT);
+    }
+
+    const reference = row.doc(studentUpn);
+    const stored = await transaction.get(reference);
+    if (!stored.exists) throw new ServiceError(ErrorCode.NotFound, NO_SUCH_REGISTRATION);
+
+    // Read inside the transaction, so a registration arriving while this one is removed keeps the
+    // mirror true rather than being counted away by a stale total.
+    const remaining = await transaction.get(row);
+
+    transaction.delete(reference);
+    if (remaining.size <= 1) transaction.update(seriesRef, { hasRegistrations: false });
   });
 }

--- a/src/lib/report/report-fields.test.ts
+++ b/src/lib/report/report-fields.test.ts
@@ -9,7 +9,7 @@ import { EQUIPMENT_RENTAL_LABEL } from "@/lib/registration/answer-labels";
 import { FOOD_OPTION_OTHER } from "@/lib/schemas/master-data";
 import type { Registration } from "@/lib/schemas/registration";
 import { studentRecord } from "@/test/roster-student";
-import { NO_ANSWER, REPORT_FIELD_TAGS, reportFieldsOf } from "./report-fields";
+import { fieldTagsFor, NO_ANSWER, REPORT_FIELD_TAGS, reportFieldsOf } from "./report-fields";
 
 const keys = REPORT_FIELD_TAGS.map((tag) => tag.key);
 
@@ -189,5 +189,70 @@ describe("a field's value", () => {
 
   it("leaves the event unanswered while nobody has assigned them a week yet", () => {
     expect(lineFor("Event", studentRecord({ event: null }))).toBeNull();
+  });
+});
+
+/**
+ * An empty list is a question the student was never asked (US-21), so a tag for it would add a
+ * detail line reading "keine Angabe" for every student — noise wearing the shape of data.
+ */
+describe("fieldTagsFor", () => {
+  const lists = {
+    events: ["Woche 1"],
+    classOptions: ["5AHIF"],
+    programs: [{ name: "Ski", requiredEquipment: ["Ski"] }],
+    skillLevels: ["Profi"],
+    seasonPassOptions: ["Keine"],
+    busPickupPoints: ["HTL"],
+    foodOptions: ["Vegetarisch"],
+  };
+
+  const keysFor = (overrides: Partial<typeof lists> = {}) =>
+    fieldTagsFor({ ...lists, ...overrides }).map((tag) => tag.key);
+
+  it("offers every tag to a series that maintains every list", () => {
+    expect(keysFor()).toEqual(REPORT_FIELD_TAGS.map((tag) => tag.key));
+  });
+
+  it.each([
+    ["events", "event"],
+    ["classOptions", "class"],
+    ["programs", "program"],
+    ["skillLevels", "skillLevel"],
+    ["seasonPassOptions", "seasonPassOption"],
+    ["busPickupPoints", "busPickupPoint"],
+    ["foodOptions", "food"],
+  ])("drops the tag for %s once the list is empty", (list, key) => {
+    expect(keysFor({ [list]: [] })).not.toContain(key);
+  });
+
+  /** Renting is asked of a student whose program requires something; here none does. */
+  it("drops the rental tag where no program requires anything", () => {
+    expect(keysFor({ programs: [{ name: "Wandern", requiredEquipment: [] }] })).not.toContain(
+      "rentedEquipment",
+    );
+  });
+
+  /** Nothing has to be maintained for these to be put to a student, so nothing can take them away. */
+  it("keeps the tags no list backs, whatever the series maintains", () => {
+    const bare = keysFor({
+      events: [],
+      classOptions: [],
+      programs: [],
+      skillLevels: [],
+      seasonPassOptions: [],
+      busPickupPoints: [],
+      foodOptions: [],
+    });
+
+    expect(bare).toEqual([
+      "attendance",
+      "gender",
+      "dateOfBirth",
+      "contact",
+      "measurements",
+      "health",
+      "completeness",
+    ]);
   });
 });

--- a/src/lib/report/report-fields.ts
+++ b/src/lib/report/report-fields.ts
@@ -4,8 +4,15 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 
-import { ANSWER_LABELS } from "@/lib/master-data/categories";
+import {
+  ANSWER_LABELS,
+  questionsAsked,
+  rentsEquipment,
+  type AnswerField,
+  type EventSeriesListField,
+} from "@/lib/master-data/categories";
 import { FOOD_OPTION_OTHER, FOOD_OPTION_OTHER_LABEL } from "@/lib/schemas/master-data";
+import type { EventSeries } from "@/lib/schemas/event-series";
 import type { Registration } from "@/lib/schemas/registration";
 import {
   COMPLETENESS_LABELS,
@@ -37,7 +44,19 @@ export type ReportFieldTag = {
   key: string;
   label: string;
   fields: readonly ReportField[];
+  /**
+   * Whether the series asks what this reports on. Absent where nothing has to be maintained for
+   * the question to be put — a gender, a date of birth, a phone number — which is always.
+   */
+  offered?: (eventSeries: OfferedTo) => boolean;
 };
+
+/** What deciding which tags a series offers needs of it: its lists, and nothing else. */
+type OfferedTo = Pick<EventSeries, EventSeriesListField>;
+
+/** Offered where the list behind the answer has entries, which is the whole of US-21's rule. */
+const asksFor = (answerField: AnswerField) => (eventSeries: OfferedTo) =>
+  questionsAsked(eventSeries).has(answerField);
 
 /** Reformatted rather than passed through `Date`, whose ISO parsing is UTC and shifts the day. */
 function germanDate(iso: string): string {
@@ -74,9 +93,15 @@ const field = (key: string, label: string, valueOf: ReportField["valueOf"]): Rep
 });
 
 /** A tag standing for a single field, which is what all but the three groups below are. */
-const answer = (key: string, label: string, valueOf: ReportField["valueOf"]): ReportFieldTag => ({
+const answer = (
+  key: string,
+  label: string,
+  valueOf: ReportField["valueOf"],
+  offered?: ReportFieldTag["offered"],
+): ReportFieldTag => ({
   key,
   label,
+  offered,
   fields: [field(key, label, valueOf)],
 });
 
@@ -87,8 +112,8 @@ const answer = (key: string, label: string, valueOf: ReportField["valueOf"]): Re
  */
 export const REPORT_FIELD_TAGS: readonly ReportFieldTag[] = [
   answer("attendance", "Teilnahme", (record) => yesNo(record.isAttendingSportsWeek)),
-  answer("event", ANSWER_LABELS.event, (record) => record.event),
-  answer("class", ANSWER_LABELS.class, (record) => record.class),
+  answer("event", ANSWER_LABELS.event, (record) => record.event, asksFor("event")),
+  answer("class", ANSWER_LABELS.class, (record) => record.class, asksFor("class")),
   answer("gender", "Geschlecht", (record) =>
     record.gender === null ? null : GENDER_LABELS[record.gender],
   ),
@@ -109,10 +134,14 @@ export const REPORT_FIELD_TAGS: readonly ReportFieldTag[] = [
       ),
     ],
   },
-  answer("program", ANSWER_LABELS.program, (record) => record.program),
-  answer("rentedEquipment", EQUIPMENT_RENTAL_LABEL, (record) =>
-    // Nothing rented is an answer in itself, not a gap: the student was asked and said no.
-    record.rentedEquipment.length > 0 ? record.rentedEquipment.join(", ") : yesNo(false),
+  answer("program", ANSWER_LABELS.program, (record) => record.program, asksFor("program")),
+  answer(
+    "rentedEquipment",
+    EQUIPMENT_RENTAL_LABEL,
+    (record) =>
+      // Nothing rented is an answer in itself, not a gap: the student was asked and said no.
+      record.rentedEquipment.length > 0 ? record.rentedEquipment.join(", ") : yesNo(false),
+    rentsEquipment,
   ),
   // Next to the rental, which is what the shoe size and the height are asked for.
   {
@@ -124,10 +153,25 @@ export const REPORT_FIELD_TAGS: readonly ReportFieldTag[] = [
       field("shoeSize", "Schuhgröße", (record) => record.shoeSize),
     ],
   },
-  answer("skillLevel", ANSWER_LABELS.skillLevel, (record) => record.skillLevel),
-  answer("seasonPassOption", ANSWER_LABELS.seasonPassOption, (record) => record.seasonPassOption),
-  answer("busPickupPoint", ANSWER_LABELS.busPickupPoint, (record) => record.busPickupPoint),
-  answer("food", ANSWER_LABELS.foodOption, foodOf),
+  answer(
+    "skillLevel",
+    ANSWER_LABELS.skillLevel,
+    (record) => record.skillLevel,
+    asksFor("skillLevel"),
+  ),
+  answer(
+    "seasonPassOption",
+    ANSWER_LABELS.seasonPassOption,
+    (record) => record.seasonPassOption,
+    asksFor("seasonPassOption"),
+  ),
+  answer(
+    "busPickupPoint",
+    ANSWER_LABELS.busPickupPoint,
+    (record) => record.busPickupPoint,
+    asksFor("busPickupPoint"),
+  ),
+  answer("food", ANSWER_LABELS.foodOption, foodOf, asksFor("foodOption")),
   {
     key: "health",
     label: "Gesundheit",
@@ -157,8 +201,23 @@ export function reportFieldsOf(selected: readonly string[]): ReportField[] {
 /**
  * The same selection with the keys nothing offers any more taken out — in tags, not in the fields
  * a tag expands into, which is what the row is pressed by and what a saved report holds (US-13).
+ *
+ * What is on offer defaults to every tag there is, and is narrowed to one series' where a report
+ * is being applied to it: a list emptied since the report was saved takes its tag with it.
  */
-export function offeredFieldTags(selected: readonly string[]): string[] {
-  const offered = new Set(REPORT_FIELD_TAGS.map((tag) => tag.key));
+export function offeredFieldTags(
+  selected: readonly string[],
+  tags: readonly ReportFieldTag[] = REPORT_FIELD_TAGS,
+): string[] {
+  const offered = new Set(tags.map((tag) => tag.key));
   return selected.filter((key) => offered.has(key));
+}
+
+/**
+ * The tags this series offers: every one whose question it actually asks (US-21). A tag for a
+ * question nobody was asked would add a detail line reading "keine Angabe" for every student,
+ * which is noise wearing the shape of data.
+ */
+export function fieldTagsFor(eventSeries: OfferedTo): readonly ReportFieldTag[] {
+  return REPORT_FIELD_TAGS.filter((tag) => tag.offered === undefined || tag.offered(eventSeries));
 }

--- a/src/lib/report/saved-report-service.test.ts
+++ b/src/lib/report/saved-report-service.test.ts
@@ -32,8 +32,14 @@ const stored = {
 
 beforeEach(() => {
   firestore.reset();
-  firestore.seed("eventSeries", SERIES, storedEventSeries());
-  firestore.seed("eventSeries", "s2", storedEventSeries({ name: "Wintersportwoche 2027" }));
+  // A report is pruned to the lists its series maintains (US-21), so the series has to ask the
+  // question this one filters on.
+  firestore.seed("eventSeries", SERIES, storedEventSeries({ classOptions: ["5AHIF"] }));
+  firestore.seed(
+    "eventSeries",
+    "s2",
+    storedEventSeries({ name: "Wintersportwoche 2027", classOptions: ["5AHIF"] }),
+  );
 });
 
 describe("createSavedReport", () => {
@@ -220,5 +226,54 @@ describe("reorderSavedReports", () => {
 
   it("reports a report that is not there rather than renumbering around it", async () => {
     await expect(reorderSavedReports(SERIES, ["r1", "gone"])).rejects.toBeInstanceOf(ServiceError);
+  });
+});
+
+/**
+ * A report holds only what its series asks for (US-21). Emptying a list leaves the reports that
+ * filtered on it holding a tag nothing can show and a field that would print "keine Angabe" for
+ * every student — cleared out on the report's next write rather than by a cascade over every
+ * report of the series each time a teacher edits a list.
+ */
+describe("pruning a report to what its series asks for", () => {
+  const withoutClasses = { classOptions: [], programs: [] };
+
+  it("drops a tag for a list the series does not maintain", async () => {
+    firestore.seed("eventSeries", "bare", storedEventSeries({ name: "Kultur", ...withoutClasses }));
+
+    const saved = await createSavedReport(
+      "bare",
+      { name: "5AHIF", filter: selection, fields: FIELDS },
+      TEACHER,
+    );
+
+    expect(saved.filter.tags.class).toEqual([]);
+    expect(saved.fields).toEqual(["contact"]);
+  });
+
+  it("keeps what the series does maintain", async () => {
+    const saved = await createSavedReport(
+      SERIES,
+      { name: "5AHIF", filter: selection, fields: FIELDS },
+      TEACHER,
+    );
+
+    expect(saved.filter.tags.class).toEqual(["5AHIF"]);
+    expect(saved.fields).toEqual(FIELDS);
+  });
+
+  it("prunes on the next edit, which is where a report already holding one is repaired", async () => {
+    firestore.seed("eventSeries", "bare", storedEventSeries({ name: "Kultur", ...withoutClasses }));
+    firestore.seed(savedReportPath("bare"), "r1", { ...stored, position: 0 });
+
+    const edited = await updateSavedReport("bare", "r1", {
+      name: "5AHIF",
+      filter: selection,
+      fields: FIELDS,
+    });
+
+    expect(edited.filter.tags.class).toEqual([]);
+    expect(edited.fields).toEqual(["contact"]);
+    expect(firestore.get(savedReportPath("bare"), "r1")).toMatchObject({ fields: ["contact"] });
   });
 });

--- a/src/lib/report/saved-report-service.ts
+++ b/src/lib/report/saved-report-service.ts
@@ -10,7 +10,8 @@ import { ErrorCode } from "@/lib/errors";
 import { ServiceError } from "@/lib/service-error";
 import { NO_SUCH_EVENT_SERIES } from "@/lib/event-series/event-series-state";
 import { COLLECTIONS } from "@/lib/schemas/collections";
-import { savedReportPath } from "@/lib/report/saved-reports";
+import { eventSeriesSchema } from "@/lib/schemas/event-series";
+import { prunedSelection, savedReportPath } from "@/lib/report/saved-reports";
 import {
   savedReportEditSchema,
   savedReportInputSchema,
@@ -19,6 +20,13 @@ import {
   type SavedReportEdit,
   type SavedReportInput,
 } from "@/lib/schemas/saved-report";
+
+import type { DocumentSnapshot } from "firebase-admin/firestore";
+
+/** The lists a report is pruned against, parsed so a series stored before a field existed reads. */
+function listsOf(series: DocumentSnapshot) {
+  return eventSeriesSchema.parse({ id: series.id, ...series.data() });
+}
 
 function reportDoc(eventSeriesId: string, id: string) {
   return adminDb.collection(savedReportPath(eventSeriesId)).doc(id);
@@ -74,7 +82,11 @@ export async function createSavedReport(
     const existing = await transaction.get(row);
 
     const reference = row.doc();
-    const data = { ...parsed.data, createdByUserId, position: existing.size };
+    const data = {
+      ...prunedSelection(parsed.data, listsOf(series)),
+      createdByUserId,
+      position: existing.size,
+    };
     transaction.set(reference, data);
 
     return { id: reference.id, ...data };
@@ -85,6 +97,11 @@ export async function createSavedReport(
  * An edit replaces everything a teacher may change. Renaming and bringing up to date are one
  * write rather than two: the tag a teacher renames is the report they are looking at, and
  * storing the name without the selection is what left it reading as changed afterwards (US-13).
+ *
+ * The selection is pruned to the series as it now stands (US-21). A list emptied since the report
+ * was saved leaves a tag nothing can show and a field that would print "keine Angabe" for every
+ * student, and this is where that is cleared out: on the next write of the report, rather than by
+ * a cascade over every report each time a teacher edits a list.
  */
 export async function updateSavedReport(
   eventSeriesId: string,
@@ -97,9 +114,13 @@ export async function updateSavedReport(
   }
 
   const current = await readReport(eventSeriesId, id);
+  const series = await adminDb.collection(COLLECTIONS.eventSeries).doc(eventSeriesId).get();
+  if (!series.exists) throw new ServiceError(ErrorCode.NotFound, NO_SUCH_EVENT_SERIES);
 
-  await reportDoc(eventSeriesId, id).update(parsed.data);
-  return { ...current, ...parsed.data };
+  const edit = prunedSelection(parsed.data, listsOf(series));
+
+  await reportDoc(eventSeriesId, id).update(edit);
+  return { ...current, ...edit };
 }
 
 export async function deleteSavedReport(eventSeriesId: string, id: string): Promise<void> {

--- a/src/lib/report/saved-reports.ts
+++ b/src/lib/report/saved-reports.ts
@@ -3,8 +3,11 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { sameFilter } from "@/lib/filters/student-filter";
+import { prunedToLists, sameFilter } from "@/lib/filters/student-filter";
+import { fieldTagsFor } from "@/lib/report/report-fields";
+import type { AnswerField, EventSeriesListField } from "@/lib/master-data/categories";
 import { COLLECTIONS } from "@/lib/schemas/collections";
+import type { EventSeries } from "@/lib/schemas/event-series";
 import type { ReportSelection, SavedReport } from "@/lib/schemas/saved-report";
 
 /**
@@ -24,6 +27,54 @@ export function savedReportPath(eventSeriesId: string): string {
 function sameFields(left: readonly string[], right: readonly string[]): boolean {
   const chosen = new Set(left);
   return chosen.size === new Set(right).size && right.every((key) => chosen.has(key));
+}
+
+/**
+ * A saved report holding only what its series still asks for (US-21). A list a teacher has since
+ * emptied takes its tags and its field with it: the report would otherwise filter on an answer
+ * nobody can give any more, and print a line reading "keine Angabe" for every student.
+ */
+export function prunedSelection<T extends ReportSelection>(
+  selection: T,
+  eventSeries: Pick<EventSeries, EventSeriesListField>,
+): T {
+  const offered = new Set(fieldTagsFor(eventSeries).map((tag) => tag.key));
+
+  return {
+    ...selection,
+    filter: prunedToLists(selection.filter, eventSeries),
+    fields: selection.fields.filter((key) => offered.has(key)),
+  };
+}
+
+/** What one list edit was: which answer it is behind, and what it renamed while it was there. */
+export type ListEdit = {
+  answer: AnswerField;
+  renamed: ReadonlyMap<string, string>;
+};
+
+/**
+ * A saved report as one edit of one list leaves it, written back in the same transaction as the
+ * edit itself (US-13, US-21) — so what a report holds is true of its series at rest, and no
+ * reader has to prune what it was given.
+ *
+ * A renamed value is carried across rather than dropped: the teacher renamed a class, they did
+ * not stop wanting to see it. A removed one goes, along with the field for a list that is now
+ * empty. The rename is scoped to the answer the edited list is behind, so a program and a class
+ * that happen to share a name do not rename each other.
+ */
+export function afterListEdit<T extends ReportSelection>(
+  selection: T,
+  eventSeries: Pick<EventSeries, EventSeriesListField>,
+  { answer, renamed }: ListEdit,
+): T {
+  const chosen = selection.filter.tags[answer];
+  const carried = { ...selection.filter.tags, [answer]: chosen.map((v) => renamed.get(v) ?? v) };
+
+  return prunedSelection(
+    { ...selection, filter: { ...selection.filter, tags: carried } },
+    eventSeries,
+  );
 }
 
 /** Whether a saved report is what the page currently shows, both selections at once (US-13). */

--- a/src/lib/report/use-saved-reports.test.ts
+++ b/src/lib/report/use-saved-reports.test.ts
@@ -19,7 +19,17 @@ vi.mock("firebase/firestore", () => ({
 vi.mock("firebase/auth", () => ({ onAuthStateChanged }));
 vi.mock("@/lib/firebase/client", () => ({ auth: {}, db: {} }));
 
+const apiRequest = vi.fn();
+vi.mock("@/lib/api/client", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  apiRequest: (...args: unknown[]) => apiRequest(...args),
+}));
+
 const { useSavedReports } = await import("./use-saved-reports");
+const { storedEventSeries } = await import("@/test/event-series");
+const { EMPTY_FILTER } = await import("@/lib/filters/student-filter");
+
+const LISTS = storedEventSeries({ name: "Wintersportwoche", classOptions: ["5AHIF"] });
 
 /** The hook waits for Firebase Auth, so a test has to announce a signed-in user first. */
 function signIn() {
@@ -31,20 +41,21 @@ function signIn() {
 describe("useSavedReports", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    apiRequest.mockResolvedValue(undefined);
     onSnapshot.mockReturnValue(() => {});
     onAuthStateChanged.mockReturnValue(() => {});
   });
 
   /** A report filters on one series' lists, so another series' row is no part of this one. */
   it("reads the row of the series it was given, and no other", () => {
-    renderHook(() => useSavedReports("s1"));
+    renderHook(() => useSavedReports("s1", LISTS));
     signIn();
 
     expect(collection).toHaveBeenCalledWith({}, "eventSeries/s1/savedReports");
   });
 
   it("subscribes again when the selection moves to another series", () => {
-    const { rerender } = renderHook(({ id }) => useSavedReports(id), {
+    const { rerender } = renderHook(({ id }) => useSavedReports(id, LISTS), {
       initialProps: { id: "s1" },
     });
     signIn();
@@ -53,5 +64,86 @@ describe("useSavedReports", () => {
     signIn();
 
     expect(collection).toHaveBeenCalledWith({}, "eventSeries/s2/savedReports");
+  });
+});
+
+type Doc = { id: string; data: () => Record<string, unknown> };
+
+function deliver(...reports: { id: string; data: Record<string, unknown> }[]) {
+  const docs: Doc[] = reports.map(({ id, data }) => ({ id, data: () => data }));
+  act(() => (onSnapshot.mock.calls.at(-1)![1] as (snapshot: { docs: Doc[] }) => void)({ docs }));
+}
+
+const report = (tags: string[], fields: string[]) => ({
+  id: "r1",
+  data: {
+    name: "5AHIF",
+    filter: { ...EMPTY_FILTER, tags: { ...EMPTY_FILTER.tags, class: tags } },
+    fields,
+    createdByUserId: "jane.doe@htldornbirn.at",
+    position: 0,
+  },
+});
+
+/**
+ * A list emptied since a report was saved leaves it holding a tag nothing can show (US-21). It is
+ * pruned where it is read, and written back so that it is stored as it is shown.
+ */
+describe("useSavedReports — repairing what it prunes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiRequest.mockResolvedValue(undefined);
+    onSnapshot.mockReturnValue(() => {});
+    onAuthStateChanged.mockReturnValue(() => {});
+  });
+
+  it("hands out the report pruned to the lists the series maintains", () => {
+    const { result } = renderHook(() => useSavedReports("s1", LISTS));
+    signIn();
+    deliver(report(["5AHIF", "5BHIF"], ["class", "program"]));
+
+    expect(result.current.reports[0].filter.tags.class).toEqual(["5AHIF"]);
+    expect(result.current.reports[0].fields).toEqual(["class"]);
+  });
+
+  it("writes the pruned report back, so the store says what the row shows", async () => {
+    renderHook(() => useSavedReports("s1", LISTS));
+    signIn();
+    deliver(report(["5AHIF", "5BHIF"], ["class", "program"]));
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      "/api/event-series/s1/saved-reports/r1",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+    const [, options] = apiRequest.mock.calls[0] as [string, { body: { fields: string[] } }];
+    expect(options.body.fields).toEqual(["class"]);
+  });
+
+  it("leaves a report the series still asks for alone", () => {
+    renderHook(() => useSavedReports("s1", LISTS));
+    signIn();
+    deliver(report(["5AHIF"], ["class"]));
+
+    expect(apiRequest).not.toHaveBeenCalled();
+  });
+
+  /** The repaired report comes back equal to its own pruned form, which is what ends the round. */
+  it("repairs a report once, however often the row arrives again", () => {
+    renderHook(() => useSavedReports("s1", LISTS));
+    signIn();
+    deliver(report(["5AHIF", "5BHIF"], ["class"]));
+    deliver(report(["5AHIF", "5BHIF"], ["class"]));
+
+    expect(apiRequest).toHaveBeenCalledTimes(1);
+  });
+
+  /** Without the series there is nothing to prune against, so nothing is touched. */
+  it("prunes nothing while the series has not arrived", () => {
+    const { result } = renderHook(() => useSavedReports("s1", null));
+    signIn();
+    deliver(report(["5AHIF", "5BHIF"], ["class", "program"]));
+
+    expect(result.current.reports[0].fields).toEqual(["class", "program"]);
+    expect(apiRequest).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/report/use-saved-reports.ts
+++ b/src/lib/report/use-saved-reports.ts
@@ -5,23 +5,34 @@
  */
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { collection, query } from "firebase/firestore";
+import { apiRequest } from "@/lib/api/client";
 import { db } from "@/lib/firebase/client";
 import { subscribeWithRecovery } from "@/lib/firebase/live-query";
+import type { EventSeriesListField } from "@/lib/master-data/categories";
 import { byPosition } from "@/lib/schemas/position";
-import { savedReportPath } from "@/lib/report/saved-reports";
+import { prunedSelection, sameSelection, savedReportPath } from "@/lib/report/saved-reports";
+import type { EventSeries } from "@/lib/schemas/event-series";
 import { savedReportSchema, type SavedReport } from "@/lib/schemas/saved-report";
+
+type Lists = Pick<EventSeries, EventSeriesListField>;
 
 /**
  * One event series' saved reports, live. They are shared among all teachers (US-13), so one
  * teacher's save shows up in another's tag row without either of them reloading — but only in
  * the series it was saved in, whose lists it filters on.
  *
+ * Each is pruned to what that series still asks for (US-21), and a report that had to be pruned
+ * is written back so that it is stored as it is shown. A list emptied since a report was saved
+ * leaves it holding a tag nothing can show and a field that would print "keine Angabe" for every
+ * student; repairing it here rather than by cascading from the master data keeps a list edit one
+ * write, and repairing it rather than only hiding it keeps the store honest.
+ *
  * In the order the tags were dragged into (see Ordering): a teacher puts the reports they open
  * every week at the front, which no alphabet would have guessed.
  */
-export function useSavedReports(eventSeriesId: string) {
+export function useSavedReports(eventSeriesId: string, eventSeries: Lists | null) {
   const [reports, setReports] = useState<SavedReport[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -51,5 +62,54 @@ export function useSavedReports(eventSeriesId: string) {
     });
   }, [eventSeriesId]);
 
-  return { reports, loading, error };
+  const pruned = useMemo(
+    () =>
+      eventSeries === null ? reports : reports.map((one) => prunedSelection(one, eventSeries)),
+    [reports, eventSeries],
+  );
+
+  useRepair(eventSeriesId, reports, pruned);
+
+  return { reports: pruned, loading, error };
+}
+
+/**
+ * Writes back what pruning changed. Through the handler, because the declarative write path is
+ * closed to a browser (see firestore.rules) — and once, because the repaired report comes back
+ * through the subscription equal to its own pruned form, which is what ends the round.
+ *
+ * Every teacher looking at the same series will try it. The write is the same write, so the last
+ * one wins with the value all of them computed; the attempted ids are remembered only to keep
+ * one tab from sending it twice while the first is still out.
+ */
+function useRepair(
+  eventSeriesId: string,
+  stored: readonly SavedReport[],
+  pruned: readonly SavedReport[],
+) {
+  const attempted = useRef(new Set<string>());
+
+  useEffect(() => {
+    attempted.current = new Set();
+  }, [eventSeriesId]);
+
+  useEffect(() => {
+    for (const [index, report] of pruned.entries()) {
+      const before = stored[index];
+      if (before === undefined || sameSelection(before, report)) continue;
+      if (attempted.current.has(report.id)) continue;
+
+      attempted.current.add(report.id);
+      const url = `/api/event-series/${encodeURIComponent(eventSeriesId)}/saved-reports/${encodeURIComponent(report.id)}`;
+      void apiRequest(url, {
+        method: "PATCH",
+        body: { name: report.name, filter: report.filter, fields: report.fields },
+      }).catch((caught: unknown) => {
+        // A repair nobody asked for says nothing when it fails: the report still reads correctly,
+        // it is only still stored wrong, and the next reader will try again.
+        console.error(`Repairing saved report ${report.id} failed`, caught);
+        attempted.current.delete(report.id);
+      });
+    }
+  }, [eventSeriesId, stored, pruned]);
 }


### PR DESCRIPTION
Let a teacher remove a registration

An invitation names a class rather than a student (US-23), so a link can
be forwarded, pasted into a group chat, or used by somebody it was never
meant for. Without a way out one stray registration is permanent.

It is done from the overview, which lists every registered student of
the series, attending and not — the board would never show a wrongly
registered student who answered "no". The control lives on the student's
own tag and follows the saved report tags: press a tag to mark it, and
the controls appear on the marked one only.

Deleting asks in a warning dialog naming the student. It does not ask
for the name to be typed back, as deleting a whole series does: this is
one record and its name is already on the screen. It is still a dialog
rather than the inline confirmation a teacher's own saved report gets,
because what is destroyed is somebody else's work.

`hasRegistrations` is recomputed in the same transaction, which is the
first time that mirror has ever had to go back down — and it is what the
archive and delete controls read. The count is read inside the
transaction, so a registration arriving while this one goes keeps the
mirror true rather than being counted away by a stale total.

A student cannot do this: one who is not coming answers "no", which
keeps their answers and keeps them in the figures. Nor can a teacher do
it directly from the client — the rules deny every write to a
registration, and a new rules test says so for a delete.
