### PR TITLE
Give teachers permissions, and say what a user is apart from what they may do

### DIFF
--- a/.github/instructions/route-handlers.instructions.md
+++ b/.github/instructions/route-handlers.instructions.md
@@ -37,12 +37,19 @@ Licensed under the MIT License. See LICENSE in the repository root for details.
 `src/lib/api/handler.ts` owns the four steps every handler takes. A handler that hand-rolls one
 of them is a handler whose envelope will eventually differ from the others':
 
-| Step                                  | Helper                                                 |
-| ------------------------------------- | ------------------------------------------------------ |
-| Check the caller's role               | `requireTeacherOrResponse`, `requireStudentOrResponse` |
-| Parse and validate a body             | `parseJsonBody(request, schema)`                       |
-| Report a refusal                      | `errorResponse(code, message, details?)`               |
-| Turn a thrown failure into a response | `handleServiceFailure(error, context)`                 |
+| Step                                  | Helper                                                    |
+| ------------------------------------- | --------------------------------------------------------- |
+| Check what the caller may do          | `requirePermissionOrResponse`, `requireStudentOrResponse` |
+| The same, plus who they are           | `requirePermissionIdentityOrResponse(permission)`         |
+| Parse and validate a body             | `parseJsonBody(request, schema)`                          |
+| Report a refusal                      | `errorResponse(code, message, details?)`                  |
+| Turn a thrown failure into a response | `handleServiceFailure(error, context)`                    |
+
+A handler names the one permission it needs. Being a teacher opens nothing on its own, and no
+permission stands in for another — so the name passed here is the whole of the decision, and
+getting it wrong is the failure a test for a teacher holding a _different_ permission catches.
+Refusals carry `PERMISSION_DENIED_HINT`, one sentence for every permission, so a caller learns
+nothing about which was missing.
 
 Services throw `ServiceError` with an `ErrorCode`; `handleServiceFailure` maps it to the
 documented status and sanitises anything else into a logged 500.
@@ -53,7 +60,7 @@ documented status and sanitises anything else into a logged 500.
 | ------ | ---------------------------------- | ---------------------------------------------------------------------------------- |
 | 400    | `ErrorCode.ValidationError`        | Zod `safeParse` failed                                                             |
 | 401    | `ErrorCode.AuthenticationRequired` | No/invalid session                                                                 |
-| 403    | `ErrorCode.PermissionDenied`       | Authenticated but missing required role/permission                                 |
+| 403    | `ErrorCode.PermissionDenied`       | Authenticated, but does not hold the permission the handler names                  |
 | 404    | `ErrorCode.NotFound`               | The referenced resource does not exist                                             |
 | 409    | `ErrorCode.Conflict`               | Duplicate, concurrent update                                                       |
 | 500    | `ErrorCode.InternalError`          | Unexpected error / Admin SDK failure — log server-side, return a sanitized message |
@@ -62,7 +69,7 @@ documented status and sanitises anything else into a logged 500.
 
 ```ts
 export async function POST(request: Request) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editMasterData");
   if (denied) return denied;
 
   const body = await parseJsonBody(request, createEventSeriesSchema);

--- a/firestore-tests/live-updates.rules.test.ts
+++ b/firestore-tests/live-updates.rules.test.ts
@@ -29,7 +29,7 @@ const TEACHER_UPN = "lehrperson@htldornbirn.at";
 beforeEach(async () => {
   await testEnv.clearFirestore();
   await testEnv.withSecurityRulesDisabled(async (context) => {
-    await context.firestore().collection("users").doc(TEACHER_UPN).set({ role: "teacher" });
+    await context.firestore().collection("users").doc(TEACHER_UPN).set({ accountType: "teacher" });
   });
 });
 

--- a/firestore-tests/master-data.rules.test.ts
+++ b/firestore-tests/master-data.rules.test.ts
@@ -41,8 +41,8 @@ beforeEach(async () => {
   await testEnv.clearFirestore();
   await testEnv.withSecurityRulesDisabled(async (context) => {
     const db = context.firestore();
-    await db.collection("users").doc(TEACHER_UPN).set({ role: "teacher" });
-    await db.collection("users").doc(STUDENT_UPN).set({ role: "student" });
+    await db.collection("users").doc(TEACHER_UPN).set({ accountType: "teacher" });
+    await db.collection("users").doc(STUDENT_UPN).set({ accountType: "student" });
   });
 });
 

--- a/firestore-tests/registration.rules.test.ts
+++ b/firestore-tests/registration.rules.test.ts
@@ -51,10 +51,15 @@ beforeEach(async () => {
   await testEnv.clearFirestore();
   await testEnv.withSecurityRulesDisabled(async (context) => {
     const db = context.firestore();
-    await db.collection("users").doc(TEACHER_UPN).set({ role: "teacher" });
-    await db.collection("users").doc(STUDENT_UPN).set({ role: "student" });
-    await db.collection("users").doc(OTHER_STUDENT_UPN).set({ role: "student" });
-    await db.collection("users").doc(NEWCOMER_UPN).set({ role: "student" });
+    // The teacher whose reads these tests are about: planning a series is what reads a
+    // registration, and reporting on it is what reads a saved report (US-2).
+    await db
+      .collection("users")
+      .doc(TEACHER_UPN)
+      .set({ accountType: "teacher", permissions: ["viewReports", "editAssignments"] });
+    await db.collection("users").doc(STUDENT_UPN).set({ accountType: "student" });
+    await db.collection("users").doc(OTHER_STUDENT_UPN).set({ accountType: "student" });
+    await db.collection("users").doc(NEWCOMER_UPN).set({ accountType: "student" });
   });
 
   await seed(REGISTRATIONS, STUDENT_UPN, {
@@ -119,6 +124,20 @@ describe("/eventSeries/{id}/registrations", () => {
 
   it("lets a teacher read a single record", async () => {
     await assertSucceeds(teacher().collection(REGISTRATIONS).doc(OTHER_STUDENT_UPN).get());
+  });
+
+  /** Being a teacher opens nothing on its own: each permission is granted deliberately (US-2). */
+  it("denies a teacher holding no permission", async () => {
+    await seed("users", TEACHER_UPN, { accountType: "teacher", permissions: [] });
+
+    await assertFails(teacher().collection(REGISTRATIONS).get());
+    await assertFails(teacher().collection(REGISTRATIONS).doc(OTHER_STUDENT_UPN).get());
+  });
+
+  it("denies a teacher whose permissions are about reports they may not plan with", async () => {
+    await seed("users", TEACHER_UPN, { accountType: "teacher", permissions: ["editMasterData"] });
+
+    await assertFails(teacher().collection(REGISTRATIONS).get());
   });
 
   it("denies a student reading another student's record", async () => {
@@ -199,6 +218,17 @@ describe("/eventSeries/{id}/savedReports", () => {
 
   it("lets a teacher query them, which is what the report's tag row does", async () => {
     await assertSucceeds(teacher().collection(SAVED_REPORTS).get());
+  });
+
+  /** A saved report is a report: whoever may not see one may not see what was saved of it. */
+  it("denies a teacher who may not view reports", async () => {
+    await seed("users", TEACHER_UPN, {
+      accountType: "teacher",
+      permissions: ["editAssignments", "editMasterData"],
+    });
+
+    await assertFails(teacher().collection(SAVED_REPORTS).get());
+    await assertFails(teacher().collection(SAVED_REPORTS).doc("report1").get());
   });
 
   it("denies a student reading them", async () => {

--- a/firestore-tests/users.rules.test.ts
+++ b/firestore-tests/users.rules.test.ts
@@ -61,8 +61,14 @@ function signInAs(upn: string, claims: Record<string, unknown> = {}) {
   return testEnv.authenticatedContext(`uid-of-${upn}`, { email: upn, ...claims }).firestore();
 }
 
-const student = (extra: Record<string, unknown> = {}) => ({ role: "student", ...extra });
-const teacher = (extra: Record<string, unknown> = {}) => ({ role: "teacher", ...extra });
+const student = (extra: Record<string, unknown> = {}) => ({ accountType: "student", ...extra });
+const teacher = (extra: Record<string, unknown> = {}) => ({
+  accountType: "teacher",
+  permissions: [],
+  ...extra,
+});
+const admin = (extra: Record<string, unknown> = {}) =>
+  teacher({ permissions: ["editUsers"], ...extra });
 
 describe("/users/{uid} read access", () => {
   it("denies read access to signed-out users", async () => {
@@ -89,15 +95,32 @@ describe("/users/{uid} read access", () => {
 
   /**
    * A teacher used to read every user, because the roster joined registrations to them for the
-   * student's name. The registration carries that name itself now (US-26), so the permission
-   * has no reader left and is withdrawn.
+   * student's name. The registration carries that name itself now (US-26), so what is left of
+   * that permission belongs to whoever hands the permissions out (US-2).
    */
-  it("denies a teacher reading another user's document", async () => {
+  it("denies a teacher without editUsers reading another user's document", async () => {
     await seedUser(ALICE, student());
     await seedUser(CAROL, teacher());
     const db = signInAs(CAROL);
 
     await assertFails(db.collection("users").doc(ALICE).get());
+  });
+
+  it("allows a teacher with editUsers to read another user's document", async () => {
+    await seedUser(ALICE, student());
+    await seedUser(CAROL, admin());
+    const db = signInAs(CAROL);
+
+    await assertSucceeds(db.collection("users").doc(ALICE).get());
+  });
+
+  /** A permission on a student's record grants nothing: they are refused by what they are. */
+  it("denies a student whose record lists editUsers", async () => {
+    await seedUser(ALICE, student({ permissions: ["editUsers"] }));
+    await seedUser(BOB, student());
+    const db = signInAs(ALICE);
+
+    await assertFails(db.collection("users").doc(BOB).get());
   });
 
   it("allows a teacher to read their own document", async () => {
@@ -108,19 +131,45 @@ describe("/users/{uid} read access", () => {
   });
 });
 
-describe("/users/{uid} role immutability", () => {
-  it("denies a student changing their own role", async () => {
+describe("/users/{uid} account type and permission immutability", () => {
+  it("denies a student changing their own account type", async () => {
     await seedUser(ALICE, student({ firstName: "Alice" }));
     const db = signInAs(ALICE);
 
-    await assertFails(db.collection("users").doc(ALICE).update({ role: "teacher" }));
+    await assertFails(db.collection("users").doc(ALICE).update({ accountType: "teacher" }));
   });
 
-  it("denies a teacher changing their own role", async () => {
+  it("denies a teacher changing their own account type", async () => {
     await seedUser(CAROL, teacher({ firstName: "Carol" }));
     const db = signInAs(CAROL);
 
-    await assertFails(db.collection("users").doc(CAROL).update({ role: "student" }));
+    await assertFails(db.collection("users").doc(CAROL).update({ accountType: "student" }));
+  });
+
+  /** Granting is a Route Handler's, which owns the refusals a rule cannot express (US-2). */
+  it("denies a teacher granting themselves a permission", async () => {
+    await seedUser(CAROL, teacher({ firstName: "Carol" }));
+    const db = signInAs(CAROL);
+
+    await assertFails(
+      db
+        .collection("users")
+        .doc(CAROL)
+        .update({ permissions: ["editMasterData"] }),
+    );
+  });
+
+  it("denies an admin granting someone else a permission directly", async () => {
+    await seedUser(CAROL, admin());
+    await seedUser(ALICE, student());
+    const db = signInAs(CAROL);
+
+    await assertFails(
+      db
+        .collection("users")
+        .doc(ALICE)
+        .update({ permissions: ["editUsers"] }),
+    );
   });
 
   it("denies a teacher changing someone else's role", async () => {
@@ -128,10 +177,10 @@ describe("/users/{uid} role immutability", () => {
     await seedUser(ALICE, student());
     const db = signInAs(CAROL);
 
-    await assertFails(db.collection("users").doc(ALICE).update({ role: "teacher" }));
+    await assertFails(db.collection("users").doc(ALICE).update({ accountType: "teacher" }));
   });
 
-  it("allows a user to update their own non-role fields", async () => {
+  it("allows a user to update their own remaining fields", async () => {
     await seedUser(ALICE, student({ firstName: "Alice" }));
     const db = signInAs(ALICE);
 
@@ -180,12 +229,12 @@ describe("/users/{uid} create and delete", () => {
 
 describe("/users/{uid} has no admin role", () => {
   it("grants a document claiming role 'admin' no privileges at all", async () => {
-    await seedUser(MALLORY, { role: "admin" });
+    await seedUser(MALLORY, { accountType: "admin" });
     await seedUser(ALICE, student());
     const db = signInAs(MALLORY);
 
     await assertFails(db.collection("users").doc(ALICE).get());
-    await assertFails(db.collection("users").doc(ALICE).update({ role: "teacher" }));
+    await assertFails(db.collection("users").doc(ALICE).update({ accountType: "teacher" }));
     await assertFails(db.collection("users").doc(DAVE).set(student()));
   });
 
@@ -226,7 +275,7 @@ describe("identity resolution with a realistic uid", () => {
   });
 
   it("recognises a teacher whose record is keyed by UPN", async () => {
-    await seedUser(UPN, teacher({ email: UPN }));
+    await seedUser(UPN, teacher({ email: UPN, permissions: ["viewReports"] }));
     await seedRegistration("pupil@student.htldornbirn.at");
 
     await assertSucceeds(
@@ -234,11 +283,16 @@ describe("identity resolution with a realistic uid", () => {
     );
   });
 
-  it("recognises a teacher from the role claim, without reading the record", async () => {
+  /**
+   * The account type claim spares the common case a document read, but a permission is never
+   * taken from it: permissions are granted and withdrawn while a session is live, and a token
+   * minted beforehand would go on admitting what an admin has just taken away (US-2).
+   */
+  it("does not take a permission from the claim, so a record is still read", async () => {
     await seedRegistration("pupil@student.htldornbirn.at");
 
-    await assertSucceeds(
-      signedIn({ role: "teacher" })
+    await assertFails(
+      signedIn({ accountType: "teacher", permissions: ["viewReports"] })
         .collection(REGISTRATIONS)
         .doc("pupil@student.htldornbirn.at")
         .get(),

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,19 +20,36 @@ service cloud.firestore {
         : '';
     }
 
-    function recordRole() {
-      return get(/databases/$(database)/documents/users/$(upn())).data.role;
+    function recordAccountType() {
+      return get(/databases/$(database)/documents/users/$(upn())).data.accountType;
     }
 
     /**
-     * Hierarchical by construction: every student-level rule also admits isTeacher().
-     * The claim is checked first so the common case costs no document read; it is missing on
-     * the very first login, which is what the fallback covers (see resolveRole in guards.ts).
+     * An account type says which population somebody belongs to, derived once from the UPN
+     * domain and granted by nobody (US-3). The claim is checked first so the common case costs
+     * no document read; it is missing on the very first login, which is what the fallback
+     * covers (see resolveAccountType in guards.ts).
      */
     function isTeacher() {
       return upn() != ''
-        && (request.auth.token.role == 'teacher'
-          || (exists(/databases/$(database)/documents/users/$(upn())) && recordRole() == 'teacher'));
+        && (request.auth.token.accountType == 'teacher'
+          || (exists(/databases/$(database)/documents/users/$(upn())) && recordAccountType() == 'teacher'));
+    }
+
+    /**
+     * What a teacher may do, as against what they are (US-2). Read from the record rather than
+     * the token: permissions are granted and withdrawn while a session is live, and a claim
+     * minted before the change would go on admitting what an admin has just taken away.
+     *
+     * A record carrying none reaches nothing, and a student is refused by isTeacher() ahead of
+     * whatever their own record happens to list. The names below are a copy of PERMISSIONS in
+     * src/lib/auth/permissions.ts, which this language cannot import.
+     */
+    function may(permission) {
+      return isTeacher()
+        && exists(/databases/$(database)/documents/users/$(upn()))
+        && get(/databases/$(database)/documents/users/$(upn())).data
+             .get('permissions', []).hasAny([permission]);
     }
 
     function isSelf(uid) {
@@ -40,22 +57,30 @@ service cloud.firestore {
     }
 
     /**
-     * A caller's own record, and nobody else's. A teacher used to read every user because the
-     * roster joined registrations to them for the student's name; the registration now carries
-     * that name itself (US-26), so the permission has no reader left and is withdrawn.
+     * A caller's own record, and every record to whoever hands out the permissions (US-2). A
+     * teacher used to read every user because the roster joined registrations to them for the
+     * student's name; the registration now carries that name itself (US-26), so that reader is
+     * gone and what is left is the rights page.
      *
      * The fake login's list of existing users (US-16) is unaffected: it is read server-side
      * with the Admin SDK, which bypasses these rules.
      */
     match /users/{uid} {
-      allow read: if isSelf(uid);
+      allow read: if isSelf(uid) || may('editUsers');
 
       // Records are provisioned on first login by the Admin SDK, which bypasses these rules.
       allow create: if false;
 
-      // `role` is assigned once from the UPN domain and is never client-writable, at any role (US-3).
+      /**
+       * Neither what somebody is nor what they may do is theirs to write (US-3). The account
+       * type is assigned once from the UPN domain; the permissions are an admin's to grant,
+       * through the Route Handler that owns the refusals a rule cannot express — that a
+       * dependent permission travels with the one it needs, and that nobody takes editUsers
+       * off themselves.
+       */
       allow update: if isSelf(uid)
-        && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role']);
+        && !request.resource.data.diff(resource.data).affectedKeys()
+             .hasAny(['accountType', 'permissions']);
 
       allow delete: if false;
     }
@@ -79,7 +104,7 @@ service cloud.firestore {
      * through a handler that owns `event`.
      */
     match /eventSeries/{eventSeriesId}/registrations/{studentUpn} {
-      allow read: if isTeacher() || isSelf(studentUpn);
+      allow read: if may('viewReports') || may('editAssignments') || isSelf(studentUpn);
       allow write: if false;
     }
 
@@ -98,7 +123,7 @@ service cloud.firestore {
      * offer (US-22). Both are done in transactions by the Route Handlers.
      */
     match /eventSeries/{eventSeriesId}/savedReports/{reportId} {
-      allow read: if isTeacher();
+      allow read: if may('viewReports');
       allow write: if false;
     }
 

--- a/scripts/seed-environment.mts
+++ b/scripts/seed-environment.mts
@@ -32,7 +32,7 @@ import type { Gender } from "@/lib/schemas/common";
 import { FOOD_OPTION_OTHER, type Program } from "@/lib/schemas/master-data";
 import type { EventSeries } from "@/lib/schemas/event-series";
 import { registrationSchema, type RegistrationInput } from "@/lib/schemas/registration";
-import { userRoleSchema, userSchema } from "@/lib/schemas/user";
+import { accountTypeSchema, userSchema } from "@/lib/schemas/user";
 import { normalizeName } from "@/lib/firebase/name-key";
 import { isRegistrationIncomplete } from "@/lib/registration/completeness";
 import { questionsAsked } from "@/lib/master-data/categories";
@@ -276,7 +276,7 @@ function createPerson(gender: Gender, taken: Set<string>): Person {
   for (let attempt = 0; ; attempt += 1) {
     const firstName = pick(firstNames);
     const lastName = attempt < 20 ? pick(LAST_NAMES) : `${pick(LAST_NAMES)}-${pick(LAST_NAMES)}`;
-    const upn = buildUpn(firstName, lastName, userRoleSchema.enum.student);
+    const upn = buildUpn(firstName, lastName, accountTypeSchema.enum.student);
 
     if (upn && !taken.has(upn)) {
       taken.add(upn);
@@ -571,7 +571,7 @@ async function main(): Promise<void> {
       const registration = registrationOf(person, chosen[index], lists, progress[index]);
       if (registration.isAttendingSportsWeek === true) written.attending += 1;
 
-      const user = userSchema.parse({ id: person.upn, ...person, email: person.upn, role: "student" }); // prettier-ignore
+      const user = userSchema.parse({ id: person.upn, ...person, email: person.upn, accountType: "student" }); // prettier-ignore
       const record = registrationSchema.parse({
         id: person.upn,
         studentUpn: person.upn,

--- a/spec/database-erd.puml
+++ b/spec/database-erd.puml
@@ -15,7 +15,11 @@ entity "User" as user {
   firstName : string
   lastName : string
   email : string
-  role : enum(teacher, student)  ' auto-assigned from UPN domain at creation (US-3)
+  accountType : enum(teacher, student)  ' what they are: auto-assigned from the UPN domain at
+                                        ' creation, granted by nobody, never client-writable (US-3)
+  permissions : string[]  ' what they may do: a set, not a rank, granted through the rights page
+                          ' by a holder of editUsers. Empty for every student, and for a teacher
+                          ' until granted — the school's first teacher excepted (US-2, US-30)
 }
 
 entity "EventSeries" as eventSeries {

--- a/spec/refactoring-event-series.md
+++ b/spec/refactoring-event-series.md
@@ -567,8 +567,8 @@ everybody at once.
   invalidated with it. What a link may never become is an enrolment into a class that is gone.
   the third thing a list change reaches, after the registrations and the saved reports.
 - The link selects an event series and does nothing else. It signs nobody in and grants no
-  identity: a student following it still signs in through Entra ID (US-1) and still has the role
-  their UPN domain gives them (US-3).
+  identity: a student following it still signs in through Entra ID (US-1) and still has the
+  account type their UPN domain gives them (US-3).
 - Following the link as a signed-in student opens that series' registration form (US-11); the
   registration itself is created on the first save, as it is today.
 - **A link never leads to a choice.** It names one series, so a student following it goes there

--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -60,35 +60,56 @@ As a user, I log in with my Microsoft Entra ID credentials so that I can access 
 - First name, last name, and email address are obtained from Entra ID and stored in the user record.
 - The two names are read from the directory itself, each asked for by name — the first name from `givenName`, the last from `surname` — so that neither can be mistaken for the other. Whichever of them the directory holds is used, even if it holds only one.
 - The display name is never split into the two. Its word order is the tenant's own choice, and this school writes the surname first, so splitting it stores the name the wrong way round as often as the right way.
-- When the directory can supply neither, the name is derived from the UPN, whose local part is `firstname.lastname` by the same convention the roles rely on (see US-3, US-16). Umlauts are spelled out there, so this is an approximation — but a correct one about which name is which.
+- When the directory can supply neither, the name is derived from the UPN, whose local part is `firstname.lastname` by the same convention the account types rely on (see US-3, US-16). Umlauts are spelled out there, so this is an approximation — but a correct one about which name is which.
 - The names are refreshed on every login, so a record stored from a worse source corrects itself the next time the user signs in.
 - A user record is created on the user's first login if none exists yet.
 - There is a 1:1 relationship between the Entra ID user and the user record stored in the database.
 - The user record's ID is the Entra ID user principal name (UPN).
 - Production always signs users in this way; only the test environment substitutes a fake login for the identity provider (see US-16).
 
-### US-2: Role model
+### US-2: Account types and permissions
 
-As the system, I recognize the teacher and student roles so that access rights can be managed according to the role assigned in the user's record.
-
-**Acceptance criteria:**
-
-- User records can be stored in the database.
-- There is a 1:1 relationship between a logged-in user and a user record.
-- Each user record stores exactly one role.
-- A user's role is either teacher or student.
-- Roles are hierarchical: teacher has all the rights of student.
-
-### US-3: Role assigned by Entra ID domain
-
-As a user, my role is automatically determined by the domain of my Entra ID UPN when my user record is first created, so that access rights are granted without manual assignment.
+As the system, I tell apart what a person _is_ from what they _may do_, so that access can be granted and withdrawn without touching either the identity provider or the database directly.
 
 **Acceptance criteria:**
 
-- If the UPN's domain (the part after @) is exactly "htldornbirn.at", the newly created user record is assigned the teacher role.
-- If the UPN's domain is exactly "student.htldornbirn.at", the newly created user record is assigned the student role.
+- User records can be stored in the database, 1:1 with a logged-in user.
+- Each record stores exactly one account type, either teacher or student. It says which population somebody belongs to, is derived once at creation (US-3) and is granted by nobody.
+- Each record stores a set of permissions, which says what that person may do.
+- The permissions are `viewReports`, `editReports`, `editAssignments`, `editMasterData` and `editUsers`. Labels shown are "Berichte ansehen", "Berichte bearbeiten", "Zuteilung", "Stammdaten" and "Benutzerrechte".
+- A permission is asked for by name and none stands in for another: the set is not a rank, and holding one grants nothing else. Only `editUsers` grants the management of permissions.
+- `editReports` cannot be held without `viewReports`. Granting the first grants the second; withdrawing the second withdraws the first.
+- A teacher holding no permission can reach no page and perform no write. They are told so rather than redirected.
+- A student holds no permissions, whatever their record may list: they are refused by their account type, ahead of anything else.
+- Permissions are read from the user record rather than from the session token, so a grant or a withdrawal takes effect on the next request rather than the next sign-in.
+- The first teacher to sign in at a school is created holding every permission, there being nobody yet who could grant one. Every teacher after them is created holding none.
+
+### US-3: Account type assigned by Entra ID domain
+
+As a user, my account type is automatically determined by the domain of my Entra ID UPN when my user record is first created, so that a teacher is told apart from a student without manual assignment.
+
+**Acceptance criteria:**
+
+- If the UPN's domain (the part after @) is exactly "htldornbirn.at", the newly created user record is assigned the teacher account type.
+- If the UPN's domain is exactly "student.htldornbirn.at", the newly created user record is assigned the student account type.
 - If the UPN's domain matches neither pattern, the login is rejected and no user record is created.
-- Once assigned, a role can only be changed by someone with direct database access (e.g. IT staff); there is no in-app role management.
+- Once assigned, an account type can only be changed by someone with direct database access (e.g. IT staff); there is no in-app management of it. What is managed in the app is the permissions (US-30).
+
+### US-30: Admin manages permissions
+
+As a teacher holding `editUsers`, I grant and withdraw what my colleagues may do, so that access follows who is actually running the sports week rather than who happens to have signed in.
+
+**Acceptance criteria:**
+
+- The page is reached from the last item of the navigation bar, labelled "Benutzerrechte", and is offered only to a holder of `editUsers`.
+- It lists every teacher, surname first, with their UPN. Students are not listed: a permission is a teacher's.
+- Each teacher's permissions are shown as a row of tags, one per permission, pressed for what they hold. A teacher holding none says so.
+- Pressing a tag grants that permission; pressing a pressed one withdraws it. What travels with it is US-2's dependency rule, so pressing "Berichte bearbeiten" presses "Berichte ansehen" and releasing the latter releases the former.
+- The list updates live, so two admins working at once see each other's changes.
+- A holder of `editUsers` cannot withdraw that permission from themselves. Their own tag for it is shown pressed but carries no button, and the server refuses the change regardless. Every other permission of their own remains theirs to change.
+- This is what keeps at least one holder without counting them: only the last holder could be the last one, since anybody else withdrawing it would have to hold it themselves.
+- Permissions cannot be granted to a student, nor to somebody who has never signed in — there is no record to grant against.
+- Nothing here is writable from a client: the page writes through a Route Handler, and Security Rules deny every client write to the account type and the permissions alike.
 
 ## Seasons & Events
 
@@ -374,7 +395,9 @@ As a teacher, I see a dashboard when I log in so that I can navigate to the diff
 
 - A header row is shown at the top of the dashboard: the application title "Sportsweek" on the left, and a logout button on the right.
 - Below the header, the remaining area is split into a left-side navigation zone and a content area on the right.
-- The left-side navigation contains, from top to bottom: Report (see US-13), Assignment (see US-12), and Master data.
+- The left-side navigation contains, from top to bottom: Report (see US-13), Assignment (see US-12), Master data, and last, Benutzerrechte (see US-30).
+- The bar shows only what the teacher's permissions reach (see US-2), so it never offers a page that would refuse them. A teacher holding none sees no destinations and is told why on the landing route rather than redirected to a page that would send them back.
+- Benutzerrechte is not a sub-item of Master data: permissions belong to the school rather than to one event series.
 - The Master data navigation item has a sub-item for each teacher-maintained category (see US-4 through US-10), in this order: event series, classes, programs, skill levels, season passes, bus pickup points, food/diet options. Classes come first because a class is asked of every student whether they attend or not (see US-11), so it is the list a teacher fills in before any other. The order is stated here rather than left to follow the story numbers, which are stable identifiers and not a running order.
 - That order is the one every other list of the same answers follows: the fields a teacher activates on the report and the categories the filter offers (see US-13), and the questions a student is asked about the event series (see US-11). One decision, so a teacher moving between the three finds an answer in the same place in each.
 - Selecting the Master data navigation item expands its sub-items; deselecting it collapses them again.
@@ -397,7 +420,7 @@ As a teacher trying the application out, I can continue as any teacher or studen
 
 **Acceptance criteria:**
 
-- The fake login replaces the identity provider and nothing else. The chosen identity is signed in through the same session endpoint as a real login, so provisioning (US-1), the role derived from the UPN domain (US-3), the session cookie, and every authorization check downstream stay on the code paths production uses.
+- The fake login replaces the identity provider and nothing else. The chosen identity is signed in through the same session endpoint as a real login, so provisioning (US-1), the account type derived from the UPN domain (US-3), the session cookie, and every authorization check downstream stay on the code paths production uses.
 - The fake login is opt-in per deployment, and the production project refuses it whatever the configuration says.
 - A deployment that does not opt in has no fake login to disable: the modules and the endpoint behind it are not part of the build at all, so a configuration mistake cannot turn it on after the fact.
 - The test environment is a separate Firebase project from production, because the fake login creates real authentication accounts and real user records, and neither belongs anywhere near real people's data.
@@ -406,7 +429,7 @@ As a teacher trying the application out, I can continue as any teacher or studen
 - Whether the caller came through Entra ID is decided by the sign-in provider that Firebase records during the token exchange, which a caller cannot assert for themselves. Without that distinction, one invented identity could authorize inventing the next.
 - The proof of the real Entra ID sign-in is kept separately from the session cookie that continuing as someone else replaces, so switching identity does not give up the right to switch again.
 - A student who signs in through Entra ID is refused with "Diese Umgebung steht nur Lehrpersonen offen.", while an impersonated student is admitted — that case is what the environment exists for.
-- The choice is made in a dialog that asks for a first name, a last name, and a role, or lets one of the users already present be picked instead. Cancelling continues as the signed-in teacher.
-- The UPN is derived from the name and the role rather than typed: `firstname.lastname` at the teacher or the student domain of US-3, with German umlauts spelled out ("Müller" becomes `mueller`, never `muller`) and remaining diacritics dropped. It is shown as it is derived and cannot be edited.
+- The choice is made in a dialog that asks for a first name, a last name, and an account type, or lets one of the users already present be picked instead. Cancelling continues as the signed-in teacher.
+- The UPN is derived from the name and the account type rather than typed: `firstname.lastname` at the teacher or the student domain of US-3, with German umlauts spelled out ("Müller" becomes `mueller`, never `muller`) and remaining diacritics dropped. It is shown as it is derived and cannot be edited.
 - A name from which no valid school address can be formed is refused, on the client and on the server alike, with "Aus diesem Namen lässt sich keine gültige Schul-Adresse bilden." — the fake tenant may only issue UPNs the real one could have issued.
-- Choosing a role chooses the domain; the role itself still follows from that domain (US-3). A user record that already exists keeps the role it was created with, exactly as after a real login.
+- Choosing an account type chooses the domain; the account type itself still follows from that domain (US-3). A user record that already exists keeps the account type it was created with, and the permissions it already holds, exactly as after a real login.

--- a/src/app/api/auth/fake/route.fake.ts
+++ b/src/app/api/auth/fake/route.fake.ts
@@ -9,17 +9,17 @@ import { z } from "zod";
 import { ErrorCode, apiError } from "@/lib/errors";
 import { adminAuth, adminDb } from "@/lib/firebase/admin";
 import { currentAuthMode } from "@/lib/auth/auth-mode";
-import { resolveRole } from "@/lib/auth/guards";
+import { resolveAccountType } from "@/lib/auth/guards";
 import { buildUpn, isSchoolUpn } from "@/lib/auth/fake/upn-builder";
 import { SESSION_COOKIE_NAME } from "@/lib/session";
 import { COLLECTIONS } from "@/lib/schemas/collections";
-import { userRoleSchema, userSchema } from "@/lib/schemas/user";
+import { accountTypeSchema, userSchema } from "@/lib/schemas/user";
 
 /**
  * Stands in for Entra ID while developing, so the app can be tried out as several teachers
  * and students without tenant accounts. It only replaces the identity provider: the client
  * trades the custom token minted here for an ID token and then goes through `/api/session`
- * like any real login, so provisioning, the role claim and the session cookie stay on the
+ * like any real login, so provisioning, the accountType claim and the session cookie stay on the
  * code path production uses.
  *
  * Reaching it takes a real Entra ID sign-in first — see `entraTeacherCookie`. The mode check
@@ -59,12 +59,12 @@ async function entraTeacherCookie(): Promise<string | null> {
 
       // Impersonation is a staff capability: without this a student could sign in for real
       // and then become a teacher.
-      const role = await resolveRole({
+      const accountType = await resolveAccountType({
         uid: decoded.uid,
         email: decoded.email ?? null,
-        role: userRoleSchema.safeParse(decoded.role).data ?? null,
+        accountType: accountTypeSchema.safeParse(decoded.accountType).data ?? null,
       });
-      if (role === "teacher") return value;
+      if (accountType === "teacher") return value;
     } catch {
       continue;
     }
@@ -76,10 +76,17 @@ async function entraTeacherCookie(): Promise<string | null> {
 const bodySchema = z.object({
   firstName: userSchema.shape.firstName,
   lastName: userSchema.shape.lastName,
-  role: userRoleSchema,
+  accountType: accountTypeSchema,
 });
 
-const listedUserSchema = userSchema.omit({ id: true, email: true, photo: true });
+// Whom to sign in as, which is a name and which domain issues the UPN. What that person may do
+// once signed in is the record's business, not the picker's.
+const listedUserSchema = userSchema.omit({
+  id: true,
+  email: true,
+  photo: true,
+  permissions: true,
+});
 
 /** The UPNs already in Firestore, so a known user can be picked instead of retyped. */
 export async function GET() {
@@ -127,10 +134,10 @@ export async function POST(request: Request) {
     );
   }
 
-  const { firstName, lastName, role } = parsed.data;
-  const upn = buildUpn(firstName, lastName, role);
+  const { firstName, lastName, accountType } = parsed.data;
+  const upn = buildUpn(firstName, lastName, accountType);
   // Holds the fake tenant to the shape the real one issues, so a UPN that could never exist
-  // in Entra ID cannot exist here either — and the role still follows from the domain (US-3).
+  // in Entra ID cannot exist here either — and the accountType still follows from the domain (US-3).
   if (!upn || !isSchoolUpn(upn)) {
     return NextResponse.json(
       apiError(

--- a/src/app/api/auth/fake/route.test.ts
+++ b/src/app/api/auth/fake/route.test.ts
@@ -42,7 +42,7 @@ function postRequest(body: unknown) {
 const ENTRA_TEACHER = {
   uid: "real-uid",
   email: "jane.doe@htldornbirn.at",
-  role: "teacher",
+  accountType: "teacher",
   firebase: { sign_in_provider: "microsoft.com" },
 };
 
@@ -81,14 +81,14 @@ describe("/api/auth/fake", () => {
       [
         "the signed-in user is a student",
         { __session: "entra-cookie" },
-        { ...ENTRA_TEACHER, role: "student" },
+        { ...ENTRA_TEACHER, accountType: "student" },
       ],
     ])("refuses when %s", async (_case, cookies, decoded) => {
       signedInWith(cookies, decoded);
 
       const listed = await GET();
       const minted = await POST(
-        postRequest({ firstName: "Jane", lastName: "Doe", role: "teacher" }),
+        postRequest({ firstName: "Jane", lastName: "Doe", accountType: "teacher" }),
       );
 
       expect(listed.status).toBe(403);
@@ -117,7 +117,7 @@ describe("/api/auth/fake", () => {
     });
 
     it("remembers the Entra session so later switches still pass", async () => {
-      await POST(postRequest({ firstName: "Jane", lastName: "Doe", role: "teacher" }));
+      await POST(postRequest({ firstName: "Jane", lastName: "Doe", accountType: "teacher" }));
 
       expect(cookieStore.set).toHaveBeenCalledWith(
         "__entra_session",
@@ -149,7 +149,7 @@ describe("/api/auth/fake", () => {
 
       const listed = await GET();
       const minted = await POST(
-        postRequest({ firstName: "Jane", lastName: "Doe", role: "teacher" }),
+        postRequest({ firstName: "Jane", lastName: "Doe", accountType: "teacher" }),
       );
 
       expect(listed.status).toBe(404);
@@ -164,13 +164,13 @@ describe("/api/auth/fake", () => {
         firstName: "Zoe",
         lastName: "Zimmer",
         email: "zoe.zimmer@student.htldornbirn.at",
-        role: "student",
+        accountType: "student",
       });
       firestore.seed("users", "jane.doe@htldornbirn.at", {
         firstName: "Jane",
         lastName: "Doe",
         email: "jane.doe@htldornbirn.at",
-        role: "teacher",
+        accountType: "teacher",
       });
 
       const response = await GET();
@@ -178,19 +178,24 @@ describe("/api/auth/fake", () => {
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({
         users: [
-          { upn: "jane.doe@htldornbirn.at", firstName: "Jane", lastName: "Doe", role: "teacher" },
+          {
+            upn: "jane.doe@htldornbirn.at",
+            firstName: "Jane",
+            lastName: "Doe",
+            accountType: "teacher",
+          },
           {
             upn: "zoe.zimmer@student.htldornbirn.at",
             firstName: "Zoe",
             lastName: "Zimmer",
-            role: "student",
+            accountType: "student",
           },
         ],
       });
     });
 
     it("skips a record that does not parse instead of failing the whole list", async () => {
-      firestore.seed("users", "broken@htldornbirn.at", { firstName: "Nur", role: "wizard" });
+      firestore.seed("users", "broken@htldornbirn.at", { firstName: "Nur", accountType: "wizard" });
 
       const response = await GET();
 
@@ -201,7 +206,7 @@ describe("/api/auth/fake", () => {
   describe("POST", () => {
     it("derives the UPN from the name and the chosen role", async () => {
       const response = await POST(
-        postRequest({ firstName: "Jürgen", lastName: "Müller", role: "student" }),
+        postRequest({ firstName: "Jürgen", lastName: "Müller", accountType: "student" }),
       );
 
       expect(response.status).toBe(200);
@@ -219,7 +224,9 @@ describe("/api/auth/fake", () => {
     // The UPN provisionUser otherwise falls back to spells umlauts out and loses the spaces,
     // so carrying the parts as claims keeps the record exactly as it was typed.
     it("passes the typed names through as token claims", async () => {
-      await POST(postRequest({ firstName: "Anna Maria", lastName: "van Berg", role: "teacher" }));
+      await POST(
+        postRequest({ firstName: "Anna Maria", lastName: "van Berg", accountType: "teacher" }),
+      );
 
       expect(createCustomToken).toHaveBeenCalledWith("uid-anna-maria.van-berg@htldornbirn.at", {
         given_name: "Anna Maria",
@@ -230,16 +237,16 @@ describe("/api/auth/fake", () => {
     it("reuses the auth account when the UPN is already known", async () => {
       getUserByEmail.mockResolvedValue({ uid: "existing-uid" });
 
-      await POST(postRequest({ firstName: "Jane", lastName: "Doe", role: "teacher" }));
+      await POST(postRequest({ firstName: "Jane", lastName: "Doe", accountType: "teacher" }));
 
       expect(createUser).not.toHaveBeenCalled();
       expect(createCustomToken).toHaveBeenCalledWith("existing-uid", expect.anything());
     });
 
     it.each([
-      ["a missing last name", { firstName: "Jane", role: "teacher" }],
-      ["an unknown role", { firstName: "Jane", lastName: "Doe", role: "admin" }],
-      ["a blank first name", { firstName: "   ", lastName: "Doe", role: "teacher" }],
+      ["a missing last name", { firstName: "Jane", accountType: "teacher" }],
+      ["an unknown role", { firstName: "Jane", lastName: "Doe", accountType: "admin" }],
+      ["a blank first name", { firstName: "   ", lastName: "Doe", accountType: "teacher" }],
     ])("returns 400 for %s", async (_case, body) => {
       const response = await POST(postRequest(body));
 
@@ -250,7 +257,7 @@ describe("/api/auth/fake", () => {
 
     it("returns 400 when the name yields no UPN the tenant could issue", async () => {
       const response = await POST(
-        postRequest({ firstName: "字", lastName: "字", role: "teacher" }),
+        postRequest({ firstName: "字", lastName: "字", accountType: "teacher" }),
       );
 
       expect(response.status).toBe(400);
@@ -262,7 +269,7 @@ describe("/api/auth/fake", () => {
       createCustomToken.mockRejectedValue(new Error("credentials missing"));
 
       const response = await POST(
-        postRequest({ firstName: "Jane", lastName: "Doe", role: "teacher" }),
+        postRequest({ firstName: "Jane", lastName: "Doe", accountType: "teacher" }),
       );
 
       expect(response.status).toBe(500);

--- a/src/app/api/event-series/[eventSeriesId]/assignments/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/assignments/route.test.ts
@@ -5,11 +5,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithRole = vi.fn();
+const getUserWithAccountType = vi.fn();
 const assignStudents = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
-  getUserWithRole: () => getUserWithRole(),
+  getUserWithAccountType: () => getUserWithAccountType(),
 }));
 
 vi.mock("@/lib/assignment/assignment-service", () => ({
@@ -31,7 +31,11 @@ function patch(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithRole.mockResolvedValue({ uid: "u1", email: "t@htldornbirn.at", role: "teacher" });
+  getUserWithAccountType.mockResolvedValue({
+    uid: "u1",
+    email: "t@htldornbirn.at",
+    accountType: "teacher",
+  });
   assignStudents.mockResolvedValue(undefined);
 });
 
@@ -59,10 +63,10 @@ describe("PATCH /api/event-series/[eventSeriesId]/assignments", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot assign", async () => {
-    getUserWithRole.mockResolvedValue({
+    getUserWithAccountType.mockResolvedValue({
       uid: "u2",
       email: "s@student.htldornbirn.at",
-      role: "student",
+      accountType: "student",
     });
 
     const response = await patch({ recordIds: ["r1"], event: "Woche 1" });
@@ -72,7 +76,7 @@ describe("PATCH /api/event-series/[eventSeriesId]/assignments", () => {
   });
 
   it("rejects a caller who is not signed in with 401", async () => {
-    getUserWithRole.mockResolvedValue(null);
+    getUserWithAccountType.mockResolvedValue(null);
 
     const response = await patch({ recordIds: ["r1"], event: null });
 

--- a/src/app/api/event-series/[eventSeriesId]/assignments/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/assignments/route.test.ts
@@ -5,11 +5,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithAccountType = vi.fn();
+const getAuthenticatedUser = vi.fn();
 const assignStudents = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
-  getUserWithAccountType: () => getUserWithAccountType(),
+  getAuthenticatedUser: () => getAuthenticatedUser(),
 }));
 
 vi.mock("@/lib/assignment/assignment-service", () => ({
@@ -31,10 +31,11 @@ function patch(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithAccountType.mockResolvedValue({
+  getAuthenticatedUser.mockResolvedValue({
     uid: "u1",
     email: "t@htldornbirn.at",
     accountType: "teacher",
+    permissions: ["editAssignments"],
   });
   assignStudents.mockResolvedValue(undefined);
 });
@@ -63,7 +64,7 @@ describe("PATCH /api/event-series/[eventSeriesId]/assignments", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot assign", async () => {
-    getUserWithAccountType.mockResolvedValue({
+    getAuthenticatedUser.mockResolvedValue({
       uid: "u2",
       email: "s@student.htldornbirn.at",
       accountType: "student",
@@ -75,8 +76,23 @@ describe("PATCH /api/event-series/[eventSeriesId]/assignments", () => {
     expect(assignStudents).not.toHaveBeenCalled();
   });
 
+  /** Planning is its own permission: reading the report that shows it grants nothing here. */
+  it("rejects a teacher who may only view reports", async () => {
+    getAuthenticatedUser.mockResolvedValue({
+      uid: "u3",
+      email: "t2@htldornbirn.at",
+      accountType: "teacher",
+      permissions: ["viewReports", "editReports", "editMasterData"],
+    });
+
+    const response = await patch({ recordIds: ["r1"], event: "Woche 1" });
+
+    expect(response.status).toBe(403);
+    expect(assignStudents).not.toHaveBeenCalled();
+  });
+
   it("rejects a caller who is not signed in with 401", async () => {
-    getUserWithAccountType.mockResolvedValue(null);
+    getAuthenticatedUser.mockResolvedValue(null);
 
     const response = await patch({ recordIds: ["r1"], event: null });
 

--- a/src/app/api/event-series/[eventSeriesId]/assignments/route.ts
+++ b/src/app/api/event-series/[eventSeriesId]/assignments/route.ts
@@ -5,7 +5,11 @@
  */
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { handleServiceFailure, parseJsonBody, requireTeacherOrResponse } from "@/lib/api/handler";
+import {
+  handleServiceFailure,
+  parseJsonBody,
+  requirePermissionOrResponse,
+} from "@/lib/api/handler";
 import { assignStudents } from "@/lib/assignment/assignment-service";
 import { MAX_WRITES_PER_BATCH } from "@/lib/firebase/batch";
 import { documentIdSchema } from "@/lib/schemas/common";
@@ -27,7 +31,7 @@ const assignSchema = z.strictObject({
 type Context = { params: Promise<{ eventSeriesId: string }> };
 
 export async function PATCH(request: Request, { params }: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editAssignments");
   if (denied) return denied;
 
   const body = await parseJsonBody(request, assignSchema);

--- a/src/app/api/event-series/[eventSeriesId]/invitations/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/invitations/route.test.ts
@@ -5,11 +5,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithRole = vi.fn();
+const getUserWithAccountType = vi.fn();
 const createInvitation = vi.fn();
 const invitationsOf = vi.fn();
 
-vi.mock("@/lib/auth/guards", () => ({ getUserWithRole: () => getUserWithRole() }));
+vi.mock("@/lib/auth/guards", () => ({ getUserWithAccountType: () => getUserWithAccountType() }));
 vi.mock("@/lib/invitations/invitation-service", () => ({
   createInvitation: (...args: unknown[]) => createInvitation(...args),
   invitationsOf: (...args: unknown[]) => invitationsOf(...args),
@@ -18,8 +18,8 @@ vi.mock("@/lib/invitations/invitation-service", () => ({
 const { GET, POST } = await import("./route");
 const { ServiceError } = await import("@/lib/service-error");
 
-const TEACHER = { uid: "u1", email: "t@htldornbirn.at", role: "teacher" };
-const STUDENT = { uid: "u2", email: "s@student.htldornbirn.at", role: "student" };
+const TEACHER = { uid: "u1", email: "t@htldornbirn.at", accountType: "teacher" };
+const STUDENT = { uid: "u2", email: "s@student.htldornbirn.at", accountType: "student" };
 
 function request(body: unknown) {
   return new Request("https://example.com/api/event-series/s1/invitations", {
@@ -32,7 +32,7 @@ const context = { params: Promise.resolve({ eventSeriesId: "s1" }) };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithRole.mockResolvedValue(TEACHER);
+  getUserWithAccountType.mockResolvedValue(TEACHER);
   createInvitation.mockResolvedValue({ token: "tok", eventSeriesId: "s1", class: "3aWI" });
   invitationsOf.mockResolvedValue([]);
 });
@@ -50,7 +50,7 @@ describe("POST /api/event-series/[eventSeriesId]/invitations", () => {
 
   /** A student holding a link must not be able to mint one, least of all for another class. */
   it("refuses a student", async () => {
-    getUserWithRole.mockResolvedValue(STUDENT);
+    getUserWithAccountType.mockResolvedValue(STUDENT);
 
     const response = await POST(request({ class: "3aWI" }), context);
 
@@ -59,7 +59,7 @@ describe("POST /api/event-series/[eventSeriesId]/invitations", () => {
   });
 
   it("refuses a caller with no session", async () => {
-    getUserWithRole.mockResolvedValue(null);
+    getUserWithAccountType.mockResolvedValue(null);
 
     const response = await POST(request({ class: "3aWI" }), context);
 
@@ -109,7 +109,7 @@ describe("GET /api/event-series/[eventSeriesId]/invitations", () => {
 
   /** A token is what enrols somebody, so reading one is enrolling (US-23). */
   it("refuses a student", async () => {
-    getUserWithRole.mockResolvedValue(STUDENT);
+    getUserWithAccountType.mockResolvedValue(STUDENT);
 
     const response = await GET(request({}), context);
 
@@ -118,7 +118,7 @@ describe("GET /api/event-series/[eventSeriesId]/invitations", () => {
   });
 
   it("refuses a caller with no session", async () => {
-    getUserWithRole.mockResolvedValue(null);
+    getUserWithAccountType.mockResolvedValue(null);
 
     const response = await GET(request({}), context);
 

--- a/src/app/api/event-series/[eventSeriesId]/invitations/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/invitations/route.test.ts
@@ -5,11 +5,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithAccountType = vi.fn();
+const getAuthenticatedUser = vi.fn();
 const createInvitation = vi.fn();
 const invitationsOf = vi.fn();
 
-vi.mock("@/lib/auth/guards", () => ({ getUserWithAccountType: () => getUserWithAccountType() }));
+vi.mock("@/lib/auth/guards", () => ({ getAuthenticatedUser: () => getAuthenticatedUser() }));
 vi.mock("@/lib/invitations/invitation-service", () => ({
   createInvitation: (...args: unknown[]) => createInvitation(...args),
   invitationsOf: (...args: unknown[]) => invitationsOf(...args),
@@ -18,7 +18,12 @@ vi.mock("@/lib/invitations/invitation-service", () => ({
 const { GET, POST } = await import("./route");
 const { ServiceError } = await import("@/lib/service-error");
 
-const TEACHER = { uid: "u1", email: "t@htldornbirn.at", accountType: "teacher" };
+const TEACHER = {
+  uid: "u1",
+  email: "t@htldornbirn.at",
+  accountType: "teacher",
+  permissions: ["editAssignments"],
+};
 const STUDENT = { uid: "u2", email: "s@student.htldornbirn.at", accountType: "student" };
 
 function request(body: unknown) {
@@ -32,7 +37,7 @@ const context = { params: Promise.resolve({ eventSeriesId: "s1" }) };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithAccountType.mockResolvedValue(TEACHER);
+  getAuthenticatedUser.mockResolvedValue(TEACHER);
   createInvitation.mockResolvedValue({ token: "tok", eventSeriesId: "s1", class: "3aWI" });
   invitationsOf.mockResolvedValue([]);
 });
@@ -50,7 +55,20 @@ describe("POST /api/event-series/[eventSeriesId]/invitations", () => {
 
   /** A student holding a link must not be able to mint one, least of all for another class. */
   it("refuses a student", async () => {
-    getUserWithAccountType.mockResolvedValue(STUDENT);
+    getAuthenticatedUser.mockResolvedValue(STUDENT);
+
+    const response = await POST(request({ class: "3aWI" }), context);
+
+    expect(response.status).toBe(403);
+    expect(createInvitation).not.toHaveBeenCalled();
+  });
+
+  /** Inviting a class is planning who takes part, which is not the same as reporting on them. */
+  it("refuses a teacher who may not edit assignments", async () => {
+    getAuthenticatedUser.mockResolvedValue({
+      ...TEACHER,
+      permissions: ["viewReports", "editReports", "editMasterData"],
+    });
 
     const response = await POST(request({ class: "3aWI" }), context);
 
@@ -59,7 +77,7 @@ describe("POST /api/event-series/[eventSeriesId]/invitations", () => {
   });
 
   it("refuses a caller with no session", async () => {
-    getUserWithAccountType.mockResolvedValue(null);
+    getAuthenticatedUser.mockResolvedValue(null);
 
     const response = await POST(request({ class: "3aWI" }), context);
 
@@ -109,7 +127,7 @@ describe("GET /api/event-series/[eventSeriesId]/invitations", () => {
 
   /** A token is what enrols somebody, so reading one is enrolling (US-23). */
   it("refuses a student", async () => {
-    getUserWithAccountType.mockResolvedValue(STUDENT);
+    getAuthenticatedUser.mockResolvedValue(STUDENT);
 
     const response = await GET(request({}), context);
 
@@ -118,7 +136,7 @@ describe("GET /api/event-series/[eventSeriesId]/invitations", () => {
   });
 
   it("refuses a caller with no session", async () => {
-    getUserWithAccountType.mockResolvedValue(null);
+    getAuthenticatedUser.mockResolvedValue(null);
 
     const response = await GET(request({}), context);
 

--- a/src/app/api/event-series/[eventSeriesId]/invitations/route.ts
+++ b/src/app/api/event-series/[eventSeriesId]/invitations/route.ts
@@ -5,7 +5,11 @@
  */
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { handleServiceFailure, parseJsonBody, requireTeacherOrResponse } from "@/lib/api/handler";
+import {
+  handleServiceFailure,
+  parseJsonBody,
+  requirePermissionOrResponse,
+} from "@/lib/api/handler";
 import { createInvitation, invitationsOf } from "@/lib/invitations/invitation-service";
 import { listItemNameSchema } from "@/lib/schemas/master-data";
 
@@ -19,7 +23,7 @@ type Context = { params: Promise<{ eventSeriesId: string }> };
  * rule grants a whole document to everyone it grants it to, and a token is the enrolment itself.
  */
 export async function GET(_request: Request, context: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editAssignments");
   if (denied) return denied;
 
   const { eventSeriesId } = await context.params;
@@ -41,7 +45,7 @@ export async function GET(_request: Request, context: Context) {
  * a rule would hand to everyone the document is readable by is not a secret.
  */
 export async function POST(request: Request, context: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editAssignments");
   if (denied) return denied;
 
   const { eventSeriesId } = await context.params;

--- a/src/app/api/event-series/[eventSeriesId]/master-data/[category]/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/master-data/[category]/route.test.ts
@@ -5,7 +5,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithRole = vi.fn();
+const getUserWithAccountType = vi.fn();
 const createMasterDataItem = vi.fn();
 const updateMasterDataItem = vi.fn();
 const deleteMasterDataItem = vi.fn();
@@ -14,7 +14,7 @@ const readMasterDataItems = vi.fn();
 const usageReport = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
-  getUserWithRole: () => getUserWithRole(),
+  getUserWithAccountType: () => getUserWithAccountType(),
 }));
 
 vi.mock("@/lib/master-data/master-data-service", () => ({
@@ -33,7 +33,7 @@ const { DELETE, GET, PATCH, POST } = await import("./route");
 const { ServiceError } = await import("@/lib/service-error");
 const { MASTER_DATA_CATEGORIES } = await import("@/lib/master-data/categories");
 
-const STUDENT = { uid: "u2", email: "s@student.htldornbirn.at", role: "student" };
+const STUDENT = { uid: "u2", email: "s@student.htldornbirn.at", accountType: "student" };
 
 function request(method: string, body: unknown) {
   return new Request("https://example.com/api/master-data/classes", {
@@ -48,7 +48,11 @@ function context(category: string, eventSeriesId = "s1") {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithRole.mockResolvedValue({ uid: "u1", email: "t@htldornbirn.at", role: "teacher" });
+  getUserWithAccountType.mockResolvedValue({
+    uid: "u1",
+    email: "t@htldornbirn.at",
+    accountType: "teacher",
+  });
   createMasterDataItem.mockResolvedValue({ name: "3AHIT" });
   updateMasterDataItem.mockResolvedValue({ name: "3BHIT" });
   deleteMasterDataItem.mockResolvedValue(undefined);
@@ -84,7 +88,7 @@ describe("POST /api/master-data/[category]", () => {
   });
 
   it("rejects an anonymous caller with 401", async () => {
-    getUserWithRole.mockResolvedValue(null);
+    getUserWithAccountType.mockResolvedValue(null);
 
     const response = await POST(request("POST", { name: "3AHIT" }), context("classes"));
 
@@ -93,7 +97,7 @@ describe("POST /api/master-data/[category]", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot write", async () => {
-    getUserWithRole.mockResolvedValue(STUDENT);
+    getUserWithAccountType.mockResolvedValue(STUDENT);
 
     const response = await POST(request("POST", { name: "3AHIT" }), context("classes"));
 
@@ -155,7 +159,7 @@ describe("PATCH /api/master-data/[category] — reordering", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot reorder", async () => {
-    getUserWithRole.mockResolvedValue(STUDENT);
+    getUserWithAccountType.mockResolvedValue(STUDENT);
 
     const response = await PATCH(request("PATCH", { order: ["3AHIT"] }), context("classes"));
 
@@ -261,7 +265,7 @@ describe("PATCH /api/master-data/[category] — editing one item", () => {
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithRole.mockResolvedValue(STUDENT);
+    getUserWithAccountType.mockResolvedValue(STUDENT);
 
     const response = await PATCH(
       request("PATCH", { item: "3AHIT", name: "3BHIT" }),
@@ -305,7 +309,7 @@ describe("DELETE /api/master-data/[category]", () => {
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithRole.mockResolvedValue(STUDENT);
+    getUserWithAccountType.mockResolvedValue(STUDENT);
 
     const response = await DELETE(request("DELETE", { item: "3AHIT" }), context("classes"));
 
@@ -339,7 +343,7 @@ describe("GET /api/master-data/[category]", () => {
   });
 
   it("rejects a student, since the answer is derived from data they cannot read", async () => {
-    getUserWithRole.mockResolvedValue(STUDENT);
+    getUserWithAccountType.mockResolvedValue(STUDENT);
 
     const response = await GET(new Request("https://example.com"), context("classes"));
 

--- a/src/app/api/event-series/[eventSeriesId]/master-data/[category]/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/master-data/[category]/route.test.ts
@@ -5,7 +5,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithAccountType = vi.fn();
+const getAuthenticatedUser = vi.fn();
 const createMasterDataItem = vi.fn();
 const updateMasterDataItem = vi.fn();
 const deleteMasterDataItem = vi.fn();
@@ -14,7 +14,7 @@ const readMasterDataItems = vi.fn();
 const usageReport = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
-  getUserWithAccountType: () => getUserWithAccountType(),
+  getAuthenticatedUser: () => getAuthenticatedUser(),
 }));
 
 vi.mock("@/lib/master-data/master-data-service", () => ({
@@ -48,10 +48,11 @@ function context(category: string, eventSeriesId = "s1") {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithAccountType.mockResolvedValue({
+  getAuthenticatedUser.mockResolvedValue({
     uid: "u1",
     email: "t@htldornbirn.at",
     accountType: "teacher",
+    permissions: ["editMasterData"],
   });
   createMasterDataItem.mockResolvedValue({ name: "3AHIT" });
   updateMasterDataItem.mockResolvedValue({ name: "3BHIT" });
@@ -88,7 +89,7 @@ describe("POST /api/master-data/[category]", () => {
   });
 
   it("rejects an anonymous caller with 401", async () => {
-    getUserWithAccountType.mockResolvedValue(null);
+    getAuthenticatedUser.mockResolvedValue(null);
 
     const response = await POST(request("POST", { name: "3AHIT" }), context("classes"));
 
@@ -97,12 +98,27 @@ describe("POST /api/master-data/[category]", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot write", async () => {
-    getUserWithAccountType.mockResolvedValue(STUDENT);
+    getAuthenticatedUser.mockResolvedValue(STUDENT);
 
     const response = await POST(request("POST", { name: "3AHIT" }), context("classes"));
 
     expect(response.status).toBe(403);
     expect(await response.json()).toMatchObject({ error: { code: "PERMISSION_DENIED" } });
+    expect(createMasterDataItem).not.toHaveBeenCalled();
+  });
+
+  /** The lists are their own permission: planning with them is not the same as maintaining them. */
+  it("rejects a teacher who may not edit master data", async () => {
+    getAuthenticatedUser.mockResolvedValue({
+      uid: "u3",
+      email: "t2@htldornbirn.at",
+      accountType: "teacher",
+      permissions: ["viewReports", "editReports", "editAssignments"],
+    });
+
+    const response = await POST(request("POST", { name: "3AHIT" }), context("classes"));
+
+    expect(response.status).toBe(403);
     expect(createMasterDataItem).not.toHaveBeenCalled();
   });
 
@@ -159,7 +175,7 @@ describe("PATCH /api/master-data/[category] — reordering", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot reorder", async () => {
-    getUserWithAccountType.mockResolvedValue(STUDENT);
+    getAuthenticatedUser.mockResolvedValue(STUDENT);
 
     const response = await PATCH(request("PATCH", { order: ["3AHIT"] }), context("classes"));
 
@@ -265,7 +281,7 @@ describe("PATCH /api/master-data/[category] — editing one item", () => {
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithAccountType.mockResolvedValue(STUDENT);
+    getAuthenticatedUser.mockResolvedValue(STUDENT);
 
     const response = await PATCH(
       request("PATCH", { item: "3AHIT", name: "3BHIT" }),
@@ -309,7 +325,7 @@ describe("DELETE /api/master-data/[category]", () => {
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithAccountType.mockResolvedValue(STUDENT);
+    getAuthenticatedUser.mockResolvedValue(STUDENT);
 
     const response = await DELETE(request("DELETE", { item: "3AHIT" }), context("classes"));
 
@@ -343,7 +359,7 @@ describe("GET /api/master-data/[category]", () => {
   });
 
   it("rejects a student, since the answer is derived from data they cannot read", async () => {
-    getUserWithAccountType.mockResolvedValue(STUDENT);
+    getAuthenticatedUser.mockResolvedValue(STUDENT);
 
     const response = await GET(new Request("https://example.com"), context("classes"));
 

--- a/src/app/api/event-series/[eventSeriesId]/master-data/[category]/route.ts
+++ b/src/app/api/event-series/[eventSeriesId]/master-data/[category]/route.ts
@@ -9,7 +9,7 @@ import {
   errorResponse,
   handleServiceFailure,
   parseJsonBody,
-  requireTeacherOrResponse,
+  requirePermissionOrResponse,
 } from "@/lib/api/handler";
 import { ErrorCode } from "@/lib/errors";
 import { listItemNameSchema, requiredEquipmentSchema } from "@/lib/schemas/master-data";
@@ -61,7 +61,7 @@ async function readTarget({ params }: Context) {
 }
 
 export async function POST(request: Request, context: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editMasterData");
   if (denied) return denied;
 
   const { eventSeriesId, category } = await readTarget(context);
@@ -85,7 +85,7 @@ export async function POST(request: Request, context: Context) {
  * changes no stored name, so no registration can be affected (see Ordering).
  */
 export async function PATCH(request: Request, context: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editMasterData");
   if (denied) return denied;
 
   const { eventSeriesId, category } = await readTarget(context);
@@ -112,7 +112,7 @@ export async function PATCH(request: Request, context: Context) {
 }
 
 export async function DELETE(request: Request, context: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editMasterData");
   if (denied) return denied;
 
   const { eventSeriesId, category } = await readTarget(context);
@@ -137,7 +137,7 @@ export async function DELETE(request: Request, context: Context) {
  * so the list cannot work this out for itself — and a teacher is the only role that sees it.
  */
 export async function GET(_request: Request, context: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editMasterData");
   if (denied) return denied;
 
   const { eventSeriesId: named, category } = await readTarget(context);

--- a/src/app/api/event-series/[eventSeriesId]/registrations/[studentUpn]/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/registrations/[studentUpn]/route.test.ts
@@ -5,10 +5,10 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithRole = vi.fn();
+const getUserWithAccountType = vi.fn();
 const deleteRegistration = vi.fn();
 
-vi.mock("@/lib/auth/guards", () => ({ getUserWithRole: () => getUserWithRole() }));
+vi.mock("@/lib/auth/guards", () => ({ getUserWithAccountType: () => getUserWithAccountType() }));
 vi.mock("@/lib/registration/registration-service", () => ({
   deleteRegistration: (...args: unknown[]) => deleteRegistration(...args),
 }));
@@ -25,7 +25,7 @@ const paramsFor = (studentUpn: string) => Promise.resolve({ eventSeriesId: "s1",
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithRole.mockResolvedValue({ uid: "u1", email: TEACHER, role: "teacher" });
+  getUserWithAccountType.mockResolvedValue({ uid: "u1", email: TEACHER, accountType: "teacher" });
   deleteRegistration.mockResolvedValue(undefined);
 });
 
@@ -46,7 +46,7 @@ describe("DELETE /api/event-series/[eventSeriesId]/registrations/[studentUpn]", 
 
   /** A student who is not coming answers "no" (US-11); removing one is a teacher's doing. */
   it("refuses a student, and writes nothing", async () => {
-    getUserWithRole.mockResolvedValue({ uid: "u2", email: STUDENT, role: "student" });
+    getUserWithAccountType.mockResolvedValue({ uid: "u2", email: STUDENT, accountType: "student" });
 
     const response = await DELETE(request, { params: paramsFor(STUDENT) });
 
@@ -55,7 +55,7 @@ describe("DELETE /api/event-series/[eventSeriesId]/registrations/[studentUpn]", 
   });
 
   it("refuses a caller with no session at all", async () => {
-    getUserWithRole.mockResolvedValue(null);
+    getUserWithAccountType.mockResolvedValue(null);
 
     const response = await DELETE(request, { params: paramsFor(STUDENT) });
 

--- a/src/app/api/event-series/[eventSeriesId]/registrations/[studentUpn]/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/registrations/[studentUpn]/route.test.ts
@@ -5,10 +5,10 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithAccountType = vi.fn();
+const getAuthenticatedUser = vi.fn();
 const deleteRegistration = vi.fn();
 
-vi.mock("@/lib/auth/guards", () => ({ getUserWithAccountType: () => getUserWithAccountType() }));
+vi.mock("@/lib/auth/guards", () => ({ getAuthenticatedUser: () => getAuthenticatedUser() }));
 vi.mock("@/lib/registration/registration-service", () => ({
   deleteRegistration: (...args: unknown[]) => deleteRegistration(...args),
 }));
@@ -25,7 +25,12 @@ const paramsFor = (studentUpn: string) => Promise.resolve({ eventSeriesId: "s1",
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithAccountType.mockResolvedValue({ uid: "u1", email: TEACHER, accountType: "teacher" });
+  getAuthenticatedUser.mockResolvedValue({
+    uid: "u1",
+    email: TEACHER,
+    accountType: "teacher",
+    permissions: ["editAssignments"],
+  });
   deleteRegistration.mockResolvedValue(undefined);
 });
 
@@ -46,7 +51,22 @@ describe("DELETE /api/event-series/[eventSeriesId]/registrations/[studentUpn]", 
 
   /** A student who is not coming answers "no" (US-11); removing one is a teacher's doing. */
   it("refuses a student, and writes nothing", async () => {
-    getUserWithAccountType.mockResolvedValue({ uid: "u2", email: STUDENT, accountType: "student" });
+    getAuthenticatedUser.mockResolvedValue({ uid: "u2", email: STUDENT, accountType: "student" });
+
+    const response = await DELETE(request, { params: paramsFor(STUDENT) });
+
+    expect(response.status).toBe(403);
+    expect(deleteRegistration).not.toHaveBeenCalled();
+  });
+
+  /** Removing somebody from the series is planning, not reporting on what was planned. */
+  it("refuses a teacher who may not edit assignments", async () => {
+    getAuthenticatedUser.mockResolvedValue({
+      uid: "u3",
+      email: "t2@htldornbirn.at",
+      accountType: "teacher",
+      permissions: ["viewReports", "editReports", "editMasterData"],
+    });
 
     const response = await DELETE(request, { params: paramsFor(STUDENT) });
 
@@ -55,7 +75,7 @@ describe("DELETE /api/event-series/[eventSeriesId]/registrations/[studentUpn]", 
   });
 
   it("refuses a caller with no session at all", async () => {
-    getUserWithAccountType.mockResolvedValue(null);
+    getAuthenticatedUser.mockResolvedValue(null);
 
     const response = await DELETE(request, { params: paramsFor(STUDENT) });
 

--- a/src/app/api/event-series/[eventSeriesId]/registrations/[studentUpn]/route.ts
+++ b/src/app/api/event-series/[eventSeriesId]/registrations/[studentUpn]/route.ts
@@ -4,7 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { NextResponse } from "next/server";
-import { handleServiceFailure, requireTeacherOrResponse } from "@/lib/api/handler";
+import { handleServiceFailure, requirePermissionOrResponse } from "@/lib/api/handler";
 import { deleteRegistration } from "@/lib/registration/registration-service";
 
 type Context = { params: Promise<{ eventSeriesId: string; studentUpn: string }> };
@@ -14,7 +14,7 @@ type Context = { params: Promise<{ eventSeriesId: string; studentUpn: string }> 
  * not coming answers "no" (US-11), and this endpoint is closed to them by the guard.
  */
 export async function DELETE(_request: Request, { params }: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editAssignments");
   if (denied) return denied;
 
   const { eventSeriesId, studentUpn } = await params;

--- a/src/app/api/event-series/[eventSeriesId]/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/route.test.ts
@@ -5,12 +5,12 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithRole = vi.fn();
+const getUserWithAccountType = vi.fn();
 const updateEventSeries = vi.fn();
 const deleteEventSeries = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
-  getUserWithRole: () => getUserWithRole(),
+  getUserWithAccountType: () => getUserWithAccountType(),
 }));
 
 vi.mock("@/lib/event-series/event-series-service", () => ({
@@ -35,10 +35,14 @@ function deleteRequest() {
 }
 
 beforeEach(() => {
-  getUserWithRole.mockReset();
+  getUserWithAccountType.mockReset();
   updateEventSeries.mockReset();
   deleteEventSeries.mockReset();
-  getUserWithRole.mockResolvedValue({ uid: "u1", email: "t@htldornbirn.at", role: "teacher" });
+  getUserWithAccountType.mockResolvedValue({
+    uid: "u1",
+    email: "t@htldornbirn.at",
+    accountType: "teacher",
+  });
   updateEventSeries.mockResolvedValue({
     id: "s1",
     name: "Winter",
@@ -88,14 +92,14 @@ describe("PATCH /api/event-series/[eventSeriesId]", () => {
   });
 
   it("rejects an unknown field instead of silently dropping it", async () => {
-    const response = await PATCH(patchRequest({ role: "teacher" }), context);
+    const response = await PATCH(patchRequest({ accountType: "teacher" }), context);
 
     expect(response.status).toBe(400);
     expect(updateEventSeries).not.toHaveBeenCalled();
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithRole.mockResolvedValue({ uid: "u2", email: "s@x", role: "student" });
+    getUserWithAccountType.mockResolvedValue({ uid: "u2", email: "s@x", accountType: "student" });
 
     const response = await PATCH(patchRequest({ name: "X" }), context);
 
@@ -132,7 +136,7 @@ describe("DELETE /api/event-series/[eventSeriesId]", () => {
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithRole.mockResolvedValue({ uid: "u2", email: "s@x", role: "student" });
+    getUserWithAccountType.mockResolvedValue({ uid: "u2", email: "s@x", accountType: "student" });
 
     const response = await DELETE(deleteRequest(), context);
 

--- a/src/app/api/event-series/[eventSeriesId]/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/route.test.ts
@@ -5,12 +5,12 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithAccountType = vi.fn();
+const getAuthenticatedUser = vi.fn();
 const updateEventSeries = vi.fn();
 const deleteEventSeries = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
-  getUserWithAccountType: () => getUserWithAccountType(),
+  getAuthenticatedUser: () => getAuthenticatedUser(),
 }));
 
 vi.mock("@/lib/event-series/event-series-service", () => ({
@@ -35,13 +35,14 @@ function deleteRequest() {
 }
 
 beforeEach(() => {
-  getUserWithAccountType.mockReset();
+  getAuthenticatedUser.mockReset();
   updateEventSeries.mockReset();
   deleteEventSeries.mockReset();
-  getUserWithAccountType.mockResolvedValue({
+  getAuthenticatedUser.mockResolvedValue({
     uid: "u1",
     email: "t@htldornbirn.at",
     accountType: "teacher",
+    permissions: ["editMasterData"],
   });
   updateEventSeries.mockResolvedValue({
     id: "s1",
@@ -92,14 +93,32 @@ describe("PATCH /api/event-series/[eventSeriesId]", () => {
   });
 
   it("rejects an unknown field instead of silently dropping it", async () => {
-    const response = await PATCH(patchRequest({ accountType: "teacher" }), context);
+    const response = await PATCH(
+      patchRequest({ accountType: "teacher", permissions: ["editMasterData"] }),
+      context,
+    );
 
     expect(response.status).toBe(400);
     expect(updateEventSeries).not.toHaveBeenCalled();
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithAccountType.mockResolvedValue({ uid: "u2", email: "s@x", accountType: "student" });
+    getAuthenticatedUser.mockResolvedValue({ uid: "u2", email: "s@x", accountType: "student" });
+
+    const response = await PATCH(patchRequest({ name: "X" }), context);
+
+    expect(response.status).toBe(403);
+    expect(updateEventSeries).not.toHaveBeenCalled();
+  });
+
+  /** The series and its lists are master data; planning inside one is a different permission. */
+  it("rejects a teacher who may not edit master data", async () => {
+    getAuthenticatedUser.mockResolvedValue({
+      uid: "u3",
+      email: "t2@htldornbirn.at",
+      accountType: "teacher",
+      permissions: ["viewReports", "editReports", "editAssignments"],
+    });
 
     const response = await PATCH(patchRequest({ name: "X" }), context);
 
@@ -136,7 +155,7 @@ describe("DELETE /api/event-series/[eventSeriesId]", () => {
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithAccountType.mockResolvedValue({ uid: "u2", email: "s@x", accountType: "student" });
+    getAuthenticatedUser.mockResolvedValue({ uid: "u2", email: "s@x", accountType: "student" });
 
     const response = await DELETE(deleteRequest(), context);
 

--- a/src/app/api/event-series/[eventSeriesId]/route.ts
+++ b/src/app/api/event-series/[eventSeriesId]/route.ts
@@ -5,7 +5,11 @@
  */
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { handleServiceFailure, parseJsonBody, requireTeacherOrResponse } from "@/lib/api/handler";
+import {
+  handleServiceFailure,
+  parseJsonBody,
+  requirePermissionOrResponse,
+} from "@/lib/api/handler";
 import { eventSeriesSchema } from "@/lib/schemas/event-series";
 import { deleteEventSeries, updateEventSeries } from "@/lib/event-series/event-series-service";
 
@@ -21,7 +25,7 @@ const updateEventSeriesSchema = z
 type Context = { params: Promise<{ eventSeriesId: string }> };
 
 export async function PATCH(request: Request, { params }: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editMasterData");
   if (denied) return denied;
 
   const body = await parseJsonBody(request, updateEventSeriesSchema);
@@ -38,7 +42,7 @@ export async function PATCH(request: Request, { params }: Context) {
 }
 
 export async function DELETE(_request: Request, { params }: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editMasterData");
   if (denied) return denied;
 
   const { eventSeriesId } = await params;

--- a/src/app/api/event-series/[eventSeriesId]/saved-reports/[reportId]/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/saved-reports/[reportId]/route.test.ts
@@ -6,11 +6,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_FILTER, toggleTag } from "@/lib/filters/student-filter";
 
-const getUserWithRole = vi.fn();
+const getUserWithAccountType = vi.fn();
 const updateSavedReport = vi.fn();
 const deleteSavedReport = vi.fn();
 
-vi.mock("@/lib/auth/guards", () => ({ getUserWithRole: () => getUserWithRole() }));
+vi.mock("@/lib/auth/guards", () => ({ getUserWithAccountType: () => getUserWithAccountType() }));
 vi.mock("@/lib/report/saved-report-service", () => ({
   updateSavedReport: (...args: unknown[]) => updateSavedReport(...args),
   deleteSavedReport: (...args: unknown[]) => deleteSavedReport(...args),
@@ -41,7 +41,7 @@ function patchRequest(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithRole.mockResolvedValue({ uid: "u1", email: TEACHER, role: "teacher" });
+  getUserWithAccountType.mockResolvedValue({ uid: "u1", email: TEACHER, accountType: "teacher" });
   updateSavedReport.mockResolvedValue(report);
   deleteSavedReport.mockResolvedValue(undefined);
 });
@@ -80,7 +80,11 @@ describe("PATCH /api/event-series/[eventSeriesId]/saved-reports/[reportId]", () 
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithRole.mockResolvedValue({ uid: "u2", email: "s@x.at", role: "student" });
+    getUserWithAccountType.mockResolvedValue({
+      uid: "u2",
+      email: "s@x.at",
+      accountType: "student",
+    });
 
     expect((await PATCH(patchRequest(report), { params })).status).toBe(403);
     expect(updateSavedReport).not.toHaveBeenCalled();
@@ -110,7 +114,11 @@ describe("DELETE /api/event-series/[eventSeriesId]/saved-reports/[reportId]", ()
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithRole.mockResolvedValue({ uid: "u2", email: "s@x.at", role: "student" });
+    getUserWithAccountType.mockResolvedValue({
+      uid: "u2",
+      email: "s@x.at",
+      accountType: "student",
+    });
 
     expect((await DELETE(new Request("https://example.com"), { params })).status).toBe(403);
     expect(deleteSavedReport).not.toHaveBeenCalled();

--- a/src/app/api/event-series/[eventSeriesId]/saved-reports/[reportId]/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/saved-reports/[reportId]/route.test.ts
@@ -6,11 +6,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_FILTER, toggleTag } from "@/lib/filters/student-filter";
 
-const getUserWithAccountType = vi.fn();
+const getAuthenticatedUser = vi.fn();
 const updateSavedReport = vi.fn();
 const deleteSavedReport = vi.fn();
 
-vi.mock("@/lib/auth/guards", () => ({ getUserWithAccountType: () => getUserWithAccountType() }));
+vi.mock("@/lib/auth/guards", () => ({ getAuthenticatedUser: () => getAuthenticatedUser() }));
 vi.mock("@/lib/report/saved-report-service", () => ({
   updateSavedReport: (...args: unknown[]) => updateSavedReport(...args),
   deleteSavedReport: (...args: unknown[]) => deleteSavedReport(...args),
@@ -41,7 +41,12 @@ function patchRequest(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithAccountType.mockResolvedValue({ uid: "u1", email: TEACHER, accountType: "teacher" });
+  getAuthenticatedUser.mockResolvedValue({
+    uid: "u1",
+    email: TEACHER,
+    accountType: "teacher",
+    permissions: ["editReports"],
+  });
   updateSavedReport.mockResolvedValue(report);
   deleteSavedReport.mockResolvedValue(undefined);
 });
@@ -80,10 +85,23 @@ describe("PATCH /api/event-series/[eventSeriesId]/saved-reports/[reportId]", () 
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithAccountType.mockResolvedValue({
+    getAuthenticatedUser.mockResolvedValue({
       uid: "u2",
       email: "s@x.at",
       accountType: "student",
+    });
+
+    expect((await PATCH(patchRequest(report), { params })).status).toBe(403);
+    expect(updateSavedReport).not.toHaveBeenCalled();
+  });
+
+  /** Changing what a saved report holds is editing it, which viewing one does not grant. */
+  it("rejects a teacher who may only view reports", async () => {
+    getAuthenticatedUser.mockResolvedValue({
+      uid: "u3",
+      email: "t2@htldornbirn.at",
+      accountType: "teacher",
+      permissions: ["viewReports", "editAssignments", "editMasterData"],
     });
 
     expect((await PATCH(patchRequest(report), { params })).status).toBe(403);
@@ -114,7 +132,7 @@ describe("DELETE /api/event-series/[eventSeriesId]/saved-reports/[reportId]", ()
   });
 
   it("rejects a student with 403", async () => {
-    getUserWithAccountType.mockResolvedValue({
+    getAuthenticatedUser.mockResolvedValue({
       uid: "u2",
       email: "s@x.at",
       accountType: "student",

--- a/src/app/api/event-series/[eventSeriesId]/saved-reports/[reportId]/route.ts
+++ b/src/app/api/event-series/[eventSeriesId]/saved-reports/[reportId]/route.ts
@@ -4,7 +4,11 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { NextResponse } from "next/server";
-import { handleServiceFailure, parseJsonBody, requireTeacherOrResponse } from "@/lib/api/handler";
+import {
+  handleServiceFailure,
+  parseJsonBody,
+  requirePermissionOrResponse,
+} from "@/lib/api/handler";
 import { savedReportEditSchema } from "@/lib/schemas/saved-report";
 import { deleteSavedReport, updateSavedReport } from "@/lib/report/saved-report-service";
 
@@ -12,7 +16,7 @@ type Context = { params: Promise<{ eventSeriesId: string; reportId: string }> };
 
 /** One edit, whichever control sent it: the report as the teacher now has it, name included. */
 export async function PATCH(request: Request, { params }: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editReports");
   if (denied) return denied;
 
   const body = await parseJsonBody(request, savedReportEditSchema);
@@ -30,7 +34,7 @@ export async function PATCH(request: Request, { params }: Context) {
 
 /** Shared among all teachers, so any of them may remove one — including one they did not save. */
 export async function DELETE(_request: Request, { params }: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editReports");
   if (denied) return denied;
 
   const { eventSeriesId, reportId } = await params;

--- a/src/app/api/event-series/[eventSeriesId]/saved-reports/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/saved-reports/route.test.ts
@@ -6,11 +6,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_FILTER, toggleTag } from "@/lib/filters/student-filter";
 
-const getUserWithRole = vi.fn();
+const getUserWithAccountType = vi.fn();
 const createSavedReport = vi.fn();
 const reorderSavedReports = vi.fn();
 
-vi.mock("@/lib/auth/guards", () => ({ getUserWithRole: () => getUserWithRole() }));
+vi.mock("@/lib/auth/guards", () => ({ getUserWithAccountType: () => getUserWithAccountType() }));
 vi.mock("@/lib/report/saved-report-service", () => ({
   createSavedReport: (...args: unknown[]) => createSavedReport(...args),
   reorderSavedReports: (...args: unknown[]) => reorderSavedReports(...args),
@@ -41,7 +41,7 @@ function patchRequest(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithRole.mockResolvedValue({ uid: "u1", email: TEACHER, role: "teacher" });
+  getUserWithAccountType.mockResolvedValue({ uid: "u1", email: TEACHER, accountType: "teacher" });
   createSavedReport.mockResolvedValue({ id: "r1", ...input, createdByUserId: TEACHER });
   reorderSavedReports.mockResolvedValue(undefined);
 });
@@ -70,7 +70,11 @@ describe("POST /api/event-series/[eventSeriesId]/saved-reports", () => {
   });
 
   it("rejects a student with 403, since the report is a teacher's (US-13)", async () => {
-    getUserWithRole.mockResolvedValue({ uid: "u2", email: "s@x.at", role: "student" });
+    getUserWithAccountType.mockResolvedValue({
+      uid: "u2",
+      email: "s@x.at",
+      accountType: "student",
+    });
 
     const response = await POST(postRequest(input), context);
 
@@ -79,7 +83,7 @@ describe("POST /api/event-series/[eventSeriesId]/saved-reports", () => {
   });
 
   it("rejects an unauthenticated caller with 401", async () => {
-    getUserWithRole.mockResolvedValue(null);
+    getUserWithAccountType.mockResolvedValue(null);
 
     expect((await POST(postRequest(input), context)).status).toBe(401);
   });
@@ -113,7 +117,11 @@ describe("PATCH /api/event-series/[eventSeriesId]/saved-reports", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot reorder", async () => {
-    getUserWithRole.mockResolvedValue({ uid: "u2", email: "s@x.at", role: "student" });
+    getUserWithAccountType.mockResolvedValue({
+      uid: "u2",
+      email: "s@x.at",
+      accountType: "student",
+    });
 
     expect((await PATCH(patchRequest({ order: ["r1"] }), context)).status).toBe(403);
     expect(reorderSavedReports).not.toHaveBeenCalled();

--- a/src/app/api/event-series/[eventSeriesId]/saved-reports/route.test.ts
+++ b/src/app/api/event-series/[eventSeriesId]/saved-reports/route.test.ts
@@ -6,11 +6,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_FILTER, toggleTag } from "@/lib/filters/student-filter";
 
-const getUserWithAccountType = vi.fn();
+const getAuthenticatedUser = vi.fn();
 const createSavedReport = vi.fn();
 const reorderSavedReports = vi.fn();
 
-vi.mock("@/lib/auth/guards", () => ({ getUserWithAccountType: () => getUserWithAccountType() }));
+vi.mock("@/lib/auth/guards", () => ({ getAuthenticatedUser: () => getAuthenticatedUser() }));
 vi.mock("@/lib/report/saved-report-service", () => ({
   createSavedReport: (...args: unknown[]) => createSavedReport(...args),
   reorderSavedReports: (...args: unknown[]) => reorderSavedReports(...args),
@@ -41,7 +41,12 @@ function patchRequest(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithAccountType.mockResolvedValue({ uid: "u1", email: TEACHER, accountType: "teacher" });
+  getAuthenticatedUser.mockResolvedValue({
+    uid: "u1",
+    email: TEACHER,
+    accountType: "teacher",
+    permissions: ["editReports"],
+  });
   createSavedReport.mockResolvedValue({ id: "r1", ...input, createdByUserId: TEACHER });
   reorderSavedReports.mockResolvedValue(undefined);
 });
@@ -70,7 +75,7 @@ describe("POST /api/event-series/[eventSeriesId]/saved-reports", () => {
   });
 
   it("rejects a student with 403, since the report is a teacher's (US-13)", async () => {
-    getUserWithAccountType.mockResolvedValue({
+    getAuthenticatedUser.mockResolvedValue({
       uid: "u2",
       email: "s@x.at",
       accountType: "student",
@@ -82,8 +87,23 @@ describe("POST /api/event-series/[eventSeriesId]/saved-reports", () => {
     expect(createSavedReport).not.toHaveBeenCalled();
   });
 
+  /** Saving a report is its own permission: seeing one does not grant keeping it for everybody. */
+  it("rejects a teacher who may only view reports", async () => {
+    getAuthenticatedUser.mockResolvedValue({
+      uid: "u3",
+      email: "t2@htldornbirn.at",
+      accountType: "teacher",
+      permissions: ["viewReports", "editAssignments", "editMasterData"],
+    });
+
+    const response = await POST(postRequest(input), context);
+
+    expect(response.status).toBe(403);
+    expect(createSavedReport).not.toHaveBeenCalled();
+  });
+
   it("rejects an unauthenticated caller with 401", async () => {
-    getUserWithAccountType.mockResolvedValue(null);
+    getAuthenticatedUser.mockResolvedValue(null);
 
     expect((await POST(postRequest(input), context)).status).toBe(401);
   });
@@ -117,7 +137,7 @@ describe("PATCH /api/event-series/[eventSeriesId]/saved-reports", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot reorder", async () => {
-    getUserWithAccountType.mockResolvedValue({
+    getAuthenticatedUser.mockResolvedValue({
       uid: "u2",
       email: "s@x.at",
       accountType: "student",

--- a/src/app/api/event-series/[eventSeriesId]/saved-reports/route.ts
+++ b/src/app/api/event-series/[eventSeriesId]/saved-reports/route.ts
@@ -8,8 +8,8 @@ import { z } from "zod";
 import {
   handleServiceFailure,
   parseJsonBody,
-  requireTeacherIdentityOrResponse,
-  requireTeacherOrResponse,
+  requirePermissionIdentityOrResponse,
+  requirePermissionOrResponse,
 } from "@/lib/api/handler";
 import { orderSchema } from "@/lib/schemas/order";
 import { savedReportInputSchema } from "@/lib/schemas/saved-report";
@@ -20,7 +20,7 @@ const reorderSchema = z.strictObject({ order: orderSchema });
 type Context = { params: Promise<{ eventSeriesId: string }> };
 
 export async function POST(request: Request, context: Context) {
-  const teacher = await requireTeacherIdentityOrResponse();
+  const teacher = await requirePermissionIdentityOrResponse("editReports");
   if (!teacher.ok) return teacher.response;
 
   const body = await parseJsonBody(request, savedReportInputSchema);
@@ -38,7 +38,7 @@ export async function POST(request: Request, context: Context) {
 
 /** Reorders the tag row (see Ordering); it changes nothing a report holds, so it needs no guard. */
 export async function PATCH(request: Request, context: Context) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editReports");
   if (denied) return denied;
 
   const body = await parseJsonBody(request, reorderSchema);

--- a/src/app/api/event-series/route.test.ts
+++ b/src/app/api/event-series/route.test.ts
@@ -5,12 +5,12 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithRole = vi.fn();
+const getUserWithAccountType = vi.fn();
 const createEventSeries = vi.fn();
 const reorderEventSeries = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
-  getUserWithRole: () => getUserWithRole(),
+  getUserWithAccountType: () => getUserWithAccountType(),
 }));
 
 vi.mock("@/lib/event-series/event-series-service", () => ({
@@ -29,10 +29,14 @@ function postRequest(body: unknown) {
 }
 
 beforeEach(() => {
-  getUserWithRole.mockReset();
+  getUserWithAccountType.mockReset();
   createEventSeries.mockReset();
   reorderEventSeries.mockReset();
-  getUserWithRole.mockResolvedValue({ uid: "u1", email: "t@htldornbirn.at", role: "teacher" });
+  getUserWithAccountType.mockResolvedValue({
+    uid: "u1",
+    email: "t@htldornbirn.at",
+    accountType: "teacher",
+  });
   createEventSeries.mockResolvedValue({
     id: "s1",
     name: "Winter 2026",
@@ -71,7 +75,7 @@ describe("POST /api/event-series", () => {
   });
 
   it("rejects an anonymous caller with 401", async () => {
-    getUserWithRole.mockResolvedValue(null);
+    getUserWithAccountType.mockResolvedValue(null);
 
     const response = await POST(postRequest({ name: "Winter 2026" }));
 
@@ -83,10 +87,10 @@ describe("POST /api/event-series", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot write", async () => {
-    getUserWithRole.mockResolvedValue({
+    getUserWithAccountType.mockResolvedValue({
       uid: "u2",
       email: "s@student.htldornbirn.at",
-      role: "student",
+      accountType: "student",
     });
 
     const response = await POST(postRequest({ name: "Winter 2026" }));
@@ -154,10 +158,10 @@ describe("PATCH /api/event-series", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot reorder", async () => {
-    getUserWithRole.mockResolvedValue({
+    getUserWithAccountType.mockResolvedValue({
       uid: "u2",
       email: "s@student.htldornbirn.at",
-      role: "student",
+      accountType: "student",
     });
 
     const response = await PATCH(patchRequest({ order: ["s1"] }));

--- a/src/app/api/event-series/route.test.ts
+++ b/src/app/api/event-series/route.test.ts
@@ -5,12 +5,12 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithAccountType = vi.fn();
+const getAuthenticatedUser = vi.fn();
 const createEventSeries = vi.fn();
 const reorderEventSeries = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
-  getUserWithAccountType: () => getUserWithAccountType(),
+  getAuthenticatedUser: () => getAuthenticatedUser(),
 }));
 
 vi.mock("@/lib/event-series/event-series-service", () => ({
@@ -29,13 +29,14 @@ function postRequest(body: unknown) {
 }
 
 beforeEach(() => {
-  getUserWithAccountType.mockReset();
+  getAuthenticatedUser.mockReset();
   createEventSeries.mockReset();
   reorderEventSeries.mockReset();
-  getUserWithAccountType.mockResolvedValue({
+  getAuthenticatedUser.mockResolvedValue({
     uid: "u1",
     email: "t@htldornbirn.at",
     accountType: "teacher",
+    permissions: ["editMasterData"],
   });
   createEventSeries.mockResolvedValue({
     id: "s1",
@@ -75,7 +76,7 @@ describe("POST /api/event-series", () => {
   });
 
   it("rejects an anonymous caller with 401", async () => {
-    getUserWithAccountType.mockResolvedValue(null);
+    getAuthenticatedUser.mockResolvedValue(null);
 
     const response = await POST(postRequest({ name: "Winter 2026" }));
 
@@ -87,7 +88,7 @@ describe("POST /api/event-series", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot write", async () => {
-    getUserWithAccountType.mockResolvedValue({
+    getAuthenticatedUser.mockResolvedValue({
       uid: "u2",
       email: "s@student.htldornbirn.at",
       accountType: "student",
@@ -97,6 +98,21 @@ describe("POST /api/event-series", () => {
 
     expect(response.status).toBe(403);
     expect(await response.json()).toMatchObject({ error: { code: "PERMISSION_DENIED" } });
+    expect(createEventSeries).not.toHaveBeenCalled();
+  });
+
+  /** An event series is master data; planning inside one is a different permission. */
+  it("rejects a teacher who may not edit master data", async () => {
+    getAuthenticatedUser.mockResolvedValue({
+      uid: "u3",
+      email: "t2@htldornbirn.at",
+      accountType: "teacher",
+      permissions: ["viewReports", "editReports", "editAssignments"],
+    });
+
+    const response = await POST(postRequest({ name: "Winter 2026" }));
+
+    expect(response.status).toBe(403);
     expect(createEventSeries).not.toHaveBeenCalled();
   });
 
@@ -158,7 +174,7 @@ describe("PATCH /api/event-series", () => {
   });
 
   it("rejects a student with 403, so a bypassed client cannot reorder", async () => {
-    getUserWithAccountType.mockResolvedValue({
+    getAuthenticatedUser.mockResolvedValue({
       uid: "u2",
       email: "s@student.htldornbirn.at",
       accountType: "student",

--- a/src/app/api/event-series/route.ts
+++ b/src/app/api/event-series/route.ts
@@ -5,7 +5,11 @@
  */
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { handleServiceFailure, parseJsonBody, requireTeacherOrResponse } from "@/lib/api/handler";
+import {
+  handleServiceFailure,
+  parseJsonBody,
+  requirePermissionOrResponse,
+} from "@/lib/api/handler";
 import { orderSchema } from "@/lib/schemas/order";
 import { documentIdSchema } from "@/lib/schemas/common";
 import { eventSeriesSchema } from "@/lib/schemas/event-series";
@@ -23,7 +27,7 @@ const createEventSeriesSchema = z.strictObject({
 const reorderSchema = z.strictObject({ order: orderSchema });
 
 export async function POST(request: Request) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editMasterData");
   if (denied) return denied;
 
   const body = await parseJsonBody(request, createEventSeriesSchema);
@@ -39,7 +43,7 @@ export async function POST(request: Request) {
 
 /** Reorders the event series list (see Ordering); it changes no name or flag, so it needs no guard. */
 export async function PATCH(request: Request) {
-  const denied = await requireTeacherOrResponse();
+  const denied = await requirePermissionOrResponse("editMasterData");
   if (denied) return denied;
 
   const body = await parseJsonBody(request, reorderSchema);

--- a/src/app/api/my-registration/[eventSeriesId]/route.test.ts
+++ b/src/app/api/my-registration/[eventSeriesId]/route.test.ts
@@ -5,11 +5,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithAccountType = vi.fn();
+const getAuthenticatedUser = vi.fn();
 const saveRegistration = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
-  getUserWithAccountType: () => getUserWithAccountType(),
+  getAuthenticatedUser: () => getAuthenticatedUser(),
 }));
 
 vi.mock("@/lib/registration/registration-service", () => ({
@@ -61,7 +61,7 @@ const context = { params: Promise.resolve({ eventSeriesId: SERIES }) };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithAccountType.mockResolvedValue({ uid: "u1", email: STUDENT, accountType: "student" });
+  getAuthenticatedUser.mockResolvedValue({ uid: "u1", email: STUDENT, accountType: "student" });
   saveRegistration.mockResolvedValue({ id: STUDENT, class: "3AHME", ...body });
 });
 
@@ -84,7 +84,7 @@ describe("PUT /api/my-registration/[eventSeriesId]", () => {
   });
 
   it("rejects an anonymous caller with 401", async () => {
-    getUserWithAccountType.mockResolvedValue(null);
+    getAuthenticatedUser.mockResolvedValue(null);
 
     const response = await PUT(putRequest(body), context);
 
@@ -93,7 +93,7 @@ describe("PUT /api/my-registration/[eventSeriesId]", () => {
   });
 
   it("rejects a teacher with 403, since a teacher keeps no master data of their own", async () => {
-    getUserWithAccountType.mockResolvedValue({
+    getAuthenticatedUser.mockResolvedValue({
       uid: "u2",
       email: "t@htldornbirn.at",
       accountType: "teacher",
@@ -107,7 +107,7 @@ describe("PUT /api/my-registration/[eventSeriesId]", () => {
   });
 
   it("rejects a student whose session carries no address to key the record by", async () => {
-    getUserWithAccountType.mockResolvedValue({ uid: "u1", email: null, accountType: "student" });
+    getAuthenticatedUser.mockResolvedValue({ uid: "u1", email: null, accountType: "student" });
 
     const response = await PUT(putRequest(body), context);
 

--- a/src/app/api/my-registration/[eventSeriesId]/route.test.ts
+++ b/src/app/api/my-registration/[eventSeriesId]/route.test.ts
@@ -5,11 +5,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithRole = vi.fn();
+const getUserWithAccountType = vi.fn();
 const saveRegistration = vi.fn();
 
 vi.mock("@/lib/auth/guards", () => ({
-  getUserWithRole: () => getUserWithRole(),
+  getUserWithAccountType: () => getUserWithAccountType(),
 }));
 
 vi.mock("@/lib/registration/registration-service", () => ({
@@ -61,7 +61,7 @@ const context = { params: Promise.resolve({ eventSeriesId: SERIES }) };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithRole.mockResolvedValue({ uid: "u1", email: STUDENT, role: "student" });
+  getUserWithAccountType.mockResolvedValue({ uid: "u1", email: STUDENT, accountType: "student" });
   saveRegistration.mockResolvedValue({ id: STUDENT, class: "3AHME", ...body });
 });
 
@@ -84,7 +84,7 @@ describe("PUT /api/my-registration/[eventSeriesId]", () => {
   });
 
   it("rejects an anonymous caller with 401", async () => {
-    getUserWithRole.mockResolvedValue(null);
+    getUserWithAccountType.mockResolvedValue(null);
 
     const response = await PUT(putRequest(body), context);
 
@@ -93,7 +93,11 @@ describe("PUT /api/my-registration/[eventSeriesId]", () => {
   });
 
   it("rejects a teacher with 403, since a teacher keeps no master data of their own", async () => {
-    getUserWithRole.mockResolvedValue({ uid: "u2", email: "t@htldornbirn.at", role: "teacher" });
+    getUserWithAccountType.mockResolvedValue({
+      uid: "u2",
+      email: "t@htldornbirn.at",
+      accountType: "teacher",
+    });
 
     const response = await PUT(putRequest(body), context);
 
@@ -103,7 +107,7 @@ describe("PUT /api/my-registration/[eventSeriesId]", () => {
   });
 
   it("rejects a student whose session carries no address to key the record by", async () => {
-    getUserWithRole.mockResolvedValue({ uid: "u1", email: null, role: "student" });
+    getUserWithAccountType.mockResolvedValue({ uid: "u1", email: null, accountType: "student" });
 
     const response = await PUT(putRequest(body), context);
 

--- a/src/app/api/session/route.test.ts
+++ b/src/app/api/session/route.test.ts
@@ -40,7 +40,7 @@ describe("POST /api/session", () => {
     cookieStore.delete.mockReset();
     provisionUser.mockResolvedValue({
       ok: true,
-      user: { id: "jane@htldornbirn.at", role: "teacher" },
+      user: { id: "jane@htldornbirn.at", accountType: "teacher" },
     });
   });
 
@@ -50,7 +50,7 @@ describe("POST /api/session", () => {
 
     const response = await POST(postRequest({ idToken: "good-token" }));
 
-    expect(await response.json()).toMatchObject({ status: "ok", role: "teacher" });
+    expect(await response.json()).toMatchObject({ status: "ok", accountType: "teacher" });
   });
 
   it("returns 400 when idToken is missing", async () => {

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -85,9 +85,9 @@ export async function POST(request: Request) {
     path: "/",
   });
 
-  // Returning the role lets the client skip the /app landing hop, which would otherwise cost
+  // Returning the account type lets the client skip the /app landing hop, which would otherwise cost
   // another request and another session-cookie verification.
-  return NextResponse.json({ status: "ok", role: provisioned.user.role });
+  return NextResponse.json({ status: "ok", accountType: provisioned.user.accountType });
 }
 
 // Signs the user out by clearing the session cookie.

--- a/src/app/api/users/[upn]/route.test.ts
+++ b/src/app/api/users/[upn]/route.test.ts
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCode } from "@/lib/errors";
+import { ServiceError } from "@/lib/service-error";
+
+const getAuthenticatedUser = vi.fn();
+vi.mock("@/lib/auth/guards", () => ({ getAuthenticatedUser }));
+
+const grantPermissions = vi.fn();
+vi.mock("@/lib/users/user-service", () => ({
+  grantPermissions,
+  SELF_DEMOTION_HINT: "self",
+  NOT_A_TEACHER_HINT: "not a teacher",
+}));
+
+const { PATCH } = await import("@/app/api/users/[upn]/route");
+
+const ADMIN = "ada@htldornbirn.at";
+const TARGET = "bob@htldornbirn.at";
+
+const patch = (body: unknown, upn = TARGET) =>
+  PATCH(
+    new Request("http://localhost/api/users/x", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ upn: encodeURIComponent(upn) }) },
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAuthenticatedUser.mockResolvedValue({
+    uid: "u1",
+    email: ADMIN,
+    accountType: "teacher",
+    permissions: ["editUsers"],
+  });
+  grantPermissions.mockResolvedValue(["viewReports"]);
+});
+
+describe("PATCH /api/users/[upn]", () => {
+  it("grants the set the admin named", async () => {
+    const response = await patch({ permissions: ["viewReports"] });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ permissions: ["viewReports"] });
+    expect(grantPermissions).toHaveBeenCalledWith(TARGET, ["viewReports"], ADMIN);
+  });
+
+  /** A UPN is an address, and an address in a path arrives encoded. */
+  it("decodes the person the path names", async () => {
+    await patch({ permissions: [] }, "o'neill@htldornbirn.at");
+
+    expect(grantPermissions).toHaveBeenCalledWith("o'neill@htldornbirn.at", [], ADMIN);
+  });
+
+  /** Who is granting comes from the session, so a body cannot name somebody else as the actor. */
+  it("takes the granting person from the session and refuses one named in the body", async () => {
+    const response = await patch({ permissions: [], actorUpn: "someone.else@htldornbirn.at" });
+
+    expect(response.status).toBe(400);
+    expect(grantPermissions).not.toHaveBeenCalled();
+  });
+
+  it("refuses a permission nothing offers", async () => {
+    const response = await patch({ permissions: ["superuser"] });
+
+    expect(response.status).toBe(400);
+    expect(grantPermissions).not.toHaveBeenCalled();
+  });
+
+  it("refuses a body with nothing to grant", async () => {
+    const response = await patch({});
+
+    expect(response.status).toBe(400);
+    expect(grantPermissions).not.toHaveBeenCalled();
+  });
+
+  it("refuses a teacher who may not edit users", async () => {
+    getAuthenticatedUser.mockResolvedValue({
+      uid: "u2",
+      email: "t2@htldornbirn.at",
+      accountType: "teacher",
+      permissions: ["editMasterData", "editAssignments", "viewReports"],
+    });
+
+    const response = await patch({ permissions: ["viewReports"] });
+
+    expect(response.status).toBe(403);
+    expect(grantPermissions).not.toHaveBeenCalled();
+  });
+
+  it("refuses a student", async () => {
+    getAuthenticatedUser.mockResolvedValue({
+      uid: "u3",
+      email: "s@student.htldornbirn.at",
+      accountType: "student",
+      permissions: ["editUsers"],
+    });
+
+    expect((await patch({ permissions: [] })).status).toBe(403);
+    expect(grantPermissions).not.toHaveBeenCalled();
+  });
+
+  it("refuses a caller with no session", async () => {
+    getAuthenticatedUser.mockResolvedValue(null);
+
+    expect((await patch({ permissions: [] })).status).toBe(401);
+    expect(grantPermissions).not.toHaveBeenCalled();
+  });
+
+  it("passes a service refusal on in the shared envelope", async () => {
+    grantPermissions.mockRejectedValue(new ServiceError(ErrorCode.Conflict, "self"));
+
+    const response = await patch({ permissions: [] });
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: ErrorCode.Conflict, message: "self" },
+    });
+  });
+});

--- a/src/app/api/users/[upn]/route.ts
+++ b/src/app/api/users/[upn]/route.ts
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  handleServiceFailure,
+  parseJsonBody,
+  requirePermissionIdentityOrResponse,
+} from "@/lib/api/handler";
+import { permissionsInputSchema } from "@/lib/auth/permissions";
+import { grantPermissions } from "@/lib/users/user-service";
+
+type Context = { params: Promise<{ upn: string }> };
+
+/**
+ * Strict, so a body naming who is doing the granting fails rather than being quietly dropped:
+ * that comes from the session, and there is nothing here for a caller to point at somebody else.
+ */
+const grantSchema = z.object({ permissions: permissionsInputSchema }).strict();
+
+export async function PATCH(request: Request, context: Context) {
+  const admin = await requirePermissionIdentityOrResponse("editUsers");
+  if (!admin.ok) return admin.response;
+
+  const body = await parseJsonBody(request, grantSchema);
+  if (!body.ok) return body.response;
+
+  const { upn } = await context.params;
+
+  try {
+    const permissions = await grantPermissions(
+      decodeURIComponent(upn).toLowerCase(),
+      body.data.permissions,
+      admin.userId,
+    );
+    return NextResponse.json({ permissions });
+  } catch (error) {
+    return handleServiceFailure(error, "Granting permissions");
+  }
+}

--- a/src/app/app/(teacher)/[eventSeriesId]/assignment/layout.tsx
+++ b/src/app/app/(teacher)/[eventSeriesId]/assignment/layout.tsx
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import type { ReactNode } from "react";
+import { requirePermission } from "@/lib/auth/guards";
+
+/** Planning who goes to which event (US-12). */
+export default async function AssignmentLayout({ children }: { children: ReactNode }) {
+  await requirePermission("editAssignments");
+
+  return <>{children}</>;
+}

--- a/src/app/app/(teacher)/[eventSeriesId]/master-data/layout.tsx
+++ b/src/app/app/(teacher)/[eventSeriesId]/master-data/layout.tsx
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import type { ReactNode } from "react";
+import { requirePermission } from "@/lib/auth/guards";
+
+/** The seven lists of one event series (US-4 to US-10), which are master data to maintain. */
+export default async function MasterDataLayout({ children }: { children: ReactNode }) {
+  await requirePermission("editMasterData");
+
+  return <>{children}</>;
+}

--- a/src/app/app/(teacher)/[eventSeriesId]/overview/layout.tsx
+++ b/src/app/app/(teacher)/[eventSeriesId]/overview/layout.tsx
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import type { ReactNode } from "react";
+import { requirePermission } from "@/lib/auth/guards";
+
+/** What the series looks like so far (US-12), which is reading the registrations. */
+export default async function OverviewLayout({ children }: { children: ReactNode }) {
+  await requirePermission("viewReports");
+
+  return <>{children}</>;
+}

--- a/src/app/app/(teacher)/[eventSeriesId]/report/layout.tsx
+++ b/src/app/app/(teacher)/[eventSeriesId]/report/layout.tsx
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import type { ReactNode } from "react";
+import { requirePermission } from "@/lib/auth/guards";
+
+/**
+ * Reading the report (US-13). Saving one is a second permission, checked by the handler that
+ * stores it rather than here — the page is the same page either way.
+ */
+export default async function ReportLayout({ children }: { children: ReactNode }) {
+  await requirePermission("viewReports");
+
+  return <>{children}</>;
+}

--- a/src/app/app/(teacher)/event-series/layout.tsx
+++ b/src/app/app/(teacher)/event-series/layout.tsx
@@ -4,9 +4,12 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import type { ReactNode } from "react";
+import { requirePermission } from "@/lib/auth/guards";
 import { ShowArchivedProvider } from "@/lib/event-series/show-archived";
 
 /** Wraps the event series list and an event series' events, so walking between them keeps what was revealed. */
-export default function EventSeriesLayout({ children }: { children: ReactNode }) {
+export default async function EventSeriesLayout({ children }: { children: ReactNode }) {
+  await requirePermission("editMasterData");
+
   return <ShowArchivedProvider>{children}</ShowArchivedProvider>;
 }

--- a/src/app/app/(teacher)/users/page.tsx
+++ b/src/app/app/(teacher)/users/page.tsx
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { requirePermission } from "@/lib/auth/guards";
+import { UserPermissionsView } from "@/components/users/user-permissions-view";
+
+/**
+ * Who may do what (US-2). The signed-in admin is named so the row can say why their own right to
+ * grant is not on offer — taking it from yourself is what would leave nobody able to give it back.
+ */
+export default async function UsersPage() {
+  const admin = await requirePermission("editUsers");
+
+  return <UserPermissionsView signedInAs={admin.email?.toLowerCase() ?? ""} />;
+}

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -31,7 +31,11 @@ export default async function AppLayout({ children }: LayoutProps<"/app">) {
     <AppShell
       nav={
         isTeacher ? (
-          <TeacherNav fallbackEventSeriesId={fallbackEventSeriesId} photo={photo} />
+          <TeacherNav
+            fallbackEventSeriesId={fallbackEventSeriesId}
+            permissions={user.permissions}
+            photo={photo}
+          />
         ) : null
       }
       scope={isTeacher ? <EventSeriesTagRows /> : null}

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -14,7 +14,7 @@ import { EVENT_SERIES_COOKIE_NAME } from "@/lib/event-series/event-series-select
 // Both roles share this frame; only a teacher is given a navigation bar (US-14, US-15).
 export default async function AppLayout({ children }: LayoutProps<"/app">) {
   const user = await requireUser();
-  const isTeacher = user.role === "teacher";
+  const isTeacher = user.accountType === "teacher";
 
   // Read here rather than below the series id, where the layout renders once and then not again
   // while the teacher moves about beneath it. Resolved rather than trusted: a teacher who has

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -6,14 +6,22 @@
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { requireUser } from "@/lib/auth/guards";
+import { firstReachableHref } from "@/lib/auth/reachable-pages";
 import { resolveSelectedEventSeriesId } from "@/lib/event-series/event-series-service";
 import { EVENT_SERIES_COOKIE_NAME } from "@/lib/event-series/event-series-selection";
-import { eventSeriesRoutes, ROUTES } from "@/lib/routes";
+import { ROUTES } from "@/lib/routes";
+
+export const NO_PERMISSIONS_HINT =
+  "Für dich ist noch nichts freigeschaltet. Bitte wende dich an eine Person mit Administrationsrechten.";
 
 /**
- * Role-based landing (US-14, US-15). A teacher's pages are all about one event series, and which
- * one they were last in is not something signing in knows — so the cookie is read here and turned
- * into a scoped destination (Q8). With no series to select, the list is where they can make one.
+ * Where each account type lands (US-14, US-15). A teacher's pages are all about one event
+ * series, and which one they were last in is not something signing in knows — so the cookie is
+ * read here and turned into a scoped destination (Q8).
+ *
+ * Which of those pages they may open is a second question, and one that has to be asked here:
+ * sending a teacher to a page their permissions refuse would bounce them back to this one, and
+ * round again. A teacher holding nothing is told so instead (US-2).
  */
 export default async function AppLandingPage() {
   const user = await requireUser();
@@ -21,6 +29,9 @@ export default async function AppLandingPage() {
 
   const remembered = (await cookies()).get(EVENT_SERIES_COOKIE_NAME)?.value;
   const eventSeriesId = await resolveSelectedEventSeriesId(remembered);
+  const destination = firstReachableHref(user.permissions, eventSeriesId);
 
-  redirect(eventSeriesId === null ? ROUTES.eventSeries : eventSeriesRoutes(eventSeriesId).overview);
+  if (destination !== null) redirect(destination);
+
+  return <p className="text-muted-foreground text-sm">{NO_PERMISSIONS_HINT}</p>;
 }

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -17,7 +17,7 @@ import { eventSeriesRoutes, ROUTES } from "@/lib/routes";
  */
 export default async function AppLandingPage() {
   const user = await requireUser();
-  if (user.role !== "teacher") redirect(ROUTES.myRegistration);
+  if (user.accountType !== "teacher") redirect(ROUTES.myRegistration);
 
   const remembered = (await cookies()).get(EVENT_SERIES_COOKIE_NAME)?.value;
   const eventSeriesId = await resolveSelectedEventSeriesId(remembered);

--- a/src/app/join/[token]/route.test.ts
+++ b/src/app/join/[token]/route.test.ts
@@ -5,11 +5,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithRole = vi.fn();
+const getUserWithAccountType = vi.fn();
 const resolveInvitation = vi.fn();
 const joinEventSeries = vi.fn();
 
-vi.mock("@/lib/auth/guards", () => ({ getUserWithRole: () => getUserWithRole() }));
+vi.mock("@/lib/auth/guards", () => ({ getUserWithAccountType: () => getUserWithAccountType() }));
 vi.mock("@/lib/invitations/invitation-service", () => ({
   resolveInvitation: (token: string) => resolveInvitation(token),
 }));
@@ -29,7 +29,11 @@ function follow(token = TOKEN) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithRole.mockResolvedValue({ uid: "u1", email: "S@student.at", role: "student" });
+  getUserWithAccountType.mockResolvedValue({
+    uid: "u1",
+    email: "S@student.at",
+    accountType: "student",
+  });
   resolveInvitation.mockResolvedValue({ token: TOKEN, eventSeriesId: "s1", class: "3aWI" });
 });
 
@@ -56,7 +60,7 @@ describe("GET /join/[token]", () => {
    * is followed before signing in. They come back here afterwards and join then.
    */
   it("sends a visitor who is not signed in to sign in, and back here", async () => {
-    getUserWithRole.mockResolvedValue(null);
+    getUserWithAccountType.mockResolvedValue(null);
 
     const response = await follow();
 
@@ -68,7 +72,11 @@ describe("GET /join/[token]", () => {
 
   /** Q12: the commonest teacher to follow a link is the one checking it before sending it out. */
   it("takes a teacher to the dashboard for the series the link names", async () => {
-    getUserWithRole.mockResolvedValue({ uid: "u2", email: "t@htl.at", role: "teacher" });
+    getUserWithAccountType.mockResolvedValue({
+      uid: "u2",
+      email: "t@htl.at",
+      accountType: "teacher",
+    });
 
     const response = await follow();
 
@@ -77,7 +85,11 @@ describe("GET /join/[token]", () => {
   });
 
   it("takes a teacher whose link leads nowhere to the dashboard, saying nothing", async () => {
-    getUserWithRole.mockResolvedValue({ uid: "u2", email: "t@htl.at", role: "teacher" });
+    getUserWithAccountType.mockResolvedValue({
+      uid: "u2",
+      email: "t@htl.at",
+      accountType: "teacher",
+    });
     resolveInvitation.mockResolvedValue(null);
 
     const response = await follow();

--- a/src/app/join/[token]/route.test.ts
+++ b/src/app/join/[token]/route.test.ts
@@ -5,11 +5,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getUserWithAccountType = vi.fn();
+const getAuthenticatedUser = vi.fn();
 const resolveInvitation = vi.fn();
 const joinEventSeries = vi.fn();
 
-vi.mock("@/lib/auth/guards", () => ({ getUserWithAccountType: () => getUserWithAccountType() }));
+vi.mock("@/lib/auth/guards", () => ({ getAuthenticatedUser: () => getAuthenticatedUser() }));
 vi.mock("@/lib/invitations/invitation-service", () => ({
   resolveInvitation: (token: string) => resolveInvitation(token),
 }));
@@ -29,7 +29,7 @@ function follow(token = TOKEN) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getUserWithAccountType.mockResolvedValue({
+  getAuthenticatedUser.mockResolvedValue({
     uid: "u1",
     email: "S@student.at",
     accountType: "student",
@@ -60,7 +60,7 @@ describe("GET /join/[token]", () => {
    * is followed before signing in. They come back here afterwards and join then.
    */
   it("sends a visitor who is not signed in to sign in, and back here", async () => {
-    getUserWithAccountType.mockResolvedValue(null);
+    getAuthenticatedUser.mockResolvedValue(null);
 
     const response = await follow();
 
@@ -72,7 +72,7 @@ describe("GET /join/[token]", () => {
 
   /** Q12: the commonest teacher to follow a link is the one checking it before sending it out. */
   it("takes a teacher to the dashboard for the series the link names", async () => {
-    getUserWithAccountType.mockResolvedValue({
+    getAuthenticatedUser.mockResolvedValue({
       uid: "u2",
       email: "t@htl.at",
       accountType: "teacher",
@@ -85,7 +85,7 @@ describe("GET /join/[token]", () => {
   });
 
   it("takes a teacher whose link leads nowhere to the dashboard, saying nothing", async () => {
-    getUserWithAccountType.mockResolvedValue({
+    getAuthenticatedUser.mockResolvedValue({
       uid: "u2",
       email: "t@htl.at",
       accountType: "teacher",

--- a/src/app/join/[token]/route.ts
+++ b/src/app/join/[token]/route.ts
@@ -4,7 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { NextResponse } from "next/server";
-import { getUserWithRole } from "@/lib/auth/guards";
+import { getUserWithAccountType } from "@/lib/auth/guards";
 import { resolveInvitation } from "@/lib/invitations/invitation-service";
 import { joinEventSeries } from "@/lib/registration/registration-service";
 import { ROUTES, eventSeriesRoutes } from "@/lib/routes";
@@ -30,7 +30,7 @@ import { ROUTES, eventSeriesRoutes } from "@/lib/routes";
  */
 export async function GET(request: Request, context: { params: Promise<{ token: string }> }) {
   const { token } = await context.params;
-  const user = await getUserWithRole();
+  const user = await getUserWithAccountType();
 
   const to = (destination: string) => NextResponse.redirect(new URL(destination, request.url));
 
@@ -42,7 +42,7 @@ export async function GET(request: Request, context: { params: Promise<{ token: 
 
   const invitation = await resolveInvitation(token);
 
-  if (user.role === "teacher") {
+  if (user.accountType === "teacher") {
     return to(invitation ? eventSeriesRoutes(invitation.eventSeriesId).overview : ROUTES.appRoot);
   }
 

--- a/src/app/join/[token]/route.ts
+++ b/src/app/join/[token]/route.ts
@@ -4,7 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { NextResponse } from "next/server";
-import { getUserWithAccountType } from "@/lib/auth/guards";
+import { getAuthenticatedUser } from "@/lib/auth/guards";
 import { resolveInvitation } from "@/lib/invitations/invitation-service";
 import { joinEventSeries } from "@/lib/registration/registration-service";
 import { ROUTES, eventSeriesRoutes } from "@/lib/routes";
@@ -30,7 +30,7 @@ import { ROUTES, eventSeriesRoutes } from "@/lib/routes";
  */
 export async function GET(request: Request, context: { params: Promise<{ token: string }> }) {
   const { token } = await context.params;
-  const user = await getUserWithAccountType();
+  const user = await getAuthenticatedUser();
 
   const to = (destination: string) => NextResponse.redirect(new URL(destination, request.url));
 

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -24,7 +24,7 @@ describe("root page", () => {
     getSessionUser.mockResolvedValue({
       uid: "uid-1",
       email: "jane@htldornbirn.at",
-      role: "teacher",
+      accountType: "teacher",
     });
 
     await expect(Home()).rejects.toThrow("REDIRECT:/app");

--- a/src/components/auth/fake/impersonation-dialog.test.tsx
+++ b/src/components/auth/fake/impersonation-dialog.test.tsx
@@ -15,12 +15,12 @@ vi.mock("@/lib/firebase/client", () => ({ auth: {} }));
 const { ImpersonationDialog } = await import("@/components/auth/fake/impersonation-dialog");
 
 const KNOWN_USERS = [
-  { upn: "jane.doe@htldornbirn.at", firstName: "Jane", lastName: "Doe", role: "teacher" },
+  { upn: "jane.doe@htldornbirn.at", firstName: "Jane", lastName: "Doe", accountType: "teacher" },
   {
     upn: "zoe.zimmer@student.htldornbirn.at",
     firstName: "Zoe",
     lastName: "Zimmer",
-    role: "student",
+    accountType: "student",
   },
 ];
 
@@ -116,7 +116,7 @@ describe("ImpersonationDialog", () => {
     expect(JSON.parse((post[1] as { body: string }).body)).toEqual({
       firstName: "Jane",
       lastName: "Doe",
-      role: "teacher",
+      accountType: "teacher",
     });
     expect(onImpersonated).toHaveBeenCalled();
   });

--- a/src/components/auth/fake/impersonation-dialog.tsx
+++ b/src/components/auth/fake/impersonation-dialog.tsx
@@ -17,7 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { apiRequest, ApiRequestError } from "@/lib/api/client";
 import { buildUpn, isSchoolUpn } from "@/lib/auth/fake/upn-builder";
-import { userRoleSchema, userSchema, type UserRole } from "@/lib/schemas/user";
+import { accountTypeSchema, userSchema, type AccountType } from "@/lib/schemas/user";
 
 const NO_UPN = "Aus diesem Namen lässt sich keine gültige Schul-Adresse bilden.";
 const SIGN_IN_FAILED = "Test-Anmeldung fehlgeschlagen.";
@@ -28,7 +28,7 @@ const knownUsersSchema = z.array(
     upn: z.string(),
     firstName: z.string(),
     lastName: z.string(),
-    role: userRoleSchema,
+    accountType: accountTypeSchema,
   }),
 );
 type KnownUser = z.infer<typeof knownUsersSchema>[number];
@@ -36,11 +36,11 @@ type KnownUser = z.infer<typeof knownUsersSchema>[number];
 const formSchema = z.object({
   firstName: userSchema.shape.firstName,
   lastName: userSchema.shape.lastName,
-  role: userRoleSchema,
+  accountType: accountTypeSchema,
 });
 type FormValues = z.infer<typeof formSchema>;
 
-const ROLE_LABELS: Record<UserRole, string> = { teacher: "Lehrperson", student: "Schüler:in" };
+const ROLE_LABELS: Record<AccountType, string> = { teacher: "Lehrperson", student: "Schüler:in" };
 
 // A native <select> rather than the design system's portalled one: this dialog never ships,
 // so it is not worth the weight to render a list of UPNs.
@@ -77,7 +77,7 @@ export function ImpersonationDialog({
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(formSchema),
-    defaultValues: { firstName: "", lastName: "", role: "teacher" },
+    defaultValues: { firstName: "", lastName: "", accountType: "teacher" },
   });
 
   React.useEffect(() => {
@@ -105,7 +105,7 @@ export function ImpersonationDialog({
 
   const [firstName, lastName, role] = useWatch({
     control,
-    name: ["firstName", "lastName", "role"],
+    name: ["firstName", "lastName", "accountType"],
   });
   const derived = buildUpn(firstName, lastName, role);
   const upn = derived && isSchoolUpn(derived) ? derived : null;
@@ -119,7 +119,7 @@ export function ImpersonationDialog({
 
     setValue("firstName", picked.firstName);
     setValue("lastName", picked.lastName);
-    setValue("role", picked.role);
+    setValue("accountType", picked.accountType);
   }
 
   const onSubmit = handleSubmit(async (values) => {
@@ -189,9 +189,9 @@ export function ImpersonationDialog({
         <fieldset className="flex flex-col gap-1.5">
           <legend className="text-sm leading-none font-medium">Rolle</legend>
           <div className="flex gap-4 pt-1.5">
-            {userRoleSchema.options.map((option) => (
+            {accountTypeSchema.options.map((option) => (
               <label key={option} className="flex items-center gap-2 text-sm">
-                <input type="radio" value={option} {...register("role")} />
+                <input type="radio" value={option} {...register("accountType")} />
                 {ROLE_LABELS[option]}
               </label>
             ))}

--- a/src/components/auth/sign-in-card.test.tsx
+++ b/src/components/auth/sign-in-card.test.tsx
@@ -240,16 +240,16 @@ describe("SignInCard", () => {
   it.each([
     ["teacher", "/app"],
     ["student", "/app/my-registration"],
-  ])("sends a %s straight to their own start page", async (role, expected) => {
-    respondWith(200, { status: "ok", role });
+  ])("sends a %s straight to their own start page", async (accountType, expected) => {
+    respondWith(200, { status: "ok", accountType });
 
     render(<SignInCard />);
 
     await waitFor(() => expect(push).toHaveBeenCalledWith(expected));
   });
 
-  it("ignores an unusable role and falls back to the landing route", async () => {
-    respondWith(200, { status: "ok", role: "admin" });
+  it("ignores an unusable account type and falls back to the landing route", async () => {
+    respondWith(200, { status: "ok", accountType: "admin" });
 
     render(<SignInCard />);
 

--- a/src/components/layout/teacher-nav.test.tsx
+++ b/src/components/layout/teacher-nav.test.tsx
@@ -18,6 +18,8 @@ vi.mock("@/components/auth/sign-out-button", () => ({
   SignOutButton: () => <button type="button">Abmelden</button>,
 }));
 
+import { PERMISSIONS } from "@/lib/auth/permissions";
+
 const { TeacherNav } = await import("@/components/layout/teacher-nav");
 
 const SUB_ITEMS = [
@@ -47,7 +49,7 @@ describe("TeacherNav", () => {
   });
 
   it("lists the top-level items in order", () => {
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     const labels = screen
       .getAllByRole("link")
@@ -63,7 +65,7 @@ describe("TeacherNav", () => {
   });
 
   it("gives every top-level item an icon to be recognised by once the labels are gone", () => {
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     for (const label of ["Bericht", "Zuteilung", "\u00dcbersicht"]) {
       expect(screen.getByRole("link", { name: label })).toBeInTheDocument();
@@ -76,7 +78,7 @@ describe("TeacherNav", () => {
 
   /** Moving into the section is not a change of series, so it opens on the one already selected. */
   it("opens Stammdaten on the selected series, at its first list", () => {
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     expect(screen.getByRole("link", { name: /stammdaten/i })).toHaveAttribute(
       "href",
@@ -89,7 +91,7 @@ describe("TeacherNav", () => {
     pathname.mockReturnValue("/app/event-series");
     showing(series("s1"), series("s2"));
 
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     expect(screen.getByRole("link", { name: /stammdaten/i })).toHaveAttribute(
       "href",
@@ -101,7 +103,7 @@ describe("TeacherNav", () => {
     pathname.mockReturnValue("/app/s2/master-data/classes");
     showing(series("s1"), series("s2"));
 
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     expect(screen.getByRole("link", { name: "Bericht" })).toHaveAttribute("href", "/app/s2/report");
   });
@@ -114,7 +116,7 @@ describe("TeacherNav", () => {
     pathname.mockReturnValue("/app/event-series");
     showing();
 
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     expect(screen.getByRole("link", { name: "Eventreihen" })).toBeInTheDocument();
     for (const label of ["Bericht", "Zuteilung", "\u00dcbersicht", "Klassen"]) {
@@ -126,7 +128,7 @@ describe("TeacherNav", () => {
   it("points at the remembered series while standing on the unscoped list", () => {
     pathname.mockReturnValue("/app/event-series");
 
-    render(<TeacherNav fallbackEventSeriesId="s7" />);
+    render(<TeacherNav fallbackEventSeriesId="s7" permissions={[...PERMISSIONS]} />);
 
     expect(screen.getByRole("link", { name: "Bericht" })).toHaveAttribute("href", "/app/s7/report");
   });
@@ -137,16 +139,16 @@ describe("TeacherNav", () => {
    */
   it("keeps pointing at the series it was last in after leaving it for the list", () => {
     pathname.mockReturnValue("/app/s1/report");
-    const { rerender } = render(<TeacherNav />);
+    const { rerender } = render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     pathname.mockReturnValue("/app/event-series");
-    rerender(<TeacherNav />);
+    rerender(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     expect(screen.getByRole("link", { name: "Bericht" })).toHaveAttribute("href", "/app/s1/report");
   });
 
   it("shows the master data sub-items whatever the route is, since they never fold away", () => {
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     for (const label of SUB_ITEMS) {
       expect(screen.getByRole("link", { name: label })).toBeInTheDocument();
@@ -154,7 +156,7 @@ describe("TeacherNav", () => {
   });
 
   it("leaves them there when Stammdaten is clicked, which folds nothing", async () => {
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     await userEvent.click(screen.getByRole("link", { name: /stammdaten/i }));
 
@@ -164,7 +166,7 @@ describe("TeacherNav", () => {
   });
 
   it("has one sub-item per teacher-maintained category", () => {
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     expect(SUB_ITEMS).toHaveLength(7);
     for (const label of SUB_ITEMS) {
@@ -175,7 +177,7 @@ describe("TeacherNav", () => {
   it("marks the active item for assistive technology", () => {
     pathname.mockReturnValue("/app/s1/assignment");
 
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     expect(screen.getByRole("link", { name: "Zuteilung" })).toHaveAttribute("aria-current", "page");
     expect(screen.getByRole("link", { name: "Bericht" })).not.toHaveAttribute("aria-current");
@@ -184,7 +186,7 @@ describe("TeacherNav", () => {
   it("marks the active sub-item", () => {
     pathname.mockReturnValue("/app/s1/master-data/classes");
 
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     expect(screen.getByRole("link", { name: "Klassen" })).toHaveAttribute("aria-current", "page");
   });
@@ -204,7 +206,7 @@ describe("TeacherNav — always open", () => {
   const openSubItems = () => screen.queryByRole("link", { name: "Klassen" });
 
   it("offers nothing that folds it", () => {
-    render(<TeacherNav />);
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
     expect(screen.queryByRole("button", { name: /navigation/i })).not.toBeInTheDocument();
   });
@@ -212,11 +214,66 @@ describe("TeacherNav — always open", () => {
   it.each(["Bericht", "\u00dcbersicht", "Stammdaten"])(
     "stays open when %s is pressed, whether it is where you already are or not",
     async (label) => {
-      render(<TeacherNav />);
+      render(<TeacherNav permissions={[...PERMISSIONS]} />);
 
       await userEvent.click(screen.getByRole("link", { name: label }));
 
       expect(openSubItems()).toBeInTheDocument();
     },
   );
+});
+
+/**
+ * A bar that offered a page the teacher may not open would send them to the landing route and
+ * back again. It is built from what their permissions reach instead (US-2).
+ */
+describe("TeacherNav — what the permissions reach", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pathname.mockReturnValue("/app/s1/report");
+    showing(series("s1"));
+  });
+
+  const linkNames = () => screen.queryAllByRole("link").map((link) => link.textContent);
+
+  it("shows nothing to a teacher holding no permission", () => {
+    render(<TeacherNav permissions={[]} />);
+
+    expect(linkNames()).toEqual([]);
+  });
+
+  it("shows only the assignment to somebody who may only plan", () => {
+    render(<TeacherNav permissions={["editAssignments"]} />);
+
+    expect(linkNames()).toEqual(["Zuteilung"]);
+  });
+
+  /** One permission carries both report pages, and neither appears without it. */
+  it("shows both report pages to somebody who may view them", () => {
+    render(<TeacherNav permissions={["viewReports"]} />);
+
+    expect(linkNames()).toEqual(["\u00dcbersicht", "Bericht"]);
+  });
+
+  it("hides the master data section and its sub-items without the permission", () => {
+    render(<TeacherNav permissions={["viewReports"]} />);
+
+    expect(screen.queryByRole("link", { name: "Stammdaten" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Klassen" })).not.toBeInTheDocument();
+  });
+
+  it("offers the rights page only to somebody who may edit users", () => {
+    render(<TeacherNav permissions={["editUsers"]} />);
+
+    expect(screen.getByRole("link", { name: "Benutzerrechte" })).toHaveAttribute(
+      "href",
+      "/app/users",
+    );
+  });
+
+  it("does not offer it to anybody else", () => {
+    render(<TeacherNav permissions={["editMasterData"]} />);
+
+    expect(screen.queryByRole("link", { name: "Benutzerrechte" })).not.toBeInTheDocument();
+  });
 });

--- a/src/components/layout/teacher-nav.tsx
+++ b/src/components/layout/teacher-nav.tsx
@@ -8,7 +8,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ChartColumn, Database, FileText, Shuffle } from "lucide-react";
+import { ChartColumn, Database, FileText, Shuffle, Users } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Brand } from "@/components/layout/brand";
 import { SignOutButton } from "@/components/auth/sign-out-button";
@@ -18,15 +18,17 @@ import {
   liveSelection,
   selectedEventSeriesIdFrom,
 } from "@/lib/event-series/event-series-selection";
+import { reachablePages, type PageKey } from "@/lib/auth/reachable-pages";
+import type { Permission } from "@/lib/auth/permissions";
 import { eventSeriesRoutes, ROUTES } from "@/lib/routes";
 
-function topLevel(eventSeriesId: string) {
+function topLevel(eventSeriesId: string, reachable: readonly PageKey[]) {
   const routes = eventSeriesRoutes(eventSeriesId);
   return [
-    { href: routes.overview, label: "\u00dcbersicht", Icon: ChartColumn },
-    { href: routes.assignment, label: "Zuteilung", Icon: Shuffle },
-    { href: routes.report, label: "Bericht", Icon: FileText },
-  ];
+    { key: "overview", href: routes.overview, label: "\u00dcbersicht", Icon: ChartColumn },
+    { key: "assignment", href: routes.assignment, label: "Zuteilung", Icon: Shuffle },
+    { key: "report", href: routes.report, label: "Bericht", Icon: FileText },
+  ].filter((item) => reachable.includes(item.key as PageKey));
 }
 
 function itemClasses(active: boolean) {
@@ -45,9 +47,11 @@ function itemClasses(active: boolean) {
  */
 export function TeacherNav({
   fallbackEventSeriesId = null,
+  permissions = [],
   photo = null,
 }: {
   fallbackEventSeriesId?: string | null;
+  permissions?: readonly Permission[];
   photo?: string | null;
 }) {
   const pathname = usePathname();
@@ -67,6 +71,7 @@ export function TeacherNav({
   const { eventSeries } = useEventSeries();
   const selectedId = liveSelection(eventSeries, eventSeriesId);
   const sections = masterDataSections(selectedId);
+  const reachable = reachablePages(permissions);
 
   return (
     <nav aria-label="Hauptnavigation" className="flex h-full flex-col gap-1 p-2 md:w-56">
@@ -74,7 +79,7 @@ export function TeacherNav({
           the column beside it is where a page begins. */}
       <Brand />
 
-      {(selectedId === null ? [] : topLevel(selectedId)).map(({ href, label, Icon }) => {
+      {(selectedId === null ? [] : topLevel(selectedId, reachable)).map(({ href, label, Icon }) => {
         const active = pathname === href || pathname.startsWith(`${href}/`);
         return (
           <Link
@@ -90,30 +95,46 @@ export function TeacherNav({
       })}
 
       {/* The section has no view of its own, so it opens on the first list beneath it. */}
-      <Link
-        href={selectedId === null ? ROUTES.eventSeries : firstMasterDataPath(selectedId)}
-        className={itemClasses(inMasterData)}
-      >
-        <Database aria-hidden className="size-6 shrink-0" />
-        <span>Stammdaten</span>
-      </Link>
+      {reachable.includes("masterData") ? (
+        <>
+          <Link
+            href={selectedId === null ? ROUTES.eventSeries : firstMasterDataPath(selectedId)}
+            className={itemClasses(inMasterData)}
+          >
+            <Database aria-hidden className="size-6 shrink-0" />
+            <span>Stammdaten</span>
+          </Link>
 
-      <ul className="flex flex-col gap-1">
-        {sections.map(({ href, label }) => (
-          <li key={href}>
-            <Link
-              href={href}
-              aria-current={pathname === href ? "page" : undefined}
-              className={itemClasses(pathname === href)}
-            >
-              {/* Stands in for the icon above it, so the text lines up by being laid out the
+          <ul className="flex flex-col gap-1">
+            {sections.map(({ href, label }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  aria-current={pathname === href ? "page" : undefined}
+                  className={itemClasses(pathname === href)}
+                >
+                  {/* Stands in for the icon above it, so the text lines up by being laid out the
                   same way rather than by a padding that has to add up to the same number. */}
-              <span aria-hidden className="size-6 shrink-0" />
-              {label}
-            </Link>
-          </li>
-        ))}
-      </ul>
+                  <span aria-hidden className="size-6 shrink-0" />
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+
+      {/* Not part of the section above it: rights are the school's, not one event series'. */}
+      {reachable.includes("users") ? (
+        <Link
+          href={`${ROUTES.appRoot}/users`}
+          aria-current={pathname === `${ROUTES.appRoot}/users` ? "page" : undefined}
+          className={itemClasses(pathname === `${ROUTES.appRoot}/users`)}
+        >
+          <Users aria-hidden className="size-6 shrink-0" />
+          <span>Benutzerrechte</span>
+        </Link>
+      ) : null}
 
       {/* The foot of the bar: who is signed in. */}
       <div className="mt-auto">

--- a/src/components/users/user-permissions-view.test.tsx
+++ b/src/components/users/user-permissions-view.test.tsx
@@ -1,0 +1,180 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PERMISSIONS, PERMISSION_LABELS } from "@/lib/auth/permissions";
+
+const useTeachers = vi.fn();
+vi.mock("@/lib/users/use-teachers", () => ({ useTeachers: () => useTeachers() }));
+
+const apiRequest = vi.fn();
+vi.mock("@/lib/api/client", () => ({ apiRequest: (...args: unknown[]) => apiRequest(...args) }));
+
+const { UserPermissionsView, OWN_GRANT_HINT, NO_PERMISSIONS_LABEL } =
+  await import("@/components/users/user-permissions-view");
+
+const ADA = { upn: "ada@htldornbirn.at", firstName: "Ada", lastName: "Auer" };
+const BOB = { upn: "bob@htldornbirn.at", firstName: "Bob", lastName: "Berger" };
+
+function teachers(
+  ...rows: { upn: string; firstName: string; lastName: string; permissions?: string[] }[]
+) {
+  useTeachers.mockReturnValue({
+    teachers: rows.map((row) => ({ ...row, permissions: row.permissions ?? [] })),
+    loading: false,
+    error: null,
+  });
+}
+
+const tagIn = (name: string, label: string) =>
+  screen.getByRole("button", { name: `${name}: ${label}` });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiRequest.mockResolvedValue({ permissions: [] });
+  teachers({ ...ADA, permissions: ["editUsers"] }, BOB);
+});
+
+function show(signedInAs = ADA.upn) {
+  return render(<UserPermissionsView signedInAs={signedInAs} />);
+}
+
+describe("UserPermissionsView", () => {
+  it("lists every teacher by name", () => {
+    show();
+
+    expect(screen.getByText("Auer Ada")).toBeInTheDocument();
+    expect(screen.getByText("Berger Bob")).toBeInTheDocument();
+  });
+
+  it("offers every permission as a tag against each teacher", () => {
+    show();
+
+    for (const permission of PERMISSIONS) {
+      expect(tagIn("Berger Bob", PERMISSION_LABELS[permission])).toBeInTheDocument();
+    }
+  });
+
+  it("presses the tags a teacher holds and leaves the rest unpressed", () => {
+    teachers({ ...BOB, permissions: ["viewReports"] });
+    show();
+
+    expect(tagIn("Berger Bob", PERMISSION_LABELS.viewReports)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(tagIn("Berger Bob", PERMISSION_LABELS.editMasterData)).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("says so when somebody holds nothing at all", () => {
+    teachers(BOB);
+    show();
+
+    expect(screen.getByText(NO_PERMISSIONS_LABEL)).toBeInTheDocument();
+  });
+
+  it("grants the permission that was pressed", async () => {
+    show();
+
+    await userEvent.click(tagIn("Berger Bob", PERMISSION_LABELS.editAssignments));
+
+    await waitFor(() =>
+      expect(apiRequest).toHaveBeenCalledWith(`/api/users/${encodeURIComponent(BOB.upn)}`, {
+        method: "PATCH",
+        body: { permissions: ["editAssignments"] },
+      }),
+    );
+  });
+
+  it("withdraws one that was pressed already", async () => {
+    teachers({ ...BOB, permissions: ["viewReports", "editAssignments"] });
+    show();
+
+    await userEvent.click(tagIn("Berger Bob", PERMISSION_LABELS.editAssignments));
+
+    await waitFor(() =>
+      expect(apiRequest).toHaveBeenCalledWith(expect.any(String), {
+        method: "PATCH",
+        body: { permissions: ["viewReports"] },
+      }),
+    );
+  });
+
+  /** The row sends what the dependency rule makes of a press, not the press itself. */
+  it("presses viewReports along with editReports", async () => {
+    teachers(BOB);
+    show();
+
+    await userEvent.click(tagIn("Berger Bob", PERMISSION_LABELS.editReports));
+
+    await waitFor(() =>
+      expect(apiRequest).toHaveBeenCalledWith(expect.any(String), {
+        method: "PATCH",
+        body: { permissions: ["viewReports", "editReports"] },
+      }),
+    );
+  });
+
+  it("withdraws editReports along with viewReports", async () => {
+    teachers({ ...BOB, permissions: ["viewReports", "editReports"] });
+    show();
+
+    await userEvent.click(tagIn("Berger Bob", PERMISSION_LABELS.viewReports));
+
+    await waitFor(() =>
+      expect(apiRequest).toHaveBeenCalledWith(expect.any(String), {
+        method: "PATCH",
+        body: { permissions: [] },
+      }),
+    );
+  });
+
+  /**
+   * Only the last holder can be the last one, so refusing self-removal is what keeps somebody
+   * able to hand permissions out. The row says so rather than offering a control that cannot work.
+   */
+  it("shows the signed-in admin's own editUsers as a tag with no button", () => {
+    show();
+
+    expect(
+      screen.queryByRole("button", { name: `Auer Ada: ${PERMISSION_LABELS.editUsers}` }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(OWN_GRANT_HINT)).toBeInTheDocument();
+  });
+
+  it("still lets the admin change their own other permissions", async () => {
+    show();
+
+    await userEvent.click(tagIn("Auer Ada", PERMISSION_LABELS.editMasterData));
+
+    await waitFor(() =>
+      expect(apiRequest).toHaveBeenCalledWith(expect.any(String), {
+        method: "PATCH",
+        body: { permissions: ["editMasterData", "editUsers"] },
+      }),
+    );
+  });
+
+  it("offers somebody else's editUsers as a button, since that one can be withdrawn", () => {
+    teachers({ ...BOB, permissions: ["editUsers"] });
+    show();
+
+    expect(tagIn("Berger Bob", PERMISSION_LABELS.editUsers)).toBeInTheDocument();
+  });
+
+  it("reports a refusal without pretending the press landed", async () => {
+    apiRequest.mockRejectedValue(new Error("Dafür fehlen dir die Rechte."));
+    show();
+
+    await userEvent.click(tagIn("Berger Bob", PERMISSION_LABELS.editAssignments));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Dafür fehlen dir die Rechte.");
+  });
+});

--- a/src/components/users/user-permissions-view.tsx
+++ b/src/components/users/user-permissions-view.tsx
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+import { useState } from "react";
+import { apiRequest } from "@/lib/api/client";
+import { useRowAction } from "@/lib/api/use-row-action";
+import { PageHeading } from "@/components/layout/page-heading";
+import { Card, CardContent } from "@/components/ui/card";
+import { Tag, TagName } from "@/components/ui/tag";
+import {
+  PERMISSIONS,
+  PERMISSION_LABELS,
+  toggledPermissions,
+  type Permission,
+} from "@/lib/auth/permissions";
+import { useTeachers, type Teacher } from "@/lib/users/use-teachers";
+
+export const NO_PERMISSIONS_LABEL = "Keine Rechte";
+
+export const OWN_GRANT_HINT =
+  "Das Recht, Benutzerrechte zu vergeben, kannst du dir nicht selbst entziehen.";
+
+const LOADING_LABEL = "Benutzerrechte werden geladen \u2026";
+
+const NO_TEACHERS_HINT = "Es hat sich noch keine Lehrperson angemeldet.";
+
+/** Surname first, matching the order the list is sorted in. */
+const nameOf = (teacher: Teacher) => `${teacher.lastName} ${teacher.firstName}`;
+
+/**
+ * Who may do what (US-2). One row per teacher, and a tag per permission — pressed for what they
+ * hold, so the row answers "what may this person do" by being looked at.
+ *
+ * A press sends the whole set rather than the one tag, because what a press means is the
+ * dependency rule's to decide and that rule lives in one place: pressing "Berichte bearbeiten"
+ * presses "Berichte ansehen" with it, and releasing the latter releases the former.
+ */
+export function UserPermissionsView({ signedInAs }: { signedInAs: string }) {
+  const { teachers, loading, error } = useTeachers();
+  const [failure, setFailure] = useState<string | null>(null);
+  const { busyId, run } = useRowAction();
+
+  async function grant(teacher: Teacher, permission: Permission) {
+    const permissions = toggledPermissions(teacher.permissions, permission);
+    setFailure(null);
+
+    await run(teacher.upn, async () => {
+      try {
+        await apiRequest(`/api/users/${encodeURIComponent(teacher.upn)}`, {
+          method: "PATCH",
+          body: { permissions },
+        });
+      } catch (thrown) {
+        setFailure(thrown instanceof Error ? thrown.message : "Das hat leider nicht geklappt.");
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <PageHeading>Benutzerrechte</PageHeading>
+
+      {error ? (
+        <p role="alert" className="text-destructive text-sm">
+          {error}
+        </p>
+      ) : null}
+      {failure ? (
+        <p role="alert" className="text-destructive text-sm">
+          {failure}
+        </p>
+      ) : null}
+
+      {loading ? <p className="text-muted-foreground text-sm">{LOADING_LABEL}</p> : null}
+      {!loading && teachers.length === 0 ? (
+        <p className="text-muted-foreground text-sm">{NO_TEACHERS_HINT}</p>
+      ) : null}
+
+      <ul className="flex flex-col gap-3">
+        {teachers.map((teacher) => (
+          <li key={teacher.upn}>
+            <Card size="sm">
+              <CardContent className="flex flex-col gap-2">
+                <div className="flex flex-wrap items-baseline gap-x-2">
+                  <span className="font-medium">{nameOf(teacher)}</span>
+                  <span className="text-muted-foreground text-sm">{teacher.upn}</span>
+                  {teacher.permissions.length === 0 ? (
+                    <span className="text-muted-foreground text-sm">{NO_PERMISSIONS_LABEL}</span>
+                  ) : null}
+                </div>
+
+                <div
+                  role="group"
+                  aria-label={`${nameOf(teacher)}: Rechte`}
+                  className="flex flex-wrap gap-1.5"
+                >
+                  {PERMISSIONS.map((permission) => (
+                    <PermissionTag
+                      key={permission}
+                      teacher={teacher}
+                      permission={permission}
+                      // Withdrawing this one from yourself is what would leave nobody able to
+                      // grant it, so the tag states it instead of offering the press.
+                      fixed={permission === "editUsers" && teacher.upn === signedInAs}
+                      disabled={busyId === teacher.upn}
+                      onPress={() => grant(teacher, permission)}
+                    />
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function PermissionTag({
+  teacher,
+  permission,
+  fixed,
+  disabled,
+  onPress,
+}: {
+  teacher: Teacher;
+  permission: Permission;
+  fixed: boolean;
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  const label = PERMISSION_LABELS[permission];
+  const held = teacher.permissions.includes(permission);
+
+  if (fixed) {
+    return (
+      <Tag pressed={held}>
+        <span className="px-1 text-sm" title={OWN_GRANT_HINT}>
+          {label}
+        </span>
+        <span className="sr-only">{OWN_GRANT_HINT}</span>
+      </Tag>
+    );
+  }
+
+  return (
+    <Tag pressed={held} disabled={disabled}>
+      <TagName label={`${nameOf(teacher)}: ${label}`} text={label} onPress={onPress} />
+    </Tag>
+  );
+}

--- a/src/lib/api/handler.test.ts
+++ b/src/lib/api/handler.test.ts
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getAuthenticatedUser = vi.fn();
+vi.mock("@/lib/auth/guards", () => ({ getAuthenticatedUser }));
+
+const {
+  PERMISSION_DENIED_HINT,
+  requirePermissionOrResponse,
+  requirePermissionIdentityOrResponse,
+  requireStudentOrResponse,
+} = await import("@/lib/api/handler");
+
+const teacher = (...permissions: string[]) => ({
+  uid: "uid-1",
+  email: "Jane@HTLDornbirn.at",
+  accountType: "teacher",
+  permissions,
+});
+
+const student = { uid: "uid-2", email: "sam@student.htldornbirn.at", accountType: "student" };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("requirePermissionOrResponse", () => {
+  it("admits a teacher holding the permission", async () => {
+    getAuthenticatedUser.mockResolvedValue(teacher("editMasterData"));
+
+    expect(await requirePermissionOrResponse("editMasterData")).toBeNull();
+  });
+
+  it("asks an unauthenticated caller to sign in", async () => {
+    getAuthenticatedUser.mockResolvedValue(null);
+
+    const response = await requirePermissionOrResponse("editMasterData");
+
+    expect(response?.status).toBe(401);
+  });
+
+  /** Each permission is asked for by name, so holding another is holding none of this one. */
+  it("refuses a teacher holding a different permission", async () => {
+    getAuthenticatedUser.mockResolvedValue(teacher("viewReports", "editAssignments"));
+
+    const response = await requirePermissionOrResponse("editMasterData");
+
+    expect(response?.status).toBe(403);
+    expect(await response?.json()).toMatchObject({ error: { message: PERMISSION_DENIED_HINT } });
+  });
+
+  it("refuses a teacher holding none", async () => {
+    getAuthenticatedUser.mockResolvedValue(teacher());
+
+    expect((await requirePermissionOrResponse("viewReports"))?.status).toBe(403);
+  });
+
+  /** The same sentence whichever permission was missing: a refusal teaches nothing. */
+  it("names no permission in the refusal", async () => {
+    getAuthenticatedUser.mockResolvedValue(teacher());
+
+    const response = await requirePermissionOrResponse("editUsers");
+    const body = JSON.stringify(await response?.json());
+
+    expect(body).not.toContain("editUsers");
+  });
+
+  it("refuses a student whose record lists the permission anyway", async () => {
+    getAuthenticatedUser.mockResolvedValue({ ...student, permissions: ["editUsers"] });
+
+    expect((await requirePermissionOrResponse("editUsers"))?.status).toBe(403);
+  });
+});
+
+describe("requirePermissionIdentityOrResponse", () => {
+  it("returns the caller's UPN, lowercased to match the record id", async () => {
+    getAuthenticatedUser.mockResolvedValue(teacher("editReports"));
+
+    expect(await requirePermissionIdentityOrResponse("editReports")).toEqual({
+      ok: true,
+      userId: "jane@htldornbirn.at",
+    });
+  });
+
+  it("refuses a session without an address, which cannot be attributed", async () => {
+    getAuthenticatedUser.mockResolvedValue({ ...teacher("editReports"), email: null });
+
+    const outcome = await requirePermissionIdentityOrResponse("editReports");
+
+    expect(outcome.ok).toBe(false);
+  });
+
+  it("refuses a teacher holding a different permission", async () => {
+    getAuthenticatedUser.mockResolvedValue(teacher("viewReports"));
+
+    const outcome = await requirePermissionIdentityOrResponse("editReports");
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.ok === false && outcome.response.status).toBe(403);
+  });
+});
+
+describe("requireStudentOrResponse", () => {
+  it("admits a student, who carries no permissions to check", async () => {
+    getAuthenticatedUser.mockResolvedValue({ ...student, permissions: [] });
+
+    expect(await requireStudentOrResponse()).toEqual({
+      ok: true,
+      userId: "sam@student.htldornbirn.at",
+    });
+  });
+
+  /** A teacher keeps no registration of their own (US-15), so this one is not hierarchical. */
+  it("refuses a teacher holding everything", async () => {
+    getAuthenticatedUser.mockResolvedValue(teacher("editUsers", "editMasterData"));
+
+    const outcome = await requireStudentOrResponse();
+
+    expect(outcome.ok).toBe(false);
+  });
+});

--- a/src/lib/api/handler.ts
+++ b/src/lib/api/handler.ts
@@ -8,8 +8,8 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { apiError, ErrorCode } from "@/lib/errors";
 import { ServiceError, statusForCode } from "@/lib/service-error";
-import { getUserWithRole } from "@/lib/auth/guards";
-import type { UserRole } from "@/lib/schemas/user";
+import { getUserWithAccountType } from "@/lib/auth/guards";
+import type { AccountType } from "@/lib/schemas/user";
 
 export function errorResponse(code: ErrorCode, message: string, details?: unknown) {
   return NextResponse.json(apiError(code, message, details), { status: statusForCode(code) });
@@ -20,11 +20,11 @@ export function errorResponse(code: ErrorCode, message: string, details?: unknow
  * runtime cannot verify the session cookie. Every write re-verifies here (US-2, US-3).
  */
 export async function requireTeacherOrResponse(): Promise<NextResponse | null> {
-  const user = await getUserWithRole();
+  const user = await getUserWithAccountType();
   if (!user) {
     return errorResponse(ErrorCode.AuthenticationRequired, "Bitte melde dich an.");
   }
-  if (user.role !== "teacher") {
+  if (user.accountType !== "teacher") {
     return errorResponse(ErrorCode.PermissionDenied, "Dafür fehlen dir die Rechte.");
   }
   return null;
@@ -37,15 +37,15 @@ type IdentifiedOutcome = { ok: true; userId: string } | { ok: false; response: N
  * than merely permitting it (US-13). Records are keyed by the UPN, so a session without an
  * address cannot be attributed and is not served.
  */
-async function requireIdentity(role: UserRole): Promise<IdentifiedOutcome> {
-  const user = await getUserWithRole();
+async function requireIdentity(accountType: AccountType): Promise<IdentifiedOutcome> {
+  const user = await getUserWithAccountType();
   if (!user || !user.email) {
     return {
       ok: false,
       response: errorResponse(ErrorCode.AuthenticationRequired, "Bitte melde dich an."),
     };
   }
-  if (user.role !== role) {
+  if (user.accountType !== accountType) {
     return {
       ok: false,
       response: errorResponse(ErrorCode.PermissionDenied, "Dafür fehlen dir die Rechte."),
@@ -59,7 +59,7 @@ export function requireTeacherIdentityOrResponse(): Promise<IdentifiedOutcome> {
 }
 
 /**
- * Roles are hierarchical everywhere else, but not here: a teacher keeps no master data of their
+ * Account types are hierarchical everywhere else, but not here: a teacher keeps no master data of their
  * own (US-15), so admitting one would create a record for an event series they are not registered in.
  */
 export function requireStudentOrResponse(): Promise<IdentifiedOutcome> {

--- a/src/lib/api/handler.ts
+++ b/src/lib/api/handler.ts
@@ -8,8 +8,11 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { apiError, ErrorCode } from "@/lib/errors";
 import { ServiceError, statusForCode } from "@/lib/service-error";
-import { getUserWithAccountType } from "@/lib/auth/guards";
-import type { AccountType } from "@/lib/schemas/user";
+import { getAuthenticatedUser } from "@/lib/auth/guards";
+import { may, type Permission } from "@/lib/auth/permissions";
+
+/** One refusal for every permission, so a caller learns nothing about which one was missing. */
+export const PERMISSION_DENIED_HINT = "Dafür fehlen dir die Rechte.";
 
 export function errorResponse(code: ErrorCode, message: string, details?: unknown) {
   return NextResponse.json(apiError(code, message, details), { status: statusForCode(code) });
@@ -17,15 +20,18 @@ export function errorResponse(code: ErrorCode, message: string, details?: unknow
 
 /**
  * The proxy already gates teacher routes, but that check is optimistic by design — the Edge
- * runtime cannot verify the session cookie. Every write re-verifies here (US-2, US-3).
+ * runtime cannot verify the session cookie, and it knows nothing of permissions. Every write
+ * re-verifies here, against the record rather than the token (US-2, US-3).
  */
-export async function requireTeacherOrResponse(): Promise<NextResponse | null> {
-  const user = await getUserWithAccountType();
+export async function requirePermissionOrResponse(
+  permission: Permission,
+): Promise<NextResponse | null> {
+  const user = await getAuthenticatedUser();
   if (!user) {
     return errorResponse(ErrorCode.AuthenticationRequired, "Bitte melde dich an.");
   }
-  if (user.accountType !== "teacher") {
-    return errorResponse(ErrorCode.PermissionDenied, "Dafür fehlen dir die Rechte.");
+  if (!may(user, permission)) {
+    return errorResponse(ErrorCode.PermissionDenied, PERMISSION_DENIED_HINT);
   }
   return null;
 }
@@ -37,33 +43,45 @@ type IdentifiedOutcome = { ok: true; userId: string } | { ok: false; response: N
  * than merely permitting it (US-13). Records are keyed by the UPN, so a session without an
  * address cannot be attributed and is not served.
  */
-async function requireIdentity(accountType: AccountType): Promise<IdentifiedOutcome> {
-  const user = await getUserWithAccountType();
+export async function requirePermissionIdentityOrResponse(
+  permission: Permission,
+): Promise<IdentifiedOutcome> {
+  const user = await getAuthenticatedUser();
   if (!user || !user.email) {
     return {
       ok: false,
       response: errorResponse(ErrorCode.AuthenticationRequired, "Bitte melde dich an."),
     };
   }
-  if (user.accountType !== accountType) {
+  if (!may(user, permission)) {
     return {
       ok: false,
-      response: errorResponse(ErrorCode.PermissionDenied, "Dafür fehlen dir die Rechte."),
+      response: errorResponse(ErrorCode.PermissionDenied, PERMISSION_DENIED_HINT),
     };
   }
   return { ok: true, userId: user.email.toLowerCase() };
 }
 
-export function requireTeacherIdentityOrResponse(): Promise<IdentifiedOutcome> {
-  return requireIdentity("teacher");
-}
-
 /**
- * Account types are hierarchical everywhere else, but not here: a teacher keeps no master data of their
- * own (US-15), so admitting one would create a record for an event series they are not registered in.
+ * A student is admitted by what they are rather than by what they hold: they carry no
+ * permissions, and a teacher keeps no master data of their own (US-15), so admitting one would
+ * create a record for an event series they are not registered in.
  */
-export function requireStudentOrResponse(): Promise<IdentifiedOutcome> {
-  return requireIdentity("student");
+export async function requireStudentOrResponse(): Promise<IdentifiedOutcome> {
+  const user = await getAuthenticatedUser();
+  if (!user || !user.email) {
+    return {
+      ok: false,
+      response: errorResponse(ErrorCode.AuthenticationRequired, "Bitte melde dich an."),
+    };
+  }
+  if (user.accountType !== "student") {
+    return {
+      ok: false,
+      response: errorResponse(ErrorCode.PermissionDenied, PERMISSION_DENIED_HINT),
+    };
+  }
+  return { ok: true, userId: user.email.toLowerCase() };
 }
 
 type ParseOutcome<T> = { ok: true; data: T } | { ok: false; response: NextResponse };

--- a/src/lib/auth/fake/sign-in-policy.test.ts
+++ b/src/lib/auth/fake/sign-in-policy.test.ts
@@ -12,7 +12,7 @@ import { refuseSignIn } from "@/lib/auth/fake/sign-in-policy";
  */
 describe("refuseSignIn in a test environment", () => {
   it("turns away a student signing in with their real account", () => {
-    expect(refuseSignIn({ role: "student", signInProvider: "microsoft.com" })).toEqual({
+    expect(refuseSignIn({ accountType: "student", signInProvider: "microsoft.com" })).toEqual({
       reason: "students-excluded",
       message: "Diese Umgebung steht nur Lehrpersonen offen.",
     });
@@ -20,16 +20,16 @@ describe("refuseSignIn in a test environment", () => {
 
   // Which is the whole point of the environment.
   it("admits a student the fake login is standing in for", () => {
-    expect(refuseSignIn({ role: "student", signInProvider: "custom" })).toBeNull();
+    expect(refuseSignIn({ accountType: "student", signInProvider: "custom" })).toBeNull();
   });
 
   it("leaves teachers alone either way", () => {
-    expect(refuseSignIn({ role: "teacher", signInProvider: "microsoft.com" })).toBeNull();
-    expect(refuseSignIn({ role: "teacher", signInProvider: "custom" })).toBeNull();
+    expect(refuseSignIn({ accountType: "teacher", signInProvider: "microsoft.com" })).toBeNull();
+    expect(refuseSignIn({ accountType: "teacher", signInProvider: "custom" })).toBeNull();
   });
 
   // Only `microsoft.com` means the account is real, so anything else is not that case.
   it("does not turn away a student whose provider is unknown", () => {
-    expect(refuseSignIn({ role: "student" })).toBeNull();
+    expect(refuseSignIn({ accountType: "student" })).toBeNull();
   });
 });

--- a/src/lib/auth/fake/sign-in-policy.ts
+++ b/src/lib/auth/fake/sign-in-policy.ts
@@ -16,8 +16,8 @@ import type { SignInAttempt, SignInRefusal } from "@/lib/auth/sign-in-policy";
  * There is no check here for which project this is. The build already decided that by
  * resolving this module at all, and `resolveAuthMode` never resolves it for production.
  */
-export function refuseSignIn({ role, signInProvider }: SignInAttempt): SignInRefusal | null {
-  if (role === "student" && signInProvider === "microsoft.com") {
+export function refuseSignIn({ accountType, signInProvider }: SignInAttempt): SignInRefusal | null {
+  if (accountType === "student" && signInProvider === "microsoft.com") {
     return {
       reason: "students-excluded",
       message: "Diese Umgebung steht nur Lehrpersonen offen.",

--- a/src/lib/auth/fake/upn-builder.ts
+++ b/src/lib/auth/fake/upn-builder.ts
@@ -4,7 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { STUDENT_DOMAIN, TEACHER_DOMAIN } from "@/lib/auth/upn";
-import type { UserRole } from "@/lib/schemas/user";
+import type { AccountType } from "@/lib/schemas/user";
 
 /**
  * Deriving a UPN is something only an impersonation does — the real tenant issues them, and
@@ -54,10 +54,14 @@ function toNamePart(name: string): string | null {
  * Derives the UPN the tenant would issue for a person (US-3). Null when a name carries no
  * character the UPN alphabet can represent.
  */
-export function buildUpn(firstName: string, lastName: string, role: UserRole): string | null {
+export function buildUpn(
+  firstName: string,
+  lastName: string,
+  accountType: AccountType,
+): string | null {
   const first = toNamePart(firstName);
   const last = toNamePart(lastName);
   if (!first || !last) return null;
 
-  return `${first}.${last}@${role === "teacher" ? TEACHER_DOMAIN : STUDENT_DOMAIN}`;
+  return `${first}.${last}@${accountType === "teacher" ? TEACHER_DOMAIN : STUDENT_DOMAIN}`;
 }

--- a/src/lib/auth/guards.test.ts
+++ b/src/lib/auth/guards.test.ts
@@ -26,7 +26,8 @@ vi.mock("@/lib/session", () => ({ getSessionUser }));
 vi.mock("@/lib/firebase/admin", () => ({ adminDb: { collection } }));
 
 const {
-  getUserWithAccountType,
+  getAuthenticatedUser,
+  requirePermission,
   requireStudent,
   requireTeacher,
   requireUser,
@@ -150,18 +151,95 @@ describe("requireStudent", () => {
   });
 });
 
-describe("getUserWithAccountType", () => {
+describe("getAuthenticatedUser", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("returns null instead of redirecting, so handlers can emit the error envelope", async () => {
     getSessionUser.mockResolvedValue(null);
 
-    expect(await getUserWithAccountType()).toBeNull();
+    expect(await getAuthenticatedUser()).toBeNull();
   });
 
-  it("returns the user with the resolved role", async () => {
+  it("returns the user with the resolved account type", async () => {
     getSessionUser.mockResolvedValue(studentSession);
+    docGet.mockResolvedValue({ exists: true, data: () => ({ accountType: "student" }) });
 
-    expect(await getUserWithAccountType()).toMatchObject({ accountType: "student" });
+    expect(await getAuthenticatedUser()).toMatchObject({ accountType: "student" });
+  });
+
+  /**
+   * The account type may come from the claim, but a permission never does: it is granted and
+   * withdrawn while a session is live, so a token minted beforehand would go on admitting what
+   * an admin has just taken away (US-2).
+   */
+  it("reads the permissions from the record even when the claim answered the account type", async () => {
+    getSessionUser.mockResolvedValue(teacherSession);
+    docGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ accountType: "teacher", permissions: ["editMasterData"] }),
+    });
+
+    expect(await getAuthenticatedUser()).toMatchObject({ permissions: ["editMasterData"] });
+    expect(doc).toHaveBeenCalledWith("jane@htldornbirn.at");
+  });
+
+  it("reads a record written before permissions existed as holding none", async () => {
+    getSessionUser.mockResolvedValue(teacherSession);
+    docGet.mockResolvedValue({ exists: true, data: () => ({ accountType: "teacher" }) });
+
+    expect(await getAuthenticatedUser()).toMatchObject({ permissions: [] });
+  });
+
+  it("grants a student none, whatever their record lists", async () => {
+    getSessionUser.mockResolvedValue(studentSession);
+    docGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ accountType: "student", permissions: ["editUsers"] }),
+    });
+
+    expect(await getAuthenticatedUser()).toMatchObject({ permissions: [] });
+  });
+});
+
+describe("requirePermission", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the teacher who holds it", async () => {
+    getSessionUser.mockResolvedValue(teacherSession);
+    docGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ accountType: "teacher", permissions: ["editMasterData"] }),
+    });
+
+    expect(await requirePermission("editMasterData")).toMatchObject({
+      permissions: ["editMasterData"],
+    });
+  });
+
+  it("sends a teacher holding a different one back to the landing route", async () => {
+    getSessionUser.mockResolvedValue(teacherSession);
+    docGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ accountType: "teacher", permissions: ["viewReports"] }),
+    });
+
+    await expectRedirect(requirePermission("editUsers"), "/app");
+  });
+
+  it("sends a teacher holding none back to the landing route", async () => {
+    getSessionUser.mockResolvedValue(teacherSession);
+    docGet.mockResolvedValue({ exists: true, data: () => ({ accountType: "teacher" }) });
+
+    await expectRedirect(requirePermission("viewReports"), "/app");
+  });
+
+  it("sends a student back, whatever their record lists", async () => {
+    getSessionUser.mockResolvedValue(studentSession);
+    docGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ accountType: "student", permissions: ["editUsers"] }),
+    });
+
+    await expectRedirect(requirePermission("editUsers"), "/app");
   });
 });

--- a/src/lib/auth/guards.test.ts
+++ b/src/lib/auth/guards.test.ts
@@ -25,23 +25,33 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/lib/session", () => ({ getSessionUser }));
 vi.mock("@/lib/firebase/admin", () => ({ adminDb: { collection } }));
 
-const { getUserWithRole, requireStudent, requireTeacher, requireUser, resolveRole, satisfiesRole } =
-  await import("@/lib/auth/guards");
+const {
+  getUserWithAccountType,
+  requireStudent,
+  requireTeacher,
+  requireUser,
+  resolveAccountType,
+  satisfiesAccountType,
+} = await import("@/lib/auth/guards");
 
-const teacherSession = { uid: "uid-1", email: "jane@htldornbirn.at", role: "teacher" as const };
+const teacherSession = {
+  uid: "uid-1",
+  email: "jane@htldornbirn.at",
+  accountType: "teacher" as const,
+};
 const studentSession = {
   uid: "uid-2",
   email: "sam@student.htldornbirn.at",
-  role: "student" as const,
+  accountType: "student" as const,
 };
 
 async function expectRedirect(promise: Promise<unknown>, url: string) {
   await expect(promise).rejects.toThrow(`REDIRECT:${url}`);
 }
 
-describe("satisfiesRole", () => {
+describe("satisfiesAccountType", () => {
   it("lets a teacher satisfy every student-level check", () => {
-    expect(satisfiesRole("teacher", "student")).toBe(true);
+    expect(satisfiesAccountType("teacher", "student")).toBe(true);
   });
 
   it.each([
@@ -49,39 +59,39 @@ describe("satisfiesRole", () => {
     ["student", "student", true],
     ["student", "teacher", false],
   ] as const)("returns %s->%s = %s", (actual, required, expected) => {
-    expect(satisfiesRole(actual, required)).toBe(expected);
+    expect(satisfiesAccountType(actual, required)).toBe(expected);
   });
 });
 
-describe("resolveRole", () => {
+describe("resolveAccountType", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("uses the custom claim without reading Firestore", async () => {
-    expect(await resolveRole(teacherSession)).toBe("teacher");
+    expect(await resolveAccountType(teacherSession)).toBe("teacher");
     expect(collection).not.toHaveBeenCalled();
   });
 
   it("falls back to the stored record when the claim is missing", async () => {
-    docGet.mockResolvedValue({ exists: true, data: () => ({ role: "student" }) });
+    docGet.mockResolvedValue({ exists: true, data: () => ({ accountType: "student" }) });
 
-    expect(await resolveRole({ ...studentSession, role: null })).toBe("student");
+    expect(await resolveAccountType({ ...studentSession, accountType: null })).toBe("student");
     expect(doc).toHaveBeenCalledWith("sam@student.htldornbirn.at");
   });
 
   it("returns null when no record exists", async () => {
     docGet.mockResolvedValue({ exists: false, data: () => undefined });
 
-    expect(await resolveRole({ ...studentSession, role: null })).toBeNull();
+    expect(await resolveAccountType({ ...studentSession, accountType: null })).toBeNull();
   });
 
   it("returns null when the stored role is unsupported", async () => {
-    docGet.mockResolvedValue({ exists: true, data: () => ({ role: "admin" }) });
+    docGet.mockResolvedValue({ exists: true, data: () => ({ accountType: "admin" }) });
 
-    expect(await resolveRole({ ...studentSession, role: null })).toBeNull();
+    expect(await resolveAccountType({ ...studentSession, accountType: null })).toBeNull();
   });
 
   it("returns null when the session carries no email to look up", async () => {
-    expect(await resolveRole({ uid: "uid-3", email: null, role: null })).toBeNull();
+    expect(await resolveAccountType({ uid: "uid-3", email: null, accountType: null })).toBeNull();
   });
 });
 
@@ -95,7 +105,7 @@ describe("requireUser", () => {
   });
 
   it("redirects to sign-in when no role can be resolved", async () => {
-    getSessionUser.mockResolvedValue({ ...studentSession, role: null });
+    getSessionUser.mockResolvedValue({ ...studentSession, accountType: null });
     docGet.mockResolvedValue({ exists: false, data: () => undefined });
 
     await expectRedirect(requireUser(), "/sign-in");
@@ -104,7 +114,7 @@ describe("requireUser", () => {
   it("returns the user together with the resolved role", async () => {
     getSessionUser.mockResolvedValue(teacherSession);
 
-    expect(await requireUser()).toMatchObject({ uid: "uid-1", role: "teacher" });
+    expect(await requireUser()).toMatchObject({ uid: "uid-1", accountType: "teacher" });
   });
 });
 
@@ -114,7 +124,7 @@ describe("requireTeacher", () => {
   it("returns the teacher", async () => {
     getSessionUser.mockResolvedValue(teacherSession);
 
-    expect(await requireTeacher()).toMatchObject({ role: "teacher" });
+    expect(await requireTeacher()).toMatchObject({ accountType: "teacher" });
   });
 
   it("redirects a student away from a teacher-only page", async () => {
@@ -130,7 +140,7 @@ describe("requireStudent", () => {
   it("returns the student", async () => {
     getSessionUser.mockResolvedValue(studentSession);
 
-    expect(await requireStudent()).toMatchObject({ role: "student" });
+    expect(await requireStudent()).toMatchObject({ accountType: "student" });
   });
 
   it("redirects a teacher, who has no master data record of their own", async () => {
@@ -140,18 +150,18 @@ describe("requireStudent", () => {
   });
 });
 
-describe("getUserWithRole", () => {
+describe("getUserWithAccountType", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("returns null instead of redirecting, so handlers can emit the error envelope", async () => {
     getSessionUser.mockResolvedValue(null);
 
-    expect(await getUserWithRole()).toBeNull();
+    expect(await getUserWithAccountType()).toBeNull();
   });
 
   it("returns the user with the resolved role", async () => {
     getSessionUser.mockResolvedValue(studentSession);
 
-    expect(await getUserWithRole()).toMatchObject({ role: "student" });
+    expect(await getUserWithAccountType()).toMatchObject({ accountType: "student" });
   });
 });

--- a/src/lib/auth/guards.ts
+++ b/src/lib/auth/guards.ts
@@ -9,9 +9,13 @@ import { adminDb } from "@/lib/firebase/admin";
 import { getSessionUser, type SessionUser } from "@/lib/session";
 import { COLLECTIONS } from "@/lib/schemas/collections";
 import { accountTypeSchema, userSchema, type AccountType } from "@/lib/schemas/user";
+import { may, permissionsSchema, type Permission } from "@/lib/auth/permissions";
 import { ROUTES } from "@/lib/routes";
 
-export type AuthenticatedUser = SessionUser & { accountType: AccountType };
+export type AuthenticatedUser = SessionUser & {
+  accountType: AccountType;
+  permissions: readonly Permission[];
+};
 
 /** Account types are hierarchical: a teacher satisfies every student-level check (US-2). */
 export function satisfiesAccountType(actual: AccountType, required: AccountType): boolean {
@@ -33,17 +37,37 @@ export async function resolveAccountType(user: SessionUser): Promise<AccountType
   return parsed.success ? parsed.data : null;
 }
 
+/**
+ * What the caller may do, always from the record and never from the token: a permission is
+ * granted and withdrawn while a session is live, so a claim minted beforehand would go on
+ * admitting what an admin has just taken away (US-2).
+ *
+ * A student holds none whatever their record lists, being refused by what they are (US-3).
+ */
+async function resolvePermissions(
+  email: string | null,
+  accountType: AccountType,
+): Promise<readonly Permission[]> {
+  if (accountType !== "teacher" || !email) return [];
+
+  const snapshot = await adminDb.collection(COLLECTIONS.users).doc(email.toLowerCase()).get();
+  const parsed = permissionsSchema.safeParse(snapshot.data()?.permissions);
+  return parsed.success ? parsed.data : [];
+}
+
 /** For Route Handlers: returns null instead of redirecting, so the caller emits the error envelope. */
-export async function getUserWithAccountType(): Promise<AuthenticatedUser | null> {
+export async function getAuthenticatedUser(): Promise<AuthenticatedUser | null> {
   const user = await getSessionUser();
   if (!user) return null;
 
   const accountType = await resolveAccountType(user);
-  return accountType ? { ...user, accountType } : null;
+  if (!accountType) return null;
+
+  return { ...user, accountType, permissions: await resolvePermissions(user.email, accountType) };
 }
 
 export async function requireUser(): Promise<AuthenticatedUser> {
-  const user = await getUserWithAccountType();
+  const user = await getAuthenticatedUser();
   if (!user) redirect(ROUTES.signIn);
   return user;
 }
@@ -51,6 +75,16 @@ export async function requireUser(): Promise<AuthenticatedUser> {
 export async function requireTeacher(): Promise<AuthenticatedUser> {
   const user = await requireUser();
   if (user.accountType !== "teacher") redirect(ROUTES.appRoot);
+  return user;
+}
+
+/**
+ * For a page. The landing route is where somebody who may not be here goes, because it is what
+ * works out where they may be instead.
+ */
+export async function requirePermission(permission: Permission): Promise<AuthenticatedUser> {
+  const user = await requireUser();
+  if (!may(user, permission)) redirect(ROUTES.appRoot);
   return user;
 }
 

--- a/src/lib/auth/guards.ts
+++ b/src/lib/auth/guards.ts
@@ -8,13 +8,13 @@ import { redirect } from "next/navigation";
 import { adminDb } from "@/lib/firebase/admin";
 import { getSessionUser, type SessionUser } from "@/lib/session";
 import { COLLECTIONS } from "@/lib/schemas/collections";
-import { userRoleSchema, userSchema, type UserRole } from "@/lib/schemas/user";
+import { accountTypeSchema, userSchema, type AccountType } from "@/lib/schemas/user";
 import { ROUTES } from "@/lib/routes";
 
-export type AuthenticatedUser = SessionUser & { role: UserRole };
+export type AuthenticatedUser = SessionUser & { accountType: AccountType };
 
-/** Roles are hierarchical: a teacher satisfies every student-level check (US-2). */
-export function satisfiesRole(actual: UserRole, required: UserRole): boolean {
+/** Account types are hierarchical: a teacher satisfies every student-level check (US-2). */
+export function satisfiesAccountType(actual: AccountType, required: AccountType): boolean {
   return actual === required || actual === "teacher";
 }
 
@@ -22,41 +22,41 @@ export function satisfiesRole(actual: UserRole, required: UserRole): boolean {
  * The custom claim is a cache. It is missing on the very first login, because the session
  * cookie is minted from an ID token issued before the claim was set — fall back to the record.
  */
-export async function resolveRole(user: SessionUser): Promise<UserRole | null> {
-  if (user.role) return user.role;
+export async function resolveAccountType(user: SessionUser): Promise<AccountType | null> {
+  if (user.accountType) return user.accountType;
   if (!user.email) return null;
 
   const snapshot = await adminDb.collection(COLLECTIONS.users).doc(user.email.toLowerCase()).get();
   if (!snapshot.exists) return null;
 
-  const parsed = userRoleSchema.safeParse(snapshot.data()?.role);
+  const parsed = accountTypeSchema.safeParse(snapshot.data()?.accountType);
   return parsed.success ? parsed.data : null;
 }
 
 /** For Route Handlers: returns null instead of redirecting, so the caller emits the error envelope. */
-export async function getUserWithRole(): Promise<AuthenticatedUser | null> {
+export async function getUserWithAccountType(): Promise<AuthenticatedUser | null> {
   const user = await getSessionUser();
   if (!user) return null;
 
-  const role = await resolveRole(user);
-  return role ? { ...user, role } : null;
+  const accountType = await resolveAccountType(user);
+  return accountType ? { ...user, accountType } : null;
 }
 
 export async function requireUser(): Promise<AuthenticatedUser> {
-  const user = await getUserWithRole();
+  const user = await getUserWithAccountType();
   if (!user) redirect(ROUTES.signIn);
   return user;
 }
 
 export async function requireTeacher(): Promise<AuthenticatedUser> {
   const user = await requireUser();
-  if (user.role !== "teacher") redirect(ROUTES.appRoot);
+  if (user.accountType !== "teacher") redirect(ROUTES.appRoot);
   return user;
 }
 
 export async function requireStudent(): Promise<AuthenticatedUser> {
   const user = await requireUser();
-  if (user.role !== "student") redirect(ROUTES.appRoot);
+  if (user.accountType !== "student") redirect(ROUTES.appRoot);
   return user;
 }
 

--- a/src/lib/auth/permissions.test.ts
+++ b/src/lib/auth/permissions.test.ts
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  PERMISSIONS,
+  PERMISSION_LABELS,
+  permissionSchema,
+  permissionsSchema,
+  may,
+  toggledPermissions,
+} from "./permissions";
+
+describe("PERMISSIONS", () => {
+  it("runs from the least a teacher may do to the most, which is the order the tags are shown in", () => {
+    expect(PERMISSIONS).toEqual([
+      "viewReports",
+      "editReports",
+      "editAssignments",
+      "editMasterData",
+      "editUsers",
+    ]);
+  });
+
+  it("labels every permission, so a tag can never render undefined", () => {
+    for (const permission of PERMISSIONS) {
+      expect(PERMISSION_LABELS[permission]).toBeTruthy();
+    }
+  });
+});
+
+describe("may", () => {
+  it("admits a permission the teacher holds", () => {
+    expect(may({ accountType: "teacher", permissions: ["editReports"] }, "editReports")).toBe(true);
+  });
+
+  /**
+   * There is no rank: the order above is the tag row's, so holding the permission that happens
+   * to sit highest grants nothing but itself, and each is asked for by name.
+   */
+  it("refuses a permission the teacher does not hold, whichever others they do", () => {
+    expect(may({ accountType: "teacher", permissions: ["editUsers"] }, "editMasterData")).toBe(
+      false,
+    );
+  });
+
+  it("refuses everything to a teacher holding none at all", () => {
+    for (const permission of PERMISSIONS) {
+      expect(may({ accountType: "teacher", permissions: [] }, permission)).toBe(false);
+    }
+  });
+
+  /**
+   * An account type is which population somebody belongs to, derived once from the UPN domain
+   * and granted by nobody (US-3). A student is therefore refused ahead of anything their record
+   * happens to carry, so a set written there by mistake grants nothing.
+   */
+  it("refuses a student everything, even what their record lists", () => {
+    for (const permission of PERMISSIONS) {
+      expect(may({ accountType: "student", permissions: [...PERMISSIONS] }, permission)).toBe(
+        false,
+      );
+    }
+  });
+});
+
+describe("toggledPermissions", () => {
+  it("presses one that was not held", () => {
+    expect(toggledPermissions([], "editAssignments")).toEqual(["editAssignments"]);
+  });
+
+  it("releases one that was held", () => {
+    expect(toggledPermissions(["editAssignments", "editUsers"], "editUsers")).toEqual([
+      "editAssignments",
+    ]);
+  });
+
+  it("returns them in the order the tags are shown, however they arrived", () => {
+    expect(toggledPermissions(["editUsers", "viewReports"], "editAssignments")).toEqual([
+      "viewReports",
+      "editAssignments",
+      "editUsers",
+    ]);
+  });
+
+  /** Saving a report you may not see is not a state worth being able to describe. */
+  it("presses viewReports along with editReports", () => {
+    expect(toggledPermissions([], "editReports")).toEqual(["viewReports", "editReports"]);
+  });
+
+  it("releases editReports along with viewReports", () => {
+    expect(toggledPermissions(["viewReports", "editReports"], "viewReports")).toEqual([]);
+  });
+
+  it("leaves editReports alone when something it does not depend on is released", () => {
+    expect(toggledPermissions(["viewReports", "editReports", "editUsers"], "editUsers")).toEqual([
+      "viewReports",
+      "editReports",
+    ]);
+  });
+});
+
+describe("permissionSchema", () => {
+  it("accepts every permission", () => {
+    for (const permission of PERMISSIONS) {
+      expect(permissionSchema.parse(permission)).toBe(permission);
+    }
+  });
+
+  it("refuses one nothing offers", () => {
+    expect(permissionSchema.safeParse("superuser").success).toBe(false);
+  });
+
+  it("refuses the words that say what somebody is rather than what they may do", () => {
+    expect(permissionSchema.safeParse("teacher").success).toBe(false);
+    expect(permissionSchema.safeParse("student").success).toBe(false);
+  });
+});
+
+describe("permissionsSchema", () => {
+  it("reads a missing list as none, so a record written before this existed grants nothing", () => {
+    expect(permissionsSchema.parse(undefined)).toEqual([]);
+  });
+
+  it("accepts a list that satisfies what its permissions depend on", () => {
+    expect(permissionsSchema.parse(["viewReports", "editReports"])).toEqual([
+      "viewReports",
+      "editReports",
+    ]);
+  });
+
+  /** Refused rather than repaired: a caller asking for this has misunderstood something. */
+  it("refuses editReports without viewReports", () => {
+    expect(permissionsSchema.safeParse(["editReports"]).success).toBe(false);
+  });
+
+  it("refuses a repeated permission, which would let one tag be stored twice", () => {
+    expect(permissionsSchema.safeParse(["viewReports", "viewReports"]).success).toBe(false);
+  });
+
+  it("refuses a list longer than there are permissions", () => {
+    expect(permissionsSchema.safeParse([...PERMISSIONS, "viewReports"]).success).toBe(false);
+  });
+});

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { z } from "zod";
+import type { AccountType } from "@/lib/schemas/user";
+
+/**
+ * What a teacher may do, as against what they are (US-2). A set rather than a rank: the order is
+ * the tag row's, running from the least a teacher may do to the most, and nothing reads it as
+ * seniority — each permission is asked for by name, and none stands in for another.
+ *
+ * There is no bundling layer, so what is granted is what is checked. Should these outgrow a
+ * single row, the word "role" is still free for a bundle of them.
+ */
+export const PERMISSIONS = [
+  "viewReports",
+  "editReports",
+  "editAssignments",
+  "editMasterData",
+  "editUsers",
+] as const;
+
+export type Permission = (typeof PERMISSIONS)[number];
+
+export const PERMISSION_LABELS: Record<Permission, string> = {
+  viewReports: "Berichte ansehen",
+  editReports: "Berichte bearbeiten",
+  editAssignments: "Zuteilung",
+  editMasterData: "Stammdaten",
+  editUsers: "Benutzerrechte",
+};
+
+/**
+ * A permission that cannot be held without another. Saving a report you may not see is not a
+ * state worth being able to describe, so the pair travels together in both directions.
+ */
+const REQUIRES = [["editReports", "viewReports"]] as const satisfies readonly (readonly [
+  Permission,
+  Permission,
+])[];
+
+export const permissionSchema = z.enum(PERMISSIONS);
+
+export const permissionsSchema = z
+  .array(permissionSchema)
+  .max(PERMISSIONS.length)
+  .refine((permissions) => new Set(permissions).size === permissions.length, {
+    message: "Eine Berechtigung darf nur einmal vorkommen.",
+  })
+  .refine(
+    (permissions) =>
+      REQUIRES.every(
+        ([permission, required]) =>
+          !permissions.includes(permission) || permissions.includes(required),
+      ),
+    { message: "Berichte bearbeiten setzt Berichte ansehen voraus." },
+  )
+  .default([]);
+
+/** Whoever is being asked about, narrowed to the two fields that decide it. */
+type Principal = { accountType: AccountType; permissions: readonly Permission[] };
+
+/**
+ * The one question the rest of the application asks. It takes the person rather than their list,
+ * so a permission cannot be checked without also saying whose it is — which is what keeps a
+ * student refused by what they are, ahead of whatever their record happens to carry (US-3).
+ */
+export function may(user: Principal, required: Permission): boolean {
+  return user.accountType === "teacher" && user.permissions.includes(required);
+}
+
+/**
+ * The tag row's rule, kept here so the page and the handler cannot disagree about what a press
+ * means: a permission arrives with whatever it depends on, and leaves with whatever depends on it.
+ */
+export function toggledPermissions(
+  held: readonly Permission[],
+  permission: Permission,
+): readonly Permission[] {
+  const wanted = new Set<Permission>(held);
+
+  if (wanted.has(permission)) {
+    wanted.delete(permission);
+    for (const [dependent, required] of REQUIRES) {
+      if (required === permission) wanted.delete(dependent);
+    }
+  } else {
+    wanted.add(permission);
+    for (const [dependent, required] of REQUIRES) {
+      if (dependent === permission) wanted.add(required);
+    }
+  }
+
+  return PERMISSIONS.filter((one) => wanted.has(one));
+}

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -43,7 +43,11 @@ const REQUIRES = [["editReports", "viewReports"]] as const satisfies readonly (r
 
 export const permissionSchema = z.enum(PERMISSIONS);
 
-export const permissionsSchema = z
+/**
+ * What a caller has to say out loud. Granting is a replacement rather than a patch, so an
+ * absent list is a request that means nothing and is refused rather than read as "none".
+ */
+export const permissionsInputSchema = z
   .array(permissionSchema)
   .max(PERMISSIONS.length)
   .refine((permissions) => new Set(permissions).size === permissions.length, {
@@ -56,8 +60,10 @@ export const permissionsSchema = z
           !permissions.includes(permission) || permissions.includes(required),
       ),
     { message: "Berichte bearbeiten setzt Berichte ansehen voraus." },
-  )
-  .default([]);
+  );
+
+/** The same, as a record carries it: one written before permissions existed holds none. */
+export const permissionsSchema = permissionsInputSchema.default([]);
 
 /** Whoever is being asked about, narrowed to the two fields that decide it. */
 type Principal = { accountType: AccountType; permissions: readonly Permission[] };

--- a/src/lib/auth/provision-user.test.ts
+++ b/src/lib/auth/provision-user.test.ts
@@ -11,10 +11,17 @@ const docGet = vi.fn();
 const docSet = vi.fn();
 const docUpdate = vi.fn();
 const doc = vi.fn(() => ({ get: docGet, set: docSet, update: docUpdate }));
-const collection = vi.fn(() => ({ doc }));
+// Whether anybody already teaches here, which is what decides the first teacher's roles (US-2).
+const teachersGet = vi.fn();
+const limit = vi.fn(() => ({ get: teachersGet }));
+const where = vi.fn(() => ({ limit }));
+const collection = vi.fn(() => ({ doc, where }));
 const setCustomUserClaims = vi.fn();
 const fetchEntraName = vi.fn();
 const fetchEntraPhoto = vi.fn();
+
+// A school that already has one, so a test says so itself when it means to be the first.
+teachersGet.mockResolvedValue({ empty: false });
 
 /**
  * The user record stays a mock, so the tests below can stage a login that finds one or does
@@ -41,6 +48,7 @@ vi.mock("@/lib/auth/sign-in-policy", () => ({ refuseSignIn }));
 
 const { provisionUser } = await import("@/lib/auth/provision-user");
 const { registrationPath } = await import("@/lib/registration/registration");
+const { PERMISSIONS } = await import("@/lib/auth/permissions");
 
 const teacherClaims = {
   uid: "firebase-uid-1",
@@ -93,7 +101,7 @@ describe("the deployment's own sign-in policy", () => {
     await provisionUser({ ...studentClaims, ...ENTRA });
 
     expect(refuseSignIn).toHaveBeenCalledWith({
-      role: "student",
+      accountType: "student",
       signInProvider: "microsoft.com",
     });
   });
@@ -101,7 +109,7 @@ describe("the deployment's own sign-in policy", () => {
   it("passes on an impersonated provider unchanged, so the policy can tell them apart", async () => {
     await provisionUser({ ...studentClaims, ...IMPERSONATED });
 
-    expect(refuseSignIn).toHaveBeenCalledWith({ role: "student", signInProvider: "custom" });
+    expect(refuseSignIn).toHaveBeenCalledWith({ accountType: "student", signInProvider: "custom" });
   });
 
   it("provisions as usual when nothing is refused", async () => {
@@ -129,14 +137,15 @@ describe("provisionUser", () => {
         firstName: "Jane",
         lastName: "Doe",
         email: "jane.doe@htldornbirn.at",
-        role: "teacher",
+        accountType: "teacher",
+        permissions: [],
         photo: null,
       },
     });
     expect(collection).toHaveBeenCalledWith("users");
     expect(doc).toHaveBeenCalledWith("jane.doe@htldornbirn.at");
     expect(docSet).toHaveBeenCalledWith(
-      expect.objectContaining({ firstName: "Jane", lastName: "Doe", role: "teacher" }),
+      expect.objectContaining({ firstName: "Jane", lastName: "Doe", accountType: "teacher" }),
     );
   });
 
@@ -146,7 +155,7 @@ describe("provisionUser", () => {
       email: "sam.smith@student.htldornbirn.at",
     });
 
-    expect(result).toMatchObject({ ok: true, user: { role: "student" } });
+    expect(result).toMatchObject({ ok: true, user: { accountType: "student" } });
   });
 
   it.each([
@@ -175,15 +184,15 @@ describe("provisionUser", () => {
       firstName: "Jane",
       lastName: "Doe",
       email: "jane.doe@htldornbirn.at",
-      role: "student",
+      accountType: "student",
     });
 
     const result = await provisionUser(teacherClaims);
 
-    expect(result).toMatchObject({ ok: true, user: { role: "student" } });
+    expect(result).toMatchObject({ ok: true, user: { accountType: "student" } });
     expect(docSet).not.toHaveBeenCalled();
     expect(docUpdate).not.toHaveBeenCalledWith(
-      expect.objectContaining({ role: expect.anything() }),
+      expect.objectContaining({ accountType: expect.anything() }),
     );
   });
 
@@ -192,7 +201,7 @@ describe("provisionUser", () => {
       firstName: "Old",
       lastName: "Name",
       email: "jane.doe@htldornbirn.at",
-      role: "teacher",
+      accountType: "teacher",
     });
 
     await provisionUser(teacherClaims);
@@ -208,7 +217,7 @@ describe("provisionUser", () => {
   it("mirrors the stored role into the custom claim", async () => {
     await provisionUser(teacherClaims);
 
-    expect(setCustomUserClaims).toHaveBeenCalledWith("firebase-uid-1", { role: "teacher" });
+    expect(setCustomUserClaims).toHaveBeenCalledWith("firebase-uid-1", { accountType: "teacher" });
   });
 
   it("skips the claim write when the token already carries the right role", async () => {
@@ -216,10 +225,10 @@ describe("provisionUser", () => {
       firstName: "Jane",
       lastName: "Doe",
       email: "jane.doe@htldornbirn.at",
-      role: "teacher",
+      accountType: "teacher",
     });
 
-    await provisionUser({ ...teacherClaims, role: "teacher" });
+    await provisionUser({ ...teacherClaims, accountType: "teacher" });
 
     expect(setCustomUserClaims).not.toHaveBeenCalled();
   });
@@ -328,6 +337,85 @@ describe("provisionUser", () => {
 });
 
 /**
+ * Somebody has to be able to hand out the first roles, and nobody can be granted one before a
+ * teacher exists to grant it — so the school's first teacher is provisioned holding all of them
+ * (US-2). Everyone after that starts with none and is granted what they need deliberately.
+ */
+describe("the roles a new teacher is provisioned with", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    refuseSignIn.mockReturnValue(null);
+    docGet.mockResolvedValue({ exists: false, data: () => undefined });
+    fetchEntraName.mockResolvedValue(null);
+    teachersGet.mockResolvedValue({ empty: false });
+  });
+
+  it("gives the first teacher every role", async () => {
+    teachersGet.mockResolvedValue({ empty: true });
+
+    const result = await provisionUser(teacherClaims);
+
+    expect(result).toMatchObject({ ok: true, user: { permissions: [...PERMISSIONS] } });
+    expect(docSet).toHaveBeenCalledWith(expect.objectContaining({ permissions: [...PERMISSIONS] }));
+  });
+
+  it("asks only whether a teacher exists, not for the whole staff room", async () => {
+    teachersGet.mockResolvedValue({ empty: true });
+
+    await provisionUser(teacherClaims);
+
+    expect(where).toHaveBeenCalledWith("accountType", "==", "teacher");
+    expect(limit).toHaveBeenCalledWith(1);
+  });
+
+  it("gives a later teacher none", async () => {
+    const result = await provisionUser(teacherClaims);
+
+    expect(result).toMatchObject({ ok: true, user: { permissions: [] } });
+    expect(docSet).toHaveBeenCalledWith(expect.objectContaining({ permissions: [] }));
+  });
+
+  /** A role says what a teacher may do; a student is not one, whoever signs in first (US-3). */
+  it("gives a student none even when nobody has signed in before", async () => {
+    teachersGet.mockResolvedValue({ empty: true });
+
+    const result = await provisionUser(studentClaims);
+
+    expect(result).toMatchObject({ ok: true, user: { accountType: "student", permissions: [] } });
+  });
+
+  it("keeps the roles already stored on a later login instead of reconsidering them", async () => {
+    existingRecord({
+      firstName: "Jane",
+      lastName: "Doe",
+      email: "jane.doe@htldornbirn.at",
+      accountType: "teacher",
+      permissions: ["viewReports"],
+    });
+
+    const result = await provisionUser(teacherClaims);
+
+    expect(result).toMatchObject({ ok: true, user: { permissions: ["viewReports"] } });
+    expect(docUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ permissions: expect.anything() }),
+    );
+  });
+
+  it("reads a record written before roles existed as holding none", async () => {
+    existingRecord({
+      firstName: "Jane",
+      lastName: "Doe",
+      email: "jane.doe@htldornbirn.at",
+      accountType: "teacher",
+    });
+
+    const result = await provisionUser(teacherClaims);
+
+    expect(result).toMatchObject({ ok: true, user: { permissions: [] } });
+  });
+});
+
+/**
  * Sign-in is the one moment the Graph token is held, so it is the one moment the photo can be
  * read — the token is not kept afterwards, and the browser never had one of its own (US-1).
  */
@@ -362,7 +450,7 @@ describe("provisionUser — the Entra photo", () => {
 
   /** Removing it in Entra removes it here, which only a write on every login can do. */
   it("clears a photo that Entra no longer has", async () => {
-    existingRecord({ role: "teacher", photo: "data:image/jpeg;base64,OLD" });
+    existingRecord({ accountType: "teacher", photo: "data:image/jpeg;base64,OLD" });
 
     await provisionUser(teacherClaims, "graph-token");
 

--- a/src/lib/auth/provision-user.ts
+++ b/src/lib/auth/provision-user.ts
@@ -9,10 +9,11 @@ import { adminAuth, adminDb } from "@/lib/firebase/admin";
 import { commitInChunks, type BatchOperation } from "@/lib/firebase/batch";
 import { COLLECTIONS } from "@/lib/schemas/collections";
 import type { Registration } from "@/lib/schemas/registration";
-import { userRoleSchema, userSchema, type User } from "@/lib/schemas/user";
+import { accountTypeSchema, userSchema, type User } from "@/lib/schemas/user";
+import { PERMISSIONS, permissionsSchema, type Permission } from "./permissions";
 import { fetchEntraName, fetchEntraPhoto } from "./graph";
 import { refuseSignIn } from "./sign-in-policy";
-import { roleFromUpn } from "./upn";
+import { accountTypeFromUpn } from "./upn";
 
 export type EntraClaims = {
   uid: string;
@@ -20,7 +21,7 @@ export type EntraClaims = {
   name?: string;
   given_name?: string;
   family_name?: string;
-  role?: unknown;
+  accountType?: unknown;
   firebase?: { sign_in_provider?: string };
 };
 
@@ -61,6 +62,21 @@ function resolveName(claims: EntraClaims, localPart: string) {
 
 /** What a registration copies off the user record, derived so a field added there reaches this. */
 type StoredIdentity = Pick<Registration, "firstName" | "lastName" | "email">;
+
+/**
+ * Whether this login is the school's first teacher, who is provisioned holding every accountType
+ * because there is nobody yet who could grant them one (US-2). Asked with a limit: what matters
+ * is that one exists, not who they are.
+ */
+async function isFirstTeacher(): Promise<boolean> {
+  const existing = await adminDb
+    .collection(COLLECTIONS.users)
+    .where("accountType", "==", accountTypeSchema.enum.teacher)
+    .limit(1)
+    .get();
+
+  return existing.empty;
+}
 
 /**
  * Carries a corrected name into the registrations this student already holds (US-26).
@@ -108,7 +124,7 @@ async function refreshRegistrations(upn: string, identity: StoredIdentity): Prom
 }
 
 /**
- * Creates the user record on first login and keeps the role custom claim in sync (US-1, US-3).
+ * Creates the user record on first login and keeps the accountType custom claim in sync (US-1, US-3).
  * Runs server-side only — the Admin SDK bypasses Security Rules, which deny client writes to `users`.
  */
 export async function provisionUser(
@@ -118,12 +134,12 @@ export async function provisionUser(
   const upn = claims.email?.trim().toLowerCase();
   if (!upn) return { ok: false, reason: "missing-upn" };
 
-  const derivedRole = roleFromUpn(upn);
-  if (!derivedRole) return { ok: false, reason: "unsupported-domain" };
+  const derivedAccountType = accountTypeFromUpn(upn);
+  if (!derivedAccountType) return { ok: false, reason: "unsupported-domain" };
 
   // Whatever else this deployment refuses. Production refuses nothing here.
   const refusal = refuseSignIn({
-    role: derivedRole,
+    accountType: derivedAccountType,
     signInProvider: claims.firebase?.sign_in_provider,
   });
   if (refusal) return { ok: false, ...refusal };
@@ -141,26 +157,43 @@ export async function provisionUser(
   const ref = adminDb.collection(COLLECTIONS.users).doc(upn);
   const snapshot = await ref.get();
 
-  let role = derivedRole;
+  let accountType = derivedAccountType;
+  let permissions: readonly Permission[] = [];
   if (snapshot.exists) {
-    // The role is assigned once, at creation; a later login never recomputes it (US-3).
-    const stored = userSchema.shape.role.safeParse(snapshot.data()?.role);
-    if (stored.success) role = stored.data;
+    // The accountType is assigned once, at creation; a later login never recomputes it (US-3).
+    const stored = userSchema.shape.accountType.safeParse(snapshot.data()?.accountType);
+    if (stored.success) accountType = stored.data;
+    // Nor are the permissions reconsidered: they are an admin's to grant, and a record written before
+    // they existed reads as holding none.
+    const held = permissionsSchema.safeParse(snapshot.data()?.permissions);
+    permissions = held.success ? held.data : [];
     // The photo is written even when there is none, so removing it in Entra removes it here.
     await ref.update({ firstName, lastName, email: upn, photo });
   } else {
-    await ref.set({ firstName, lastName, email: upn, role, photo });
+    permissions =
+      accountType === accountTypeSchema.enum.teacher && (await isFirstTeacher())
+        ? [...PERMISSIONS]
+        : [];
+    await ref.set({ firstName, lastName, email: upn, accountType, photo, permissions });
   }
 
-  const user = userSchema.parse({ id: upn, firstName, lastName, email: upn, role, photo });
+  const user = userSchema.parse({
+    id: upn,
+    firstName,
+    lastName,
+    email: upn,
+    accountType,
+    permissions,
+    photo,
+  });
 
   // Only a student holds registrations: a teacher keeps none of their own (US-15).
-  if (role === userRoleSchema.enum.student) {
+  if (accountType === accountTypeSchema.enum.student) {
     await refreshRegistrations(upn, { firstName, lastName, email: upn });
   }
 
-  if (claims.role !== role) {
-    await adminAuth.setCustomUserClaims(claims.uid, { role });
+  if (claims.accountType !== accountType) {
+    await adminAuth.setCustomUserClaims(claims.uid, { accountType });
   }
 
   return { ok: true, user };

--- a/src/lib/auth/reachable-pages.test.ts
+++ b/src/lib/auth/reachable-pages.test.ts
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { describe, expect, it } from "vitest";
+import { PERMISSIONS } from "@/lib/auth/permissions";
+import { PAGE_PERMISSION, reachablePages, firstReachableHref } from "./reachable-pages";
+
+const SERIES = "s1";
+
+describe("PAGE_PERMISSION", () => {
+  it("names a permission for every page a teacher can be sent to", () => {
+    for (const permission of Object.values(PAGE_PERMISSION)) {
+      expect(PERMISSIONS).toContain(permission);
+    }
+  });
+});
+
+describe("reachablePages", () => {
+  it("lists them in the order the navigation shows them", () => {
+    expect(reachablePages([...PERMISSIONS])).toEqual([
+      "overview",
+      "assignment",
+      "report",
+      "masterData",
+      "users",
+    ]);
+  });
+
+  it("lists only what the permissions reach", () => {
+    expect(reachablePages(["editAssignments"])).toEqual(["assignment"]);
+  });
+
+  /** Both report pages hang off the one permission, so neither appears without it. */
+  it("gives viewReports both the overview and the report", () => {
+    expect(reachablePages(["viewReports"])).toEqual(["overview", "report"]);
+  });
+
+  it("lists nothing for a teacher holding nothing", () => {
+    expect(reachablePages([])).toEqual([]);
+  });
+});
+
+describe("firstReachableHref", () => {
+  it("sends a teacher to the first page they may open", () => {
+    expect(firstReachableHref(["editAssignments"], SERIES)).toBe("/app/s1/assignment");
+  });
+
+  it("prefers the overview when it is reachable", () => {
+    expect(firstReachableHref([...PERMISSIONS], SERIES)).toBe("/app/s1/overview");
+  });
+
+  /**
+   * The rights page is about the school rather than a series, so it is where somebody holding
+   * only that one lands — and it is the one destination that survives having no series at all.
+   */
+  it("sends an admin with nothing else to the rights page", () => {
+    expect(firstReachableHref(["editUsers"], SERIES)).toBe("/app/users");
+    expect(firstReachableHref(["editUsers"], null)).toBe("/app/users");
+  });
+
+  it("sends somebody whose pages all need a series to the event series list", () => {
+    expect(firstReachableHref(["editMasterData"], null)).toBe("/app/event-series");
+  });
+
+  it("has nowhere to send a teacher holding nothing", () => {
+    expect(firstReachableHref([], SERIES)).toBeNull();
+    expect(firstReachableHref([], null)).toBeNull();
+  });
+
+  it("has nowhere to send one whose only pages need a series there is none of", () => {
+    expect(firstReachableHref(["viewReports"], null)).toBeNull();
+  });
+});

--- a/src/lib/auth/reachable-pages.ts
+++ b/src/lib/auth/reachable-pages.ts
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { eventSeriesRoutes, ROUTES } from "@/lib/routes";
+import { may, type Permission } from "@/lib/auth/permissions";
+
+/** The pages a teacher can be sent to, in the order the navigation shows them. */
+export type PageKey = "overview" | "assignment" | "report" | "masterData" | "users";
+
+export const PAGE_PERMISSION: Record<PageKey, Permission> = {
+  overview: "viewReports",
+  assignment: "editAssignments",
+  report: "viewReports",
+  masterData: "editMasterData",
+  users: "editUsers",
+};
+
+const PAGE_ORDER = Object.keys(PAGE_PERMISSION) as PageKey[];
+
+export function reachablePages(permissions: readonly Permission[]): PageKey[] {
+  const holder = { accountType: "teacher", permissions } as const;
+  return PAGE_ORDER.filter((page) => may(holder, PAGE_PERMISSION[page]));
+}
+
+/**
+ * Where a teacher goes when they have named no page themselves — landing on `/app`, or opening
+ * a collapsed navigation bar. Null when they may open nothing, which is the state a teacher is
+ * provisioned in and is answered with an explanation rather than a redirect that would loop.
+ *
+ * Everything but the rights page is about one event series, so with none selected only that one
+ * and the list a series can be made in are left.
+ */
+export function firstReachableHref(
+  permissions: readonly Permission[],
+  eventSeriesId: string | null,
+): string | null {
+  const reachable = reachablePages(permissions);
+  if (reachable.length === 0) return null;
+
+  if (eventSeriesId === null) {
+    if (reachable.includes("users")) return `${ROUTES.appRoot}/users`;
+    return reachable.includes("masterData") ? ROUTES.eventSeries : null;
+  }
+
+  const scoped = eventSeriesRoutes(eventSeriesId);
+  const hrefs: Record<PageKey, string> = {
+    overview: scoped.overview,
+    assignment: scoped.assignment,
+    report: scoped.report,
+    masterData: ROUTES.eventSeries,
+    users: `${ROUTES.appRoot}/users`,
+  };
+
+  return hrefs[reachable[0]];
+}

--- a/src/lib/auth/session-claims.test.ts
+++ b/src/lib/auth/session-claims.test.ts
@@ -4,32 +4,37 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { describe, expect, it } from "vitest";
-import { readUnverifiedRole } from "@/lib/auth/session-claims";
+import { readUnverifiedAccountType } from "@/lib/auth/session-claims";
 
 function jwtWith(payload: Record<string, unknown>) {
   const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
   return `${encode({ alg: "RS256" })}.${encode(payload)}.signature-not-checked`;
 }
 
-describe("readUnverifiedRole", () => {
-  it.each(["teacher", "student"])("reads the %s role from the cookie payload", (role) => {
-    expect(readUnverifiedRole(jwtWith({ role }))).toBe(role);
-  });
+describe("readUnverifiedAccountType", () => {
+  it.each(["teacher", "student"])(
+    "reads the %s account type from the cookie payload",
+    (accountType) => {
+      expect(readUnverifiedAccountType(jwtWith({ accountType }))).toBe(accountType);
+    },
+  );
 
   it("decodes a payload containing non-ASCII characters", () => {
-    expect(readUnverifiedRole(jwtWith({ role: "teacher", name: "Jürgen Öztürk" }))).toBe("teacher");
+    expect(
+      readUnverifiedAccountType(jwtWith({ accountType: "teacher", name: "Jürgen Öztürk" })),
+    ).toBe("teacher");
   });
 
-  it("returns null when the role claim is missing", () => {
-    expect(readUnverifiedRole(jwtWith({ uid: "user-1" }))).toBeNull();
+  it("returns null when the account type claim is missing", () => {
+    expect(readUnverifiedAccountType(jwtWith({ uid: "user-1" }))).toBeNull();
   });
 
-  it("returns null for an unsupported role", () => {
-    expect(readUnverifiedRole(jwtWith({ role: "admin" }))).toBeNull();
+  it("returns null for an unsupported account type", () => {
+    expect(readUnverifiedAccountType(jwtWith({ accountType: "admin" }))).toBeNull();
   });
 
   it("returns null for a legacy roles array", () => {
-    expect(readUnverifiedRole(jwtWith({ roles: ["teacher"] }))).toBeNull();
+    expect(readUnverifiedAccountType(jwtWith({ roles: ["teacher"] }))).toBeNull();
   });
 
   it.each([
@@ -38,6 +43,6 @@ describe("readUnverifiedRole", () => {
     ["a truncated JWT", "header-only."],
     ["an undecodable payload", "header.@@@@.signature"],
   ])("returns null for %s", (_case, cookie) => {
-    expect(readUnverifiedRole(cookie)).toBeNull();
+    expect(readUnverifiedAccountType(cookie)).toBeNull();
   });
 });

--- a/src/lib/auth/session-claims.ts
+++ b/src/lib/auth/session-claims.ts
@@ -3,16 +3,16 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import { userRoleSchema, type UserRole } from "@/lib/schemas/user";
+import { accountTypeSchema, type AccountType } from "@/lib/schemas/user";
 
 /**
- * Reads the role claim from a Firebase session cookie WITHOUT verifying its signature.
+ * Reads the accountType claim from a Firebase session cookie WITHOUT verifying its signature.
  *
  * Optimistic routing only — never authorization. Signature verification needs the Admin SDK,
- * which cannot run in the proxy's Edge runtime, so every protected page re-checks the role
+ * which cannot run in the proxy's Edge runtime, so every protected page re-checks the accountType
  * against the verified session (see lib/auth/guards).
  */
-export function readUnverifiedRole(sessionCookie: string): UserRole | null {
+export function readUnverifiedAccountType(sessionCookie: string): AccountType | null {
   const payload = sessionCookie.split(".")[1];
   if (!payload) return null;
 
@@ -21,9 +21,9 @@ export function readUnverifiedRole(sessionCookie: string): UserRole | null {
     const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
     const bytes = Uint8Array.from(atob(padded), (char) => char.charCodeAt(0));
     const claims: unknown = JSON.parse(new TextDecoder().decode(bytes));
-    const role = (claims as { role?: unknown } | null)?.role;
+    const accountType = (claims as { accountType?: unknown } | null)?.accountType;
 
-    const parsed = userRoleSchema.safeParse(role);
+    const parsed = accountTypeSchema.safeParse(accountType);
     return parsed.success ? parsed.data : null;
   } catch {
     return null;

--- a/src/lib/auth/sign-in-policy.test.ts
+++ b/src/lib/auth/sign-in-policy.test.ts
@@ -13,7 +13,7 @@ import { refuseSignIn } from "@/lib/auth/sign-in-policy";
  */
 describe("the production sign-in policy", () => {
   it("refuses no sign-in of its own accord", () => {
-    expect(refuseSignIn({ role: "student", signInProvider: "microsoft.com" })).toBeNull();
-    expect(refuseSignIn({ role: "teacher", signInProvider: "microsoft.com" })).toBeNull();
+    expect(refuseSignIn({ accountType: "student", signInProvider: "microsoft.com" })).toBeNull();
+    expect(refuseSignIn({ accountType: "teacher", signInProvider: "microsoft.com" })).toBeNull();
   });
 });

--- a/src/lib/auth/sign-in-policy.ts
+++ b/src/lib/auth/sign-in-policy.ts
@@ -4,12 +4,12 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import "server-only";
-import type { UserRole } from "@/lib/schemas/user";
+import type { AccountType } from "@/lib/schemas/user";
 
 export type SignInRefusal = { reason: string; message: string };
 
 export type SignInAttempt = {
-  role: UserRole;
+  accountType: AccountType;
   /** Set by Firebase during the token exchange, so a caller cannot claim it. */
   signInProvider?: string;
 };

--- a/src/lib/auth/upn.test.ts
+++ b/src/lib/auth/upn.test.ts
@@ -4,26 +4,26 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { describe, expect, it } from "vitest";
-import { roleFromUpn } from "@/lib/auth/upn";
+import { accountTypeFromUpn } from "@/lib/auth/upn";
 
-describe("roleFromUpn", () => {
+describe("accountTypeFromUpn", () => {
   it("assigns the teacher role to the staff domain", () => {
-    expect(roleFromUpn("jane.doe@htldornbirn.at")).toBe("teacher");
+    expect(accountTypeFromUpn("jane.doe@htldornbirn.at")).toBe("teacher");
   });
 
   it("assigns the student role to the student domain", () => {
-    expect(roleFromUpn("jane.doe@student.htldornbirn.at")).toBe("student");
+    expect(accountTypeFromUpn("jane.doe@student.htldornbirn.at")).toBe("student");
   });
 
   it.each([
     ["Jane.Doe@HTLDornbirn.at", "teacher"],
     ["Jane.Doe@Student.HTLDornbirn.AT", "student"],
   ])("matches %s case-insensitively", (upn, expected) => {
-    expect(roleFromUpn(upn)).toBe(expected);
+    expect(accountTypeFromUpn(upn)).toBe(expected);
   });
 
   it("trims surrounding whitespace", () => {
-    expect(roleFromUpn("  jane.doe@htldornbirn.at  ")).toBe("teacher");
+    expect(accountTypeFromUpn("  jane.doe@htldornbirn.at  ")).toBe("teacher");
   });
 
   it.each([
@@ -39,6 +39,6 @@ describe("roleFromUpn", () => {
     ["a missing domain", "jane@"],
     ["two at signs", "jane@evil.com@htldornbirn.at"],
   ])("rejects %s", (_case, upn) => {
-    expect(roleFromUpn(upn)).toBeNull();
+    expect(accountTypeFromUpn(upn)).toBeNull();
   });
 });

--- a/src/lib/auth/upn.ts
+++ b/src/lib/auth/upn.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import type { UserRole } from "@/lib/schemas/user";
+import type { AccountType } from "@/lib/schemas/user";
 
 export const TEACHER_DOMAIN = "htldornbirn.at";
 export const STUDENT_DOMAIN = "student.htldornbirn.at";
@@ -13,7 +13,7 @@ export const STUDENT_DOMAIN = "student.htldornbirn.at";
  * The domain must match exactly, so lookalikes such as `evil-htldornbirn.at`,
  * `mail.htldornbirn.at` or `htldornbirn.at.evil.com` are rejected.
  */
-export function roleFromUpn(upn: string): UserRole | null {
+export function accountTypeFromUpn(upn: string): AccountType | null {
   const parts = upn.trim().toLowerCase().split("@");
   if (parts.length !== 2) return null;
 

--- a/src/lib/auth/use-sign-in.ts
+++ b/src/lib/auth/use-sign-in.ts
@@ -16,7 +16,7 @@ import {
 } from "firebase/auth";
 import { auth, createMicrosoftAuthProvider } from "@/lib/firebase/client";
 import { ROUTES, homeFor, safeDestination } from "@/lib/routes";
-import { userRoleSchema } from "@/lib/schemas/user";
+import { accountTypeSchema } from "@/lib/schemas/user";
 
 const ACCOUNT_NOT_ENABLED = "Dieses Konto ist für Sportsweek nicht freigeschaltet.";
 const SIGN_IN_FAILED = "Anmelden fehlgeschlagen. Bitte versuchen Sie es erneut.";
@@ -98,7 +98,7 @@ export function useSignIn() {
         }
 
         const body = await response.json().catch(() => null);
-        const role = userRoleSchema.safeParse(body?.role);
+        const role = accountTypeSchema.safeParse(body?.accountType);
 
         // Deliberately stays `checking`: there is a session now, so something is always
         // happening next — either navigating, or a step the caller puts in the way.

--- a/src/lib/registration/registration-service.test.ts
+++ b/src/lib/registration/registration-service.test.ts
@@ -58,7 +58,7 @@ afterEach(() => vi.restoreAllMocks());
  * student who can save is one the directory has already provisioned (US-1).
  */
 function seedStudent(upn: string, name: { firstName: string; lastName: string }) {
-  firestore.seed("users", upn, { ...name, email: upn, role: "student" });
+  firestore.seed("users", upn, { ...name, email: upn, accountType: "student" });
 }
 
 /**

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import type { UserRole } from "@/lib/schemas/user";
+import type { AccountType } from "@/lib/schemas/user";
 
 export const ROUTES = {
   signIn: "/sign-in",
@@ -35,8 +35,8 @@ export function eventSeriesRoutes(eventSeriesId: string) {
  * A teacher lands on `/app`, which resolves the selection and sends them on, because which series
  * they were last in is not something the sign-in knows.
  */
-export function homeFor(role: UserRole): string {
-  return role === "teacher" ? ROUTES.appRoot : ROUTES.myRegistration;
+export function homeFor(accountType: AccountType): string {
+  return accountType === "teacher" ? ROUTES.appRoot : ROUTES.myRegistration;
 }
 
 export function matchesPrefix(pathname: string, prefixes: readonly string[]): boolean {

--- a/src/lib/schemas/user.test.ts
+++ b/src/lib/schemas/user.test.ts
@@ -4,23 +4,24 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { describe, expect, it } from "vitest";
-import { userLockedFields, userRoleSchema, userSchema } from "@/lib/schemas/user";
+import { userLockedFields, accountTypeSchema, userSchema } from "@/lib/schemas/user";
 
 const validUser = {
   id: "jane.doe@htldornbirn.at",
   firstName: "Jane",
   lastName: "Doe",
   email: "jane.doe@htldornbirn.at",
-  role: "teacher",
+  accountType: "teacher",
+  permissions: [],
 };
 
-describe("userRoleSchema", () => {
+describe("accountTypeSchema", () => {
   it.each(["teacher", "student"])("accepts the %s role", (role) => {
-    expect(userRoleSchema.safeParse(role).success).toBe(true);
+    expect(accountTypeSchema.safeParse(role).success).toBe(true);
   });
 
   it("rejects an admin role, which this app does not have", () => {
-    expect(userRoleSchema.safeParse("admin").success).toBe(false);
+    expect(accountTypeSchema.safeParse("admin").success).toBe(false);
   });
 });
 
@@ -42,12 +43,12 @@ describe("userSchema", () => {
   });
 
   it("stores exactly one role, not an array", () => {
-    expect(userSchema.safeParse({ ...validUser, role: ["teacher"] }).success).toBe(false);
+    expect(userSchema.safeParse({ ...validUser, accountType: ["teacher"] }).success).toBe(false);
   });
 });
 
 describe("userLockedFields", () => {
-  it("locks the role so firestore.rules can deny every client write to it", () => {
-    expect(Object.keys(userLockedFields.shape)).toEqual(["role"]);
+  it("locks what no client may ever write, so firestore.rules can deny it", () => {
+    expect(Object.keys(userLockedFields.shape)).toEqual(["accountType", "permissions"]);
   });
 });

--- a/src/lib/schemas/user.ts
+++ b/src/lib/schemas/user.ts
@@ -4,10 +4,11 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { z } from "zod";
+import { permissionsSchema } from "@/lib/auth/permissions";
 import { documentIdSchema, requiredText } from "./common";
 
-export const userRoleSchema = z.enum(["teacher", "student"]);
-export type UserRole = z.infer<typeof userRoleSchema>;
+export const accountTypeSchema = z.enum(["teacher", "student"]);
+export type AccountType = z.infer<typeof accountTypeSchema>;
 
 export const userSchema = z.object({
   // The Entra ID UPN doubles as the document id, giving a 1:1 relationship (US-1).
@@ -15,12 +16,17 @@ export const userSchema = z.object({
   firstName: requiredText(100),
   lastName: requiredText(100),
   email: z.email(),
-  role: userRoleSchema,
+  accountType: accountTypeSchema,
+  /**
+   * What this person may do, as against what they are (US-2). Empty for every student, and for
+   * a teacher until an admin grants something — a record carrying none reaches nothing.
+   */
+  permissions: permissionsSchema,
   // The Entra photo itself, as a data URL, rather than an address: Graph serves it to a bearer
   // token, and the token belongs to the sign-in that fetched it. Absent for most accounts.
   photo: z.string().nullish(),
 });
 export type User = z.infer<typeof userSchema>;
 
-/** Keep in sync with the `role` denylist in firestore.rules — no client may ever write it (US-3). */
-export const userLockedFields = userSchema.pick({ role: true });
+/** Keep in sync with the denylist in firestore.rules — no client may ever write these (US-3). */
+export const userLockedFields = userSchema.pick({ accountType: true, permissions: true });

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -41,13 +41,13 @@ describe("getSessionUser", () => {
     verifySessionCookie.mockResolvedValue({
       uid: "user-1",
       email: "user@example.com",
-      role: "teacher",
+      accountType: "teacher",
     });
 
     expect(await getSessionUser()).toEqual({
       uid: "user-1",
       email: "user@example.com",
-      role: "teacher",
+      accountType: "teacher",
     });
     expect(verifySessionCookie).toHaveBeenCalledWith("good-cookie", true);
   });
@@ -56,21 +56,21 @@ describe("getSessionUser", () => {
     cookiesGet.mockReturnValue({ value: "good-cookie" });
     verifySessionCookie.mockResolvedValue({ uid: "user-1", email: null });
 
-    expect(await getSessionUser()).toEqual({ uid: "user-1", email: null, role: null });
+    expect(await getSessionUser()).toEqual({ uid: "user-1", email: null, accountType: null });
   });
 
   it.each(["admin", "", 42])("returns a null role for the unsupported claim %p", async (role) => {
     cookiesGet.mockReturnValue({ value: "good-cookie" });
     verifySessionCookie.mockResolvedValue({ uid: "user-1", email: null, role });
 
-    expect(await getSessionUser()).toEqual({ uid: "user-1", email: null, role: null });
+    expect(await getSessionUser()).toEqual({ uid: "user-1", email: null, accountType: null });
   });
 
   it("ignores a legacy roles array, so the old model cannot grant access", async () => {
     cookiesGet.mockReturnValue({ value: "good-cookie" });
     verifySessionCookie.mockResolvedValue({ uid: "user-1", email: null, roles: ["teacher"] });
 
-    expect(await getSessionUser()).toEqual({ uid: "user-1", email: null, role: null });
+    expect(await getSessionUser()).toEqual({ uid: "user-1", email: null, accountType: null });
   });
 
   it("reads the cookie using the exported cookie name", () => {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -6,19 +6,19 @@
 import "server-only";
 import { cookies } from "next/headers";
 import { adminAuth } from "@/lib/firebase/admin";
-import { userRoleSchema, type UserRole } from "@/lib/schemas/user";
+import { accountTypeSchema, type AccountType } from "@/lib/schemas/user";
 
 export const SESSION_COOKIE_NAME = "__session";
 
 export type SessionUser = {
   uid: string;
   email: string | null;
-  role: UserRole | null;
+  accountType: AccountType | null;
 };
 
 /**
- * Verifies the Firebase session cookie and reads the role from custom claims.
- * The claim is a cached mirror of `/users/{uid}.role`: re-sync it whenever the record changes,
+ * Verifies the Firebase session cookie and reads the accountType from custom claims.
+ * The claim is a cached mirror of `/users/{uid}.accountType`: re-sync it whenever the record changes,
  * and fall back to the record for anything security-critical, as `firestore.rules` does.
  */
 export async function getSessionUser(): Promise<SessionUser | null> {
@@ -28,11 +28,11 @@ export async function getSessionUser(): Promise<SessionUser | null> {
 
   try {
     const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const role = userRoleSchema.safeParse(decoded.role);
+    const accountType = accountTypeSchema.safeParse(decoded.accountType);
     return {
       uid: decoded.uid,
       email: decoded.email ?? null,
-      role: role.success ? role.data : null,
+      accountType: accountType.success ? accountType.data : null,
     };
   } catch {
     return null;

--- a/src/lib/users/use-teachers.ts
+++ b/src/lib/users/use-teachers.ts
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import { collection, query, where } from "firebase/firestore";
+import { db } from "@/lib/firebase/client";
+import { subscribeWithRecovery } from "@/lib/firebase/live-query";
+import { COLLECTIONS } from "@/lib/schemas/collections";
+import { accountTypeSchema, userSchema } from "@/lib/schemas/user";
+import type { Permission } from "@/lib/auth/permissions";
+
+export type Teacher = {
+  upn: string;
+  firstName: string;
+  lastName: string;
+  permissions: readonly Permission[];
+};
+
+const teacherSchema = userSchema.pick({
+  firstName: true,
+  lastName: true,
+  permissions: true,
+});
+
+/**
+ * The staff room, live. Only somebody holding `editUsers` may read it, which the rules enforce;
+ * a student is filtered out by the query rather than hidden afterwards, since a permission is a
+ * teacher's and there would be nothing to show against their name (US-2).
+ */
+export function useTeachers() {
+  const [teachers, setTeachers] = useState<Teacher[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(
+    () =>
+      subscribeWithRecovery<Teacher>({
+        label: "teachers",
+        buildQuery: () =>
+          query(
+            collection(db, COLLECTIONS.users),
+            where("accountType", "==", accountTypeSchema.enum.teacher),
+          ),
+        parse: (id, data) => {
+          const parsed = teacherSchema.safeParse(data);
+          if (!parsed.success) {
+            console.error(`User ${id} does not match the schema`, parsed.error);
+            return null;
+          }
+          return { upn: id, ...parsed.data };
+        },
+        onData: (items) => {
+          setTeachers([...items].sort(byName));
+          setLoading(false);
+        },
+        onError: (message) => {
+          setError(message);
+          if (message !== null) setLoading(false);
+        },
+      }),
+    [],
+  );
+
+  return { teachers, loading, error };
+}
+
+/** Surname first, as a staff list is read. */
+function byName(a: Teacher, b: Teacher): number {
+  return (
+    a.lastName.localeCompare(b.lastName, "de-AT") || a.firstName.localeCompare(b.firstName, "de-AT")
+  );
+}

--- a/src/lib/users/user-service.test.ts
+++ b/src/lib/users/user-service.test.ts
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeFirestore } from "@/test/fake-firestore";
+import { ErrorCode } from "@/lib/errors";
+
+const firestore = new FakeFirestore();
+vi.mock("@/lib/firebase/admin", () => ({ adminDb: firestore }));
+
+const { grantPermissions, SELF_DEMOTION_HINT, NOT_A_TEACHER_HINT } =
+  await import("@/lib/users/user-service");
+
+const USERS = "users";
+const ADMIN = "ada@htldornbirn.at";
+const OTHER = "bob@htldornbirn.at";
+const STUDENT = "sam@student.htldornbirn.at";
+
+function seedTeacher(upn: string, permissions: string[]) {
+  firestore.seed(USERS, upn, {
+    firstName: "T",
+    lastName: upn,
+    email: upn,
+    accountType: "teacher",
+    permissions,
+  });
+}
+
+beforeEach(() => {
+  firestore.reset();
+  seedTeacher(ADMIN, ["editUsers"]);
+  seedTeacher(OTHER, []);
+});
+
+describe("grantPermissions", () => {
+  it("stores what the admin granted", async () => {
+    await grantPermissions(OTHER, ["viewReports", "editAssignments"], ADMIN);
+
+    expect(firestore.get(USERS, OTHER)?.permissions).toEqual(["viewReports", "editAssignments"]);
+  });
+
+  it("stores an empty set, which is how somebody is shut out again", async () => {
+    seedTeacher(OTHER, ["editMasterData"]);
+
+    await grantPermissions(OTHER, [], ADMIN);
+
+    expect(firestore.get(USERS, OTHER)?.permissions).toEqual([]);
+  });
+
+  it("leaves every other field of the record alone", async () => {
+    await grantPermissions(OTHER, ["viewReports"], ADMIN);
+
+    expect(firestore.get(USERS, OTHER)).toMatchObject({
+      email: OTHER,
+      accountType: "teacher",
+      firstName: "T",
+    });
+  });
+
+  /**
+   * The guard that keeps somebody able to hand permissions out. Only the holder can be the last
+   * one, since anyone else removing it would need it themselves — so refusing self-removal is
+   * what keeps at least one, without ever counting them (US-2).
+   */
+  it("refuses to take editUsers off the person doing the granting", async () => {
+    await expect(grantPermissions(ADMIN, ["viewReports"], ADMIN)).rejects.toMatchObject({
+      code: ErrorCode.Conflict,
+      message: SELF_DEMOTION_HINT,
+    });
+
+    expect(firestore.get(USERS, ADMIN)?.permissions).toEqual(["editUsers"]);
+  });
+
+  it("lets an admin change their own other permissions", async () => {
+    seedTeacher(ADMIN, ["editUsers", "editMasterData"]);
+
+    await grantPermissions(ADMIN, ["editUsers", "viewReports"], ADMIN);
+
+    expect(firestore.get(USERS, ADMIN)?.permissions).toEqual(["editUsers", "viewReports"]);
+  });
+
+  it("lets an admin take editUsers off somebody else", async () => {
+    seedTeacher(OTHER, ["editUsers"]);
+
+    await grantPermissions(OTHER, [], ADMIN);
+
+    expect(firestore.get(USERS, OTHER)?.permissions).toEqual([]);
+  });
+
+  /** A permission says what a teacher may do; a student is not one, so there is nothing to say. */
+  it("refuses to grant anything to a student", async () => {
+    firestore.seed(USERS, STUDENT, { email: STUDENT, accountType: "student", permissions: [] });
+
+    await expect(grantPermissions(STUDENT, ["viewReports"], ADMIN)).rejects.toMatchObject({
+      code: ErrorCode.Conflict,
+      message: NOT_A_TEACHER_HINT,
+    });
+
+    expect(firestore.get(USERS, STUDENT)?.permissions).toEqual([]);
+  });
+
+  it("refuses a person who has never signed in", async () => {
+    await expect(
+      grantPermissions("nobody@htldornbirn.at", ["viewReports"], ADMIN),
+    ).rejects.toMatchObject({ code: ErrorCode.NotFound });
+  });
+
+  /** A caller cannot name a permission that does not exist, nor one twice. */
+  it("refuses a set the schema will not have", async () => {
+    await expect(grantPermissions(OTHER, ["editReports"], ADMIN)).rejects.toMatchObject({
+      code: ErrorCode.ValidationError,
+    });
+
+    expect(firestore.get(USERS, OTHER)?.permissions).toEqual([]);
+  });
+});

--- a/src/lib/users/user-service.ts
+++ b/src/lib/users/user-service.ts
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import "server-only";
+import { adminDb } from "@/lib/firebase/admin";
+import { ErrorCode } from "@/lib/errors";
+import { ServiceError } from "@/lib/service-error";
+import { COLLECTIONS } from "@/lib/schemas/collections";
+import { accountTypeSchema } from "@/lib/schemas/user";
+import { permissionsSchema, type Permission } from "@/lib/auth/permissions";
+
+export const SELF_DEMOTION_HINT =
+  "Du kannst dir das Recht, Benutzerrechte zu vergeben, nicht selbst entziehen.";
+
+export const NOT_A_TEACHER_HINT = "Nur Lehrpersonen können Rechte erhalten.";
+
+const UNKNOWN_PERSON_HINT = "Diese Person hat sich noch nie angemeldet.";
+
+/**
+ * Grants exactly the set named, replacing whatever was held (US-2).
+ *
+ * The refusals here are the ones a Security Rule cannot make: it cannot check that the target is
+ * a teacher without a second read it has no way to relate, and it cannot express the one rule
+ * that keeps somebody able to hand permissions out at all.
+ *
+ * That rule is self-removal. Only the last holder can be the last one — anyone else taking it
+ * from them would have to hold it themselves — so refusing to take `editUsers` off yourself
+ * leaves at least one holder without ever counting them, and counting is what a transaction
+ * would have to serialise. Everything else about your own record stays yours to change.
+ *
+ * The read and the write share a transaction, so two admins withdrawing each other at the same
+ * moment cannot both pass a check made before the other's write.
+ */
+export async function grantPermissions(
+  upn: string,
+  wanted: readonly Permission[],
+  actorUpn: string,
+): Promise<readonly Permission[]> {
+  const permissions = permissionsSchema.safeParse(wanted);
+  if (!permissions.success) {
+    throw new ServiceError(ErrorCode.ValidationError, "Diese Rechte gibt es so nicht.");
+  }
+
+  const reference = adminDb.collection(COLLECTIONS.users).doc(upn);
+
+  return adminDb.runTransaction(async (transaction) => {
+    const stored = await transaction.get(reference);
+    if (!stored.exists) {
+      throw new ServiceError(ErrorCode.NotFound, UNKNOWN_PERSON_HINT);
+    }
+
+    if (accountTypeSchema.safeParse(stored.data()?.accountType).data !== "teacher") {
+      throw new ServiceError(ErrorCode.Conflict, NOT_A_TEACHER_HINT);
+    }
+
+    const held = permissionsSchema.safeParse(stored.data()?.permissions);
+    const losesEditUsers =
+      (held.success ? held.data : []).includes("editUsers") &&
+      !permissions.data.includes("editUsers");
+
+    if (upn === actorUpn && losesEditUsers) {
+      throw new ServiceError(ErrorCode.Conflict, SELF_DEMOTION_HINT);
+    }
+
+    transaction.update(reference, { permissions: permissions.data });
+    return permissions.data;
+  });
+}

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -21,8 +21,8 @@ function makeRequest(pathname: string, { session }: { session?: string } = {}) {
   return new NextRequest(new URL(pathname, "https://example.com"), { headers });
 }
 
-const asTeacher = { session: sessionCookieWith({ role: "teacher" }) };
-const asStudent = { session: sessionCookieWith({ role: "student" }) };
+const asTeacher = { session: sessionCookieWith({ accountType: "teacher" }) };
+const asStudent = { session: sessionCookieWith({ accountType: "student" }) };
 
 function locationOf(response: Response) {
   return new URL(response.headers.get("location")!).pathname;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,10 +5,10 @@
  */
 import { NextResponse, type NextRequest } from "next/server";
 import { SESSION_COOKIE_NAME } from "@/lib/session";
-import { readUnverifiedRole } from "@/lib/auth/session-claims";
+import { readUnverifiedAccountType } from "@/lib/auth/session-claims";
 import { ROUTES, STUDENT_ONLY_PREFIXES, matchesPrefix } from "@/lib/routes";
 
-// Gate everything under /app; Route Handlers/Server Actions still re-check roles themselves.
+// Gate everything under /app; Route Handlers/Server Actions still re-check permissions themselves.
 const PROTECTED_PREFIX = "/app";
 
 export function proxy(request: NextRequest) {
@@ -25,19 +25,19 @@ export function proxy(request: NextRequest) {
   }
 
   // Optimistic only: the cookie signature is not verified here, so an unreadable claim
-  // falls through to the page, which re-checks the role against the verified session.
-  const role = readUnverifiedRole(sessionCookie);
-  if (!role) {
+  // falls through to the page, which re-checks it against the verified session.
+  const accountType = readUnverifiedAccountType(sessionCookie);
+  if (!accountType) {
     return NextResponse.next();
   }
 
-  // The landing route belongs to neither role: it is what decides where each of them goes.
+  // The landing route belongs to neither of them: it is what decides where each one goes.
   if (pathname === ROUTES.appRoot) {
     return NextResponse.next();
   }
 
   const isStudentPage = matchesPrefix(pathname, STUDENT_ONLY_PREFIXES);
-  const blocked = isStudentPage ? role !== "student" : role !== "teacher";
+  const blocked = isStudentPage ? accountType !== "student" : accountType !== "teacher";
 
   return blocked
     ? NextResponse.redirect(new URL(ROUTES.appRoot, request.url))


### PR DESCRIPTION
Every teacher could do everything. The only check any write made was
that the account type said "teacher", so a colleague brought in to run
the assignment board could rename a class list, and one who may read a
report could delete somebody else's saved one.

Teachers now hold permissions, granted and withdrawn from a page of
their own.

## Two words, because there were two facts

The user record called both of them "role". Being a teacher and being
allowed to edit the master data are not the same kind of fact: the first
is derived once from the UPN domain and granted by nobody, the second is
handed out and taken back. One word for both made every sentence about
either ambiguous, and the ambiguity had reached the rules file, the
custom claim and the session.

`accountType` is now what somebody is, `permissions` what they may do.

## A set, not a rank

`viewReports` · `editReports` · `editAssignments` · `editMasterData` ·
`editUsers`

Each is asked for by name and none stands in for another. A rank would
additionally claim that editing master data is more than editing
assignments, which nothing in a school says — they are different duties,
and the first request for assignments-without-master-data would have
been a schema change. It is also how every established model assigns
them: NIST RBAC keeps role hierarchy as a separate level above flat
RBAC, and neither AWS, Kubernetes nor GCP orders roles against each
other.

Two rules are not plain membership:

- `editReports` cannot be held without `viewReports`, because saving a
  report you cannot see is not a state worth describing. The pair
  travels together in both directions.
- A permission is read from the record rather than the token, so a
  withdrawal takes effect on the next request instead of the next
  sign-in. The account type keeps its claim shortcut, since it never
  changes.

A student holds none whatever their record lists — `may()` takes the
person rather than their list, so a permission cannot be checked without
also saying whose it is.

## Where it is enforced

Each of the eight write handlers names its one permission, and each page
area gained a layout that names the same one, so a page added under
`master-data/` later is covered by existing rather than by somebody
remembering. Security Rules were narrowed to match: registrations and
saved reports are no longer readable by any teacher, and no client may
write either field.

Nothing about the mapping is derivable, so the risk is a handler naming
the wrong permission — invisible to every existing test, since a teacher
with everything passes either way. Each route therefore gained a test
for a teacher holding a *different* permission. `handler.ts` had no test
at all and now has one.

## The page

One row per teacher, a tag per permission, pressed for what they hold. A
press sends the whole set rather than the tag, because what a press
means belongs to the dependency rule and that rule lives in one place.

The one tag that is not a button is your own right to grant. Taking it
from yourself is what would leave nobody able to give it back, so the
row states it and the handler refuses it inside the transaction that
would have written it. That single rule is what keeps at least one
holder, without ever counting them: only the last holder could be the
last one, since anybody else withdrawing it would have to hold it
themselves.

## Not walking into a locked room

The navigation bar used to be built from the event series, so it would
have offered pages its reader may not open, each bouncing them to the
landing route and back. Bar and landing route now ask one function where
a teacher may go, and a teacher holding nothing is told so rather than
redirected in a circle.

The school's first teacher is provisioned holding everything, there
being nobody yet who could grant it. Everyone after them starts with
none.

## Deploying

`firestore.rules` changed, so the rules deploy has to land with this.
`accountType` renames a stored field, so development and staging want a
reseed — the seed script writes students and teachers arrive on first
sign-in, which is what makes the first-teacher rule observable.
