### PR TITLE
Report every request busy, and freeze the controls until it answers

### DIFF
--- a/src/components/assignment/assignment-board.test.tsx
+++ b/src/components/assignment/assignment-board.test.tsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { assignmentGroups, skillColumns } from "@/lib/assignment/statistics";
@@ -344,5 +344,47 @@ describe("AssignmentBoard — what the figures count", () => {
     await userEvent.click(toggleIn("Nicht zugeteilt"));
 
     expect(toggleIn("Montafon")).not.toBeChecked();
+  });
+});
+
+/**
+ * Four pixels of movement is enough for the sensor to call a press a drag, and it then swallows
+ * the click that would have followed. Picking happens on the way down and un-picking on the way
+ * up, so neither depends on a click arriving.
+ */
+describe("AssignmentBoard — picking a student without a click", () => {
+  const rowFor = (name: string) => card("Nicht zugeteilt").getByRole("button", { name });
+
+  it("picks a student on the press, before any click", () => {
+    setup();
+    const row = rowFor("Muster Anna");
+
+    fireEvent.pointerDown(row);
+
+    expect(row).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("un-picks on the release, which arrives even where the click does not", () => {
+    setup();
+    const row = rowFor("Muster Anna");
+
+    fireEvent.pointerDown(row);
+    fireEvent.pointerUp(row);
+    expect(row).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.pointerDown(row);
+    fireEvent.pointerUp(row);
+
+    expect(row).toHaveAttribute("aria-pressed", "false");
+  });
+
+  /** A keyboard activation has no press and no release, so the click is all it has. */
+  it("toggles on a keyboard activation", () => {
+    setup();
+    const row = rowFor("Muster Anna");
+
+    fireEvent.click(row, { detail: 0 });
+
+    expect(row).toHaveAttribute("aria-pressed", "true");
   });
 });

--- a/src/components/assignment/assignment-card.tsx
+++ b/src/components/assignment/assignment-card.tsx
@@ -246,15 +246,27 @@ function Row({
 
   function handlePointerDown(event: PointerEvent<HTMLButtonElement>) {
     wasPicked.current = picked;
-    // Picked on the way down rather than on the way up, so a press that turns into a drag is
+    // Picked on the way down rather than on the way up, so a press that turns its into a drag is
     // already carrying what it picked.
     if (!picked) onToggle();
     startPointerDrag?.(event);
   }
 
+  /**
+   * Releasing is what un-picks, rather than the click that would follow it. Four pixels of
+   * movement is enough for the sensor to call a press a drag, and it then swallows the click —
+   * so a press that wandered on its way down left a picked row picked and looked like nothing
+   * had happened at all.
+   *
+   * A drag that really goes somewhere is released over another card, where this never runs.
+   */
+  function handlePointerUp() {
+    if (wasPicked.current) onToggle();
+  }
+
   function handleClick(event: MouseEvent<HTMLButtonElement>) {
-    // A keyboard activation has no press before it, so it toggles on its own.
-    if (event.detail === 0 || wasPicked.current) onToggle();
+    // A keyboard activation has no press before it, and so no release either.
+    if (event.detail === 0) onToggle();
   }
 
   return (
@@ -284,6 +296,7 @@ function Row({
           aria-label={label}
           aria-pressed={picked}
           onPointerDown={handlePointerDown}
+          onPointerUp={handlePointerUp}
           onClick={handleClick}
           className={cn(
             TAG_TEXT,

--- a/src/components/assignment/assignment-view.test.tsx
+++ b/src/components/assignment/assignment-view.test.tsx
@@ -28,7 +28,10 @@ vi.mock("@/lib/api/client", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/api/client")>()),
   apiRequest: (...args: unknown[]) => apiRequest(...args),
 }));
-vi.mock("@/lib/api/busy", () => ({ useBusyWhile: (busy: boolean) => useBusyWhile(busy) }));
+vi.mock("@/lib/api/busy", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useBusyWhile: (busy: boolean) => useBusyWhile(busy),
+}));
 
 const { AssignmentView: ScopedAssignmentView } = await import("./assignment-view");
 const { NO_EVENT_SERIES_HINT } = await import("@/lib/event-series/event-series-state");

--- a/src/components/layout/app-shell.test.tsx
+++ b/src/components/layout/app-shell.test.tsx
@@ -4,7 +4,17 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { apiRequest } from "@/lib/api/client";
+
+/** A request that never answers, so the indicator is still there to be found. */
+function stubFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => new Promise<Response>(() => {})),
+  );
+}
 
 vi.mock("@/components/auth/sign-out-button", () => ({
   SignOutButton: () => <button type="button">Abmelden</button>,
@@ -105,5 +115,31 @@ describe("AppShell", () => {
     );
 
     expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
+  });
+});
+
+/** The one indicator answers for the whole app, so it has to be in the frame the whole app shares. */
+describe("AppShell — where the busy indicator sits", () => {
+  function Writer() {
+    return (
+      <button type="button" onClick={() => void apiRequest("/api/anything", { method: "POST" })}>
+        Speichern
+      </button>
+    );
+  }
+
+  it("shows it in the header while a request is out, at the end of the row", async () => {
+    stubFetch();
+    render(
+      <AppShell nav={<nav aria-label="Hauptnavigation">Navigation</nav>}>
+        <Writer />
+      </AppShell>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Speichern" }));
+
+    const indicator = await screen.findByRole("status", { name: "Wird gespeichert" });
+    expect(screen.getByRole("banner")).toContainElement(indicator);
+    expect(screen.getByRole("banner").lastElementChild).toBe(indicator);
   });
 });

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -42,17 +42,13 @@ export function AppShell({
           </div>
         ) : null}
 
-        {/* Positioned, because the busy bar straddles the border at its foot rather than sitting
-            inside it — without this it has nothing nearer than the viewport to be placed against. */}
-        <header className="border-border bg-background relative col-start-2 row-start-1 flex items-center justify-between gap-4 border-b px-4 py-2 md:px-6">
+        <header className="border-border bg-background col-start-2 row-start-1 flex items-center justify-between gap-4 border-b px-4 py-2 md:px-6">
           {nav ? null : <Brand />}
           {/* The scope leads the header, because it says what every page below it is about. */}
           {scope}
           {/* Where there is a bar, signing out sits at the foot of it, under the person's own
               mark. A student has no bar, so it stays here. */}
           {nav ? null : <SignOutButton photo={photo} />}
-          {/* Last, and positioned against the header, whose bottom border it sits on. */}
-          <BusyBar />
         </header>
 
         <main className="bg-background col-start-2 row-start-2 flex min-h-0 flex-col overflow-y-auto">
@@ -60,6 +56,14 @@ export function AppShell({
           {nav ? <div className="border-border bg-sidebar border-b md:hidden">{nav}</div> : null}
           {children}
         </main>
+
+        {/* Spanning both columns, so the indicator is centred on the window rather than on the
+            content column — the navigation's width is its own business and must not move it. It
+            takes no height of its own and sits at the foot of the header's row, which is the
+            border it straddles, so the header may grow as the tags wrap without moving it. */}
+        <div className="pointer-events-none relative col-span-2 col-start-1 row-start-1 self-end">
+          <BusyBar />
+        </div>
       </div>
     </BusyProvider>
   );

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -42,7 +42,9 @@ export function AppShell({
           </div>
         ) : null}
 
-        <header className="border-border bg-background col-start-2 row-start-1 flex items-center justify-between gap-4 border-b px-4 py-2 md:px-6">
+        {/* Positioned, because the busy bar straddles the border at its foot rather than sitting
+            inside it — without this it has nothing nearer than the viewport to be placed against. */}
+        <header className="border-border bg-background relative col-start-2 row-start-1 flex items-center justify-between gap-4 border-b px-4 py-2 md:px-6">
           {nav ? null : <Brand />}
           {/* The scope leads the header, because it says what every page below it is about. */}
           {scope}

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -49,6 +49,9 @@ export function AppShell({
           {/* Where there is a bar, signing out sits at the foot of it, under the person's own
               mark. A student has no bar, so it stays here. */}
           {nav ? null : <SignOutButton photo={photo} />}
+          {/* Last, so the row's own space-between puts it at the far end — the one part of the
+              header nothing else occupies, whatever the tags do. */}
+          <BusyBar />
         </header>
 
         <main className="bg-background col-start-2 row-start-2 flex min-h-0 flex-col overflow-y-auto">
@@ -56,14 +59,6 @@ export function AppShell({
           {nav ? <div className="border-border bg-sidebar border-b md:hidden">{nav}</div> : null}
           {children}
         </main>
-
-        {/* Spanning both columns, so the indicator is centred on the window rather than on the
-            content column — the navigation's width is its own business and must not move it. It
-            takes no height of its own and sits at the foot of the header's row, which is the
-            border it straddles, so the header may grow as the tags wrap without moving it. */}
-        <div className="pointer-events-none relative col-span-2 col-start-1 row-start-1 self-end">
-          <BusyBar />
-        </div>
       </div>
     </BusyProvider>
   );

--- a/src/components/layout/brand.tsx
+++ b/src/components/layout/brand.tsx
@@ -14,7 +14,9 @@ import Image from "next/image";
  */
 export function Brand() {
   return (
-    <span className="flex min-h-9 shrink-0 items-center gap-3 px-2 py-2">
+    // A control's height, so the name lines up with the tags across the header: both sit one
+    // step in from the top of the window, and a taller row here would drop it below them.
+    <span className="flex h-(--control-height) shrink-0 items-center gap-3 px-2">
       <span className="flex w-6 shrink-0 items-center justify-center">
         <Image
           src="/htl-logo.svg"

--- a/src/components/layout/busy-bar.test.tsx
+++ b/src/components/layout/busy-bar.test.tsx
@@ -127,21 +127,19 @@ describe("BusyBar — where it reports from", () => {
     expect(new Set(delays).size).toBe(delays.length);
   });
 
-  it("sits on the header's own line, centred across it", async () => {
+  /** An item in the row it is placed in, so whoever places it decides where it sits. */
+  it("takes no position of its own", async () => {
     const bar = await busyShell();
 
-    expect(bar.className).toContain("absolute");
-    expect(bar.className).toContain("inset-x-0");
-    expect(bar.className).toContain("justify-center");
+    expect(bar.className).not.toContain("absolute");
+    expect(bar.className).not.toContain("fixed");
   });
 
-  /** Short, so it stays on the line rather than reaching up into the event series tags (US-20). */
-  it("keeps the bars shorter than the header's own row", async () => {
+  /** A control's height, so the row it ends does not grow to hold it. */
+  it("stands as tall as the controls beside it", async () => {
     const bar = await busyShell();
 
-    for (const one of bar.querySelectorAll("[data-busy-bar]")) {
-      expect(one.className).toContain("h-2");
-    }
+    expect(bar.className).toContain("h-(--control-height)");
   });
 
   /** Grey, but darker than the line it sits on, which was too faint to notice at a glance. */

--- a/src/components/layout/busy-bar.tsx
+++ b/src/components/layout/busy-bar.tsx
@@ -33,7 +33,7 @@ export function BusyBar({ className }: { className?: string } = {}) {
       role="status"
       aria-label="Wird gespeichert"
       className={cn(
-        "pointer-events-none flex h-(--control-height) shrink-0 items-center gap-0.5",
+        "pointer-events-none flex h-(--control-height) shrink-0 items-center gap-1",
         className,
       )}
     >
@@ -42,8 +42,9 @@ export function BusyBar({ className }: { className?: string } = {}) {
           key={delay}
           data-busy-bar
           style={{ animationDelay: `${delay}s` }}
-          // Taller than they are wide, so four of them read as an indicator rather than as text.
-          className="bg-muted-foreground animate-busy-bar block h-3 w-0.5 rounded-full"
+          // Wide enough to be seen from across the header: four hairlines in the corner of the
+          // window read as nothing at all, which is the same as having no indicator.
+          className="bg-muted-foreground animate-busy-bar block h-4 w-1 rounded-full"
         />
       ))}
     </div>

--- a/src/components/layout/busy-bar.tsx
+++ b/src/components/layout/busy-bar.tsx
@@ -12,13 +12,12 @@ import { cn } from "@/lib/utils";
 const BARS = [0, 0.15, 0.3, 0.45];
 
 /**
- * One indicator for the whole app, on the line between the header and the content (US-14, US-15).
+ * One indicator for the whole app (US-14, US-15).
  *
- * Not in the header's middle: that is where the event series tags are (US-20), and an indicator
- * drawn over them cannot be read. It straddles the border instead — centred across the width,
- * centred on the line itself — which is space nothing else occupies, and one place always
- * answering "the app is working on it" is easier to learn than an indicator that appears
- * somewhere new each time.
+ * At the end of the row it is placed in rather than over anything: the header's own row already
+ * ends in space nothing else occupies, and an indicator drawn over the event series tags (US-20)
+ * cannot be read. One place always answering "the app is working on it" is easier to learn than
+ * an indicator that appears somewhere new each time.
  *
  * Bars rather than a bar that travels: most writes are answered before a sweep has crossed even
  * once, so it looked like nothing was happening. These cycle several times a second, which is
@@ -33,24 +32,20 @@ export function BusyBar({ className }: { className?: string } = {}) {
     <div
       role="status"
       aria-label="Wird gespeichert"
-      // Centred on the border rather than above it: half its height sits either side of the line.
       className={cn(
-        "pointer-events-none absolute inset-x-0 -bottom-1.5 z-20 flex justify-center",
+        "pointer-events-none flex h-(--control-height) shrink-0 items-center gap-0.5",
         className,
       )}
     >
-      <div className="bg-background flex h-3 items-center gap-0.5 px-1.5">
-        {BARS.map((delay) => (
-          <span
-            key={delay}
-            data-busy-bar
-            style={{ animationDelay: `${delay}s` }}
-            // Short on purpose, so it stays on the line instead of reaching up into the tags.
-            // Darker than the line it sits on: in the line's own grey it went unnoticed.
-            className="bg-muted-foreground animate-busy-bar block h-2 w-0.5 rounded-full"
-          />
-        ))}
-      </div>
+      {BARS.map((delay) => (
+        <span
+          key={delay}
+          data-busy-bar
+          style={{ animationDelay: `${delay}s` }}
+          // Taller than they are wide, so four of them read as an indicator rather than as text.
+          className="bg-muted-foreground animate-busy-bar block h-3 w-0.5 rounded-full"
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/layout/busy-bar.tsx
+++ b/src/components/layout/busy-bar.tsx
@@ -6,6 +6,7 @@
 "use client";
 
 import { useBusy } from "@/lib/api/busy";
+import { cn } from "@/lib/utils";
 
 /** Out of phase, or the bars rise and fall as one block and read as a single bar. */
 const BARS = [0, 0.15, 0.3, 0.45];
@@ -23,7 +24,7 @@ const BARS = [0, 0.15, 0.3, 0.45];
  * once, so it looked like nothing was happening. These cycle several times a second, which is
  * what makes a wait too short to measure still visible.
  */
-export function BusyBar() {
+export function BusyBar({ className }: { className?: string } = {}) {
   const busy = useBusy();
 
   if (!busy) return null;
@@ -33,7 +34,10 @@ export function BusyBar() {
       role="status"
       aria-label="Wird gespeichert"
       // Centred on the border rather than above it: half its height sits either side of the line.
-      className="pointer-events-none absolute inset-x-0 -bottom-1.5 z-20 flex justify-center"
+      className={cn(
+        "pointer-events-none absolute inset-x-0 -bottom-1.5 z-20 flex justify-center",
+        className,
+      )}
     >
       <div className="bg-background flex h-3 items-center gap-0.5 px-1.5">
         {BARS.map((delay) => (

--- a/src/components/layout/event-series-tag-rows.test.tsx
+++ b/src/components/layout/event-series-tag-rows.test.tsx
@@ -18,7 +18,10 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
 }));
 vi.mock("@/lib/event-series/use-event-series", () => ({ useEventSeries: () => eventSeries() }));
-vi.mock("@/lib/api/busy", () => ({ useBusyWhile: () => {} }));
+vi.mock("@/lib/api/busy", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useBusyWhile: () => {},
+}));
 vi.mock("@/lib/api/client", async (importOriginal) => ({
   ...(await importOriginal<object>()),
   apiRequest: (...args: unknown[]) => apiRequest(...args),

--- a/src/components/overview/class-cards.tsx
+++ b/src/components/overview/class-cards.tsx
@@ -353,7 +353,7 @@ function Cloud({
           const marked = student.id === markedId;
           return (
             <li key={student.id}>
-              <Tag pressed={marked} variant="neutral">
+              <Tag pressed={marked}>
                 <TagName label={name} onPress={() => onMark(marked ? null : student.id)} />
                 {/* On the marked tag only, as a saved report's controls are (US-13, US-28). */}
                 {marked && onRemove ? (

--- a/src/components/overview/overview-view.test.tsx
+++ b/src/components/overview/overview-view.test.tsx
@@ -26,7 +26,10 @@ vi.mock("@/lib/master-data/use-master-data", () => ({
   useMasterData: (key: string) => useMasterData(key),
   usePrograms: () => usePrograms(),
 }));
-vi.mock("@/lib/api/busy", () => ({ useBusyWhile: () => {} }));
+vi.mock("@/lib/api/busy", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useBusyWhile: () => {},
+}));
 vi.mock("@/lib/api/client", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/api/client")>()),
   apiRequest: (...args: unknown[]) => apiRequest(...args),

--- a/src/components/report/report-view.test.tsx
+++ b/src/components/report/report-view.test.tsx
@@ -31,7 +31,11 @@ vi.mock("@/lib/api/client", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/api/client")>()),
   apiRequest: (...args: unknown[]) => apiRequest(...args),
 }));
-vi.mock("@/lib/api/busy", () => ({ useBusyWhile: () => {}, useHold: () => () => () => {} }));
+vi.mock("@/lib/api/busy", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useBusyWhile: () => {},
+  useHold: () => () => () => {},
+}));
 vi.mock("@/lib/report/report-download", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/report/report-download")>()),
   downloadReportPdf: (report: unknown) => downloadReportPdf(report),

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,9 +6,12 @@
  * Adapted from shadcn/ui (https://ui.shadcn.com), MIT licensed.
  * See LICENSE and THIRD-PARTY-NOTICES.md in the repository root for details.
  */
+"use client";
+
 import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cva, type VariantProps } from "class-variance-authority";
 
+import { useInert } from "@/lib/api/busy";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
@@ -65,11 +68,13 @@ function Button({
   className,
   variant = "default",
   size = "default",
+  disabled,
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
   return (
     <ButtonPrimitive
       data-slot="button"
+      disabled={useInert(disabled)}
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -7,6 +7,7 @@
 
 import * as React from "react";
 import { X } from "lucide-react";
+import { BusyBar } from "@/components/layout/busy-bar";
 import { cn } from "@/lib/utils";
 
 type DialogProps = {
@@ -65,7 +66,7 @@ export function Dialog({
       onClose={onClose}
       onCancel={onClose}
       className={cn(
-        "bg-card text-card-foreground ring-foreground/10 shadow-card m-auto w-[calc(100vw-(--spacing(8)))] max-w-md rounded-xl p-0 ring-1 backdrop:bg-black/40",
+        "bg-card text-card-foreground ring-foreground/10 shadow-card relative m-auto w-[calc(100vw-(--spacing(8)))] max-w-md rounded-xl p-0 ring-1 backdrop:bg-black/40",
         className,
       )}
     >
@@ -98,7 +99,13 @@ export function Dialog({
       </div>
 
       {footer ? (
-        <div className="bg-muted/50 flex items-center justify-end gap-2 border-t p-4">{footer}</div>
+        <div className="bg-muted/50 relative flex items-center justify-end gap-2 border-t p-4">
+          {/* The one in the header is behind the backdrop while this is open, and a dialog is
+              where the slowest writes are started. Same indicator, on the line above the
+              controls that started it. */}
+          <BusyBar className="-top-1.5 bottom-auto" />
+          {footer}
+        </div>
       ) : null}
     </dialog>
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -99,11 +99,10 @@ export function Dialog({
       </div>
 
       {footer ? (
-        <div className="bg-muted/50 relative flex items-center justify-end gap-2 border-t p-4">
+        <div className="bg-muted/50 flex items-center justify-end gap-2 border-t p-4">
           {/* The one in the header is behind the backdrop while this is open, and a dialog is
-              where the slowest writes are started. Same indicator, on the line above the
-              controls that started it. */}
-          <BusyBar className="-top-1.5 bottom-auto" />
+              where the slowest writes are started. At the near end, away from the controls. */}
+          <BusyBar className="mr-auto" />
           {footer}
         </div>
       ) : null}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -6,14 +6,18 @@
  * Adapted from shadcn/ui (https://ui.shadcn.com), MIT licensed.
  * See LICENSE and THIRD-PARTY-NOTICES.md in the repository root for details.
  */
+"use client";
+
 import * as React from "react";
 import { Input as InputPrimitive } from "@base-ui/react/input";
 
+import { useInert } from "@/lib/api/busy";
 import { cn } from "@/lib/utils";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({ className, type, disabled, ...props }: React.ComponentProps<"input">) {
   return (
     <InputPrimitive
+      disabled={useInert(disabled)}
       type={type}
       data-slot="input"
       className={cn(

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import { Select as SelectPrimitive } from "@base-ui/react/select";
 
 import { cn } from "@/lib/utils";
+import { useInert } from "@/lib/api/busy";
 import { useDialogContainer } from "@/components/ui/dialog";
 import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react";
 
@@ -37,10 +38,11 @@ function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
   );
 }
 
-function SelectTrigger({ className, children, ...props }: SelectPrimitive.Trigger.Props) {
+function SelectTrigger({ className, disabled, children, ...props }: SelectPrimitive.Trigger.Props) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
+      disabled={useInert(disabled)}
       className={cn(
         "border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 flex h-(--control-height) w-fit items-center justify-between gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,

--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -16,6 +16,7 @@ import {
 } from "react";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useInert } from "@/lib/api/busy";
 import { cn } from "@/lib/utils";
 
 /**
@@ -128,7 +129,7 @@ export function TagName({
       aria-label={label}
       aria-pressed={pressed}
       aria-describedby={describedBy}
-      disabled={disabled}
+      disabled={useInert(disabled)}
       onPointerDown={onPointerDown}
       onClick={onPress}
       className="focus-visible:ring-ring/50 max-w-60 truncate rounded-md px-0.5 outline-none focus-visible:ring-3 disabled:opacity-50"

--- a/src/lib/api/busy.test.tsx
+++ b/src/lib/api/busy.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { BusyProvider, useBusyWhile } from "@/lib/api/busy";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tag, TagAction, TagField, TagName } from "@/components/ui/tag";
+
+/** Stands in for a view reporting a wait: a list still arriving from its subscription. */
+function Waiting({ busy }: { busy: boolean }) {
+  useBusyWhile(busy);
+  return null;
+}
+
+function controls() {
+  return (
+    <>
+      <Button>Speichern</Button>
+      <Input aria-label="Name" />
+      <Tag pressed={false}>
+        <TagName label="Alle" onPress={() => {}} />
+        <TagAction label="Entfernen">
+          <span />
+        </TagAction>
+      </Tag>
+      <Tag pressed={false}>
+        <TagField aria-label="Bericht" />
+      </Tag>
+    </>
+  );
+}
+
+function setup(busy: boolean) {
+  render(
+    <BusyProvider>
+      <Waiting busy={busy} />
+      {controls()}
+    </BusyProvider>,
+  );
+}
+
+const everyControl = () => [
+  screen.getByRole("button", { name: "Speichern" }),
+  screen.getByRole("textbox", { name: "Name" }),
+  screen.getByRole("button", { name: "Alle" }),
+  screen.getByRole("button", { name: "Entfernen" }),
+  screen.getByRole("textbox", { name: "Bericht" }),
+];
+
+/**
+ * Nothing is live over data that is still arriving or already being written. The controls decide
+ * that for themselves, so a view cannot place one that forgot — which is the whole point of
+ * asking here rather than at each call site.
+ */
+describe("a control while the application is busy", () => {
+  it("is live when nothing is in flight", () => {
+    setup(false);
+
+    for (const control of everyControl()) expect(control).toBeEnabled();
+  });
+
+  it("is inert while something is", () => {
+    setup(true);
+
+    for (const control of everyControl()) expect(control).toBeDisabled();
+  });
+
+  /** A page with no provider is still a page: the sign-in card has controls and no writes. */
+  it("is live where there is no provider to report to", () => {
+    render(controls());
+
+    for (const control of everyControl()) expect(control).toBeEnabled();
+  });
+});

--- a/src/lib/api/busy.tsx
+++ b/src/lib/api/busy.tsx
@@ -6,6 +6,7 @@
 "use client";
 
 import * as React from "react";
+import { requestsInFlight, subscribeToRequests } from "@/lib/api/requests";
 
 type BusyValue = { busy: boolean; hold: () => () => void };
 
@@ -18,9 +19,15 @@ const NO_HOLD = () => () => {};
  * One place that knows whether anything is being written, so one spinner can speak for all of
  * it. A count rather than a flag: two writes may overlap, and the first to finish must not
  * declare the app idle while the second is still out.
+ *
+ * Two sources, added together. Every request reports itself from inside `apiRequest`, which is
+ * what makes the spinner structural rather than something each control has to remember; the
+ * holds below are for a wait nobody is making a request for, such as a list still arriving from
+ * its subscription.
  */
 export function BusyProvider({ children }: { children: React.ReactNode }) {
   const [holds, setHolds] = React.useState(0);
+  const requests = React.useSyncExternalStore(subscribeToRequests, requestsInFlight, () => 0);
 
   const hold = React.useCallback(() => {
     setHolds((count) => count + 1);
@@ -32,7 +39,10 @@ export function BusyProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  const value = React.useMemo(() => ({ busy: holds > 0, hold }), [holds, hold]);
+  const value = React.useMemo(
+    () => ({ busy: holds > 0 || requests > 0, hold }),
+    [holds, requests, hold],
+  );
 
   return <BusyContext.Provider value={value}>{children}</BusyContext.Provider>;
 }

--- a/src/lib/api/busy.tsx
+++ b/src/lib/api/busy.tsx
@@ -51,6 +51,18 @@ export function useBusy(): boolean {
   return React.useContext(BusyContext)?.busy ?? false;
 }
 
+/**
+ * Whether a control is inert: because it was told to be, or because something is in flight.
+ *
+ * Asked by the controls themselves rather than by the views that place them, so a control cannot
+ * be left live over data that is still arriving or already being written. A read counts as much
+ * as a write — a list still loading is a list whose rows are not there to act on — and both
+ * report themselves without a caller saying so.
+ */
+export function useInert(disabled?: boolean): boolean {
+  return useBusy() || disabled === true;
+}
+
 /** Taken for the length of a write and released when it is answered, however it ends. */
 export function useHold(): () => () => void {
   return React.useContext(BusyContext)?.hold ?? NO_HOLD;

--- a/src/lib/api/client.test.ts
+++ b/src/lib/api/client.test.ts
@@ -5,6 +5,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { apiRequest, ApiRequestError } from "./client";
+import { requestsInFlight } from "./requests";
 
 /**
  * Each test installs its own fetch stub. Sharing one `vi.fn()` across the file and clearing
@@ -120,5 +121,61 @@ describe("apiRequest — reading", () => {
     await expect(
       apiRequest("/api/event-series/s1/invitations", { method: "GET" }),
     ).rejects.toMatchObject({ message: "Nicht erlaubt." });
+  });
+});
+
+/**
+ * Reporting a write is not the caller's to remember. It is taken here, inside the one function
+ * every write goes through, which is what makes a control that forgot impossible rather than
+ * unlikely.
+ */
+describe("apiRequest — reporting itself busy", () => {
+  const answered = () => new Response(null, { status: 204 });
+
+  it("is out while the request is out, and answered when it is", async () => {
+    let resolve: (value: Response) => void = () => {};
+    stubFetch(() => new Promise<Response>((keep) => (resolve = keep)));
+
+    const pending = apiRequest("/api/anything", { method: "POST", body: {} });
+    expect(requestsInFlight()).toBe(1);
+
+    resolve(answered());
+    await pending;
+
+    expect(requestsInFlight()).toBe(0);
+  });
+
+  it("is answered when the server refuses", async () => {
+    stubFetch(() => new Response(JSON.stringify({ error: { message: "Nein." } }), { status: 409 }));
+
+    await expect(apiRequest("/api/anything", { method: "DELETE" })).rejects.toThrow();
+
+    expect(requestsInFlight()).toBe(0);
+  });
+
+  it("is answered when the connection fails outright", async () => {
+    stubFetch(() => Promise.reject(new Error("offline")));
+
+    await expect(apiRequest("/api/anything", { method: "POST" })).rejects.toThrow();
+
+    expect(requestsInFlight()).toBe(0);
+  });
+
+  /** Two writes may overlap, and the first answered must not declare the app idle. */
+  it("counts overlapping requests rather than flagging one", async () => {
+    const keep: ((value: Response) => void)[] = [];
+    stubFetch(() => new Promise<Response>((resolve) => keep.push(resolve)));
+
+    const one = apiRequest("/api/one", { method: "POST" });
+    const two = apiRequest("/api/two", { method: "POST" });
+    expect(requestsInFlight()).toBe(2);
+
+    keep[0](answered());
+    await one;
+    expect(requestsInFlight()).toBe(1);
+
+    keep[1](answered());
+    await two;
+    expect(requestsInFlight()).toBe(0);
   });
 });

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -4,6 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { ErrorCodeSchema, type ErrorCode } from "@/lib/errors";
+import { holdRequest } from "@/lib/api/requests";
 
 const GENERIC_MESSAGE = "Das hat leider nicht geklappt.";
 
@@ -35,23 +36,35 @@ async function readError(response: Response): Promise<ApiRequestError> {
   }
 }
 
+/**
+ * Every request the browser makes to this application's own API, and the only place one is made.
+ *
+ * It reports itself busy for as long as it is out, so the spinner speaks for every write without
+ * a caller having to remember to say so — which is what keeps a control that forgot from being
+ * possible at all.
+ */
 export async function apiRequest<T = unknown>(
   url: string,
   { method, body }: RequestOptions,
 ): Promise<T | null> {
-  let response: Response;
+  const release = holdRequest();
   try {
-    response = await fetch(url, {
-      method,
-      headers: { "content-type": "application/json" },
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-    });
-  } catch {
-    throw new ApiRequestError("Keine Verbindung zum Server. Bitte versuche es erneut.");
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method,
+        headers: { "content-type": "application/json" },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      });
+    } catch {
+      throw new ApiRequestError("Keine Verbindung zum Server. Bitte versuche es erneut.");
+    }
+
+    if (!response.ok) throw await readError(response);
+    if (response.status === 204) return null;
+
+    return (await response.json()) as T;
+  } finally {
+    release();
   }
-
-  if (!response.ok) throw await readError(response);
-  if (response.status === 204) return null;
-
-  return (await response.json()) as T;
 }

--- a/src/lib/api/requests.ts
+++ b/src/lib/api/requests.ts
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+
+/**
+ * How many requests are out, counted where they are made rather than where they are asked for.
+ *
+ * A module-level count rather than React state, because it is taken inside `apiRequest` — the one
+ * function every write in the application goes through. That is what makes reporting a write
+ * structural: a caller cannot forget to say it is writing, because saying so is not the caller's
+ * to do. A dialog that owned its own `saving` flag and never reached the spinner is the failure
+ * this rules out.
+ *
+ * A count rather than a flag: two writes may overlap, and the first to be answered must not
+ * declare the application idle while the second is still out.
+ */
+let inFlight = 0;
+
+const listeners = new Set<() => void>();
+
+function announce() {
+  for (const listener of listeners) listener();
+}
+
+/** Taken for the length of one request and released when it is answered, however it ends. */
+export function holdRequest(): () => void {
+  inFlight += 1;
+  announce();
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    inFlight -= 1;
+    announce();
+  };
+}
+
+export function requestsInFlight(): number {
+  return inFlight;
+}
+
+export function subscribeToRequests(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}


### PR DESCRIPTION
Three things were wrong while a request was in flight, and one was wrong before it
started.

**The busy indicator was decorative rather than structural.** Whether a request
showed as busy depended on the caller remembering to say so, and callers forget.
The count now lives with the request itself: `apiRequest` takes a hold on entry
and releases it in a `finally`, so every call through the client is reported,
including the ones written after this change. Nothing has to opt in.

**Controls stayed live while the answer was outstanding.** A second click on a
save button sent a second write. `useInert` folds the busy state into the
`disabled` a control already has, and `Button`, `Input`, `SelectTrigger`,
`TagName`, `TagField` and `TagAction` all consume it, so the freeze is a
property of the primitives rather than a discipline at each call site.

**The indicator could not be seen.** Three causes in sequence: the header lost
`relative` when it became a grid, so the absolutely positioned bar had nothing
to position against; a native `<dialog>` puts the rest of the document in the
top layer's shadow, so a bar behind `::backdrop` is invisible by construction;
and once both were fixed it was still four hairlines two pixels wide, in muted
grey, in the corner of the window. It now takes no position of its own — the
header's flex row puts it at the end, the dialog footer puts it before the
buttons — and the bars are wide enough to notice.

**A student would not un-pick.** dnd-kit activates a drag after four pixels of
movement and swallows the click that follows, so un-picking from `onClick`
worked only if the hand did not move. It happens on the pointer's release now,
with `onClick` kept for the keyboard, where there is no pointer to release.

Separately, the grey highlight on a marked student said "chosen but standing
apart" — the meaning it carries on a template among event series. A student
picked out to have their registration removed is simply the one selected, so it
uses the accent every other selection uses.

`Button` also loses every size but `default` and `icon`. A size nothing uses is
a decision waiting to be made inconsistently.
