### PR TITLE
Show which build is running

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,9 +5,11 @@
  */
 import type { NextConfig } from "next";
 import { parse } from "yaml";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { resolveAuthMode } from "./src/lib/auth/auth-mode";
+import { resolveCommitHash, SHORT_COMMIT_LENGTH } from "./src/lib/build-info";
 import {
   envFromApphostingYaml,
   preferProcessEnv,
@@ -45,8 +47,33 @@ const env = requireFirebaseProject(
 // /api/auth/fake is emitted.
 const fakeLogin = resolveAuthMode(env.AUTH_MODE, env.NEXT_PUBLIC_FIREBASE_PROJECT_ID) === "fake";
 
+// Only asked once no build variable has named the commit, and answers nothing where there is no
+// repository to ask -- which is what a build from a source archive looks like.
+function commitFromGit(): string | undefined {
+  try {
+    return execFileSync("git", ["rev-parse", `--short=${SHORT_COMMIT_LENGTH}`, "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+const { version } = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf8"),
+) as {
+  version: string;
+};
+
 const nextConfig: NextConfig = {
-  env,
+  env: {
+    ...env,
+    // Read back by src/lib/build-info.ts, which spells both names out again because Next
+    // substitutes a literal `process.env.X` and nothing a constant could stand in for.
+    NEXT_PUBLIC_APP_VERSION: version,
+    NEXT_PUBLIC_COMMIT_HASH: resolveCommitHash(process.env, commitFromGit),
+  },
   pageExtensions: ["ts", "tsx", ...(fakeLogin ? ["fake.ts", "fake.tsx"] : [])],
   // The rest of it hangs off two facades, which resolve to the production implementation
   // unless a build opts in here. Aliasing the fake login *in* rather than stubbing it out

--- a/src/app/app/my-registration/[eventSeriesId]/page.test.tsx
+++ b/src/app/app/my-registration/[eventSeriesId]/page.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireStudent = vi.fn(async () => ({ uid: "uid-1", email: "jane@htldornbirn.at" }));
+const get = vi.fn(async () => ({ id: "jane@htldornbirn.at", data: () => undefined }));
+
+vi.mock("@/lib/auth/guards", () => ({ requireStudent: () => requireStudent() }));
+vi.mock("@/lib/firebase/admin", () => ({
+  adminDb: { collection: () => ({ doc: () => ({ get }) }) },
+}));
+
+// The form reaches Firestore for the lists it offers, which this page's own layout does not need.
+vi.mock("@/components/my-registration/my-registration-view", () => ({
+  MyRegistrationView: () => <form aria-label="Registrierung" />,
+}));
+
+const RegistrationPage = (await import("@/app/app/my-registration/[eventSeriesId]/page")).default;
+
+const show = async () =>
+  render(await RegistrationPage({ params: Promise.resolve({ eventSeriesId: "s1" }) }));
+
+describe("the student's registration page", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.2.3");
+    vi.stubEnv("NEXT_PUBLIC_COMMIT_HASH", "a1b2c3d");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // A student has no navigation bar to carry it, so the foot of their one page is where it goes.
+  it("says which build this is, below the form", async () => {
+    await show();
+
+    const form = screen.getByRole("form", { name: "Registrierung" });
+    const position = form.compareDocumentPosition(screen.getByText("v1.2.3 · a1b2c3d"));
+
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("centres it under the column the form is capped to", async () => {
+    await show();
+
+    expect(screen.getByText("v1.2.3 · a1b2c3d")).toHaveClass("text-center");
+  });
+});

--- a/src/app/app/my-registration/[eventSeriesId]/page.tsx
+++ b/src/app/app/my-registration/[eventSeriesId]/page.tsx
@@ -7,6 +7,7 @@ import { adminDb } from "@/lib/firebase/admin";
 import { requireStudent } from "@/lib/auth/guards";
 import { COLLECTIONS } from "@/lib/schemas/collections";
 import { userSchema } from "@/lib/schemas/user";
+import { BuildInfo } from "@/components/layout/build-info";
 import { MyRegistrationView } from "@/components/my-registration/my-registration-view";
 
 /**
@@ -42,6 +43,8 @@ export default async function RegistrationPage({
         studentUpn={studentUpn}
         studentName={studentName}
       />
+      {/* A student has no navigation bar to carry it, so it closes their one page instead. */}
+      <BuildInfo className="border-border border-t pt-4 text-center" />
     </div>
   );
 }

--- a/src/components/layout/build-info.test.tsx
+++ b/src/components/layout/build-info.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BuildInfo } from "@/components/layout/build-info";
+
+describe("BuildInfo", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("states what this build is", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.2.3");
+    vi.stubEnv("NEXT_PUBLIC_COMMIT_HASH", "a1b2c3d");
+
+    render(<BuildInfo />);
+
+    expect(screen.getByText("v1.2.3 · a1b2c3d")).toBeInTheDocument();
+  });
+
+  // Nothing rather than an empty line: the space under the button it sits below is the button's.
+  it("takes up no room when the build stamped nothing", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "");
+    vi.stubEnv("NEXT_PUBLIC_COMMIT_HASH", "");
+
+    const { container } = render(<BuildInfo />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // Its two homes place it differently -- at the foot of the bar, and centred under the form.
+  it("lets the page that shows it say where", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.2.3");
+    vi.stubEnv("NEXT_PUBLIC_COMMIT_HASH", "a1b2c3d");
+
+    render(<BuildInfo className="text-center" />);
+
+    expect(screen.getByText("v1.2.3 · a1b2c3d")).toHaveClass("text-center");
+  });
+});

--- a/src/components/layout/build-info.tsx
+++ b/src/components/layout/build-info.tsx
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { buildInfo } from "@/lib/build-info";
+import { cn } from "@/lib/utils";
+
+/**
+ * Which build this is, for anyone reporting something odd about it. Quiet on purpose: it is
+ * never what somebody came to the page for, and it has to be legible when it is.
+ */
+export function BuildInfo({ className }: { className?: string }) {
+  const line = buildInfo();
+  if (line === "") return null;
+
+  return <p className={cn("text-muted-foreground truncate text-xs", className)}>{line}</p>;
+}

--- a/src/components/layout/teacher-nav.test.tsx
+++ b/src/components/layout/teacher-nav.test.tsx
@@ -5,7 +5,7 @@
  */
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const pathname = vi.fn(() => "/app/s1/report");
 const eventSeries = vi.fn<() => { eventSeries: unknown[] }>(() => ({ eventSeries: [] }));
@@ -46,6 +46,22 @@ describe("TeacherNav", () => {
     vi.clearAllMocks();
     pathname.mockReturnValue("/app/s1/report");
     showing(series("s1"), series("s2"), series("s7"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("says which build this is, under the sign-out at the foot of the bar", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.2.3");
+    vi.stubEnv("NEXT_PUBLIC_COMMIT_HASH", "a1b2c3d");
+
+    render(<TeacherNav permissions={[...PERMISSIONS]} />);
+
+    const signOut = screen.getByRole("button", { name: "Abmelden" });
+    const stamp = screen.getByText("v1.2.3 · a1b2c3d");
+
+    expect(signOut.compareDocumentPosition(stamp) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("lists the top-level items in order", () => {

--- a/src/components/layout/teacher-nav.tsx
+++ b/src/components/layout/teacher-nav.tsx
@@ -11,6 +11,7 @@ import { usePathname } from "next/navigation";
 import { ClipboardList, Database, FileText, Shuffle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Brand } from "@/components/layout/brand";
+import { BuildInfo } from "@/components/layout/build-info";
 import { SignOutButton } from "@/components/auth/sign-out-button";
 import { masterDataSections } from "@/lib/master-data/categories";
 import { useEventSeries } from "@/lib/event-series/use-event-series";
@@ -141,9 +142,15 @@ export function TeacherNav({
         </>
       )}
 
-      {/* The foot of the bar: who is signed in. */}
+      {/* The foot of the bar: who is signed in, and which build they are signed in to. The rule
+          is what makes the line read as the bar's footer rather than as something left under
+          the button; it runs the full width by undoing the bar's own padding. */}
       <div className="mt-auto">
         <SignOutButton className="min-h-9 w-full justify-start px-2 py-2" photo={photo} />
+        {/* The rule is pulled out to the bar's edges, so the line pays back everything between
+            that edge and the button's label: the bar's 2, the button's 2, its 6-wide mark, its
+            gap-3. */}
+        <BuildInfo className="border-border -mx-2 mt-2 border-t pt-2 pr-2 pl-13" />
       </div>
     </nav>
   );

--- a/src/lib/build-info.test.ts
+++ b/src/lib/build-info.test.ts
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildInfo,
+  buildInfoLine,
+  COMMIT_VARIABLES,
+  resolveCommitHash,
+  SHORT_COMMIT_LENGTH,
+  shortCommit,
+} from "@/lib/build-info";
+
+describe("shortCommit", () => {
+  it("shortens a full sha", () => {
+    expect(shortCommit("a1b2c3d4e5f60718293a4b5c6d7e8f9012345678")).toBe("a1b2c3d");
+  });
+
+  it("keeps one that is already short", () => {
+    expect(shortCommit("a1b2c3d")).toBe("a1b2c3d");
+  });
+
+  it("lowercases, so two builds of one commit read alike", () => {
+    expect(shortCommit("A1B2C3D")).toBe("a1b2c3d");
+  });
+
+  it("ignores surrounding whitespace, as a command's output carries a newline", () => {
+    expect(shortCommit(" a1b2c3d\n")).toBe("a1b2c3d");
+  });
+
+  // A build platform that does not fill a substitution hands the placeholder on verbatim, and
+  // an unresolved `$COMMIT_SHA` on screen is worse than no hash at all.
+  it.each([undefined, "", "   ", "$COMMIT_SHA", "unknown", "a1b2c3", "not-a-sha"])(
+    "answers nothing for %o",
+    (value) => {
+      expect(shortCommit(value)).toBe("");
+    },
+  );
+});
+
+describe("resolveCommitHash", () => {
+  it("prefers what the build platform named it", () => {
+    expect(resolveCommitHash({ SHORT_SHA: "a1b2c3d" }, () => "9999999")).toBe("a1b2c3d");
+  });
+
+  it("falls through the platform's names in order", () => {
+    expect(
+      resolveCommitHash(
+        { COMMIT_SHA: "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678" },
+        () => "9999999",
+      ),
+    ).toBe("a1b2c3d");
+  });
+
+  it("asks the repository when no variable answered", () => {
+    expect(resolveCommitHash({}, () => "9999999")).toBe("9999999");
+  });
+
+  // Reading a repository costs a process, so a build told the commit never starts one.
+  it("does not ask the repository once a variable has answered", () => {
+    const fromGit = vi.fn(() => "9999999");
+
+    resolveCommitHash({ SHORT_SHA: "a1b2c3d" }, fromGit);
+
+    expect(fromGit).not.toHaveBeenCalled();
+  });
+
+  // A source archive carries no repository, so this is the case a deployment may well land in.
+  it("answers nothing when there is neither a variable nor a repository", () => {
+    expect(resolveCommitHash({}, () => undefined)).toBe("");
+  });
+
+  it("skips a variable holding an unresolved placeholder", () => {
+    expect(resolveCommitHash({ SHORT_SHA: "$SHORT_SHA" }, () => "9999999")).toBe("9999999");
+  });
+});
+
+describe("buildInfoLine", () => {
+  it("names the version and the commit", () => {
+    expect(buildInfoLine("0.1.0", "a1b2c3d")).toBe("v0.1.0 · a1b2c3d");
+  });
+
+  // Which is what a deployment looks like if the commit never reached the build.
+  it("names the version alone when there is no commit", () => {
+    expect(buildInfoLine("0.1.0", "")).toBe("v0.1.0");
+  });
+
+  it("says nothing at all when neither is known", () => {
+    expect(buildInfoLine(undefined, undefined)).toBe("");
+  });
+});
+
+describe("buildInfo", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // The names below are the ones next.config.ts stamps in; the test is what ties the two ends.
+  it("reads what the build stamped into the bundle", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.2.3");
+    vi.stubEnv("NEXT_PUBLIC_COMMIT_HASH", "a1b2c3d");
+
+    expect(buildInfo()).toBe("v1.2.3 · a1b2c3d");
+  });
+});
+
+describe("the constants", () => {
+  it("shortens to the length git itself defaults to", () => {
+    expect(SHORT_COMMIT_LENGTH).toBe(7);
+  });
+
+  it("knows the build platform's names for the commit", () => {
+    expect(COMMIT_VARIABLES).toEqual(["SHORT_SHA", "COMMIT_SHA"]);
+  });
+});

--- a/src/lib/build-info.ts
+++ b/src/lib/build-info.ts
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+
+/** How much of a sha is shown — git's own default, and enough to name a commit in this repo. */
+export const SHORT_COMMIT_LENGTH = 7;
+
+/**
+ * What a build platform may call the commit it is building, most specific first. Cloud Build
+ * sets both for a repository-triggered build, and App Hosting builds on Cloud Build — so a
+ * deployment that hands one over is preferred to reading a repository that may not be there.
+ */
+export const COMMIT_VARIABLES = ["SHORT_SHA", "COMMIT_SHA"] as const;
+
+const COMMIT_PATTERN = new RegExp(`^[0-9a-f]{${SHORT_COMMIT_LENGTH},40}$`);
+
+/**
+ * A sha cut to length, or nothing at all. Anything that is not a sha is refused rather than
+ * shown: a platform that leaves a substitution unfilled passes the placeholder through, and
+ * `$COMMIT_SHA` on screen says less than an absent hash does.
+ */
+export function shortCommit(value: string | undefined): string {
+  const candidate = (value ?? "").trim().toLowerCase();
+
+  return COMMIT_PATTERN.test(candidate) ? candidate.slice(0, SHORT_COMMIT_LENGTH) : "";
+}
+
+/**
+ * The commit this build is of. `fromGit` is only asked once no variable has answered, so a
+ * build that was told what it is building never starts a process to find out.
+ */
+export function resolveCommitHash(
+  processEnv: Record<string, string | undefined>,
+  fromGit: () => string | undefined,
+): string {
+  for (const variable of COMMIT_VARIABLES) {
+    const named = shortCommit(processEnv[variable]);
+    if (named !== "") return named;
+  }
+
+  return shortCommit(fromGit());
+}
+
+/** Whichever of the two the build knew, so a missing hash costs the version its place. */
+export function buildInfoLine(version: string | undefined, commit: string | undefined): string {
+  return [version ? `v${version}` : "", commit ?? ""].filter(Boolean).join(" · ");
+}
+
+/**
+ * What this build is, for the status line both roles are shown.
+ *
+ * The two names are spelled out because Next only inlines a literal `process.env.X`, so they
+ * cannot be read from a shared constant — next.config.ts stamps them in under exactly these
+ * names, and the test beside this file is what keeps the two ends spelling them alike.
+ */
+export function buildInfo(): string {
+  return buildInfoLine(process.env.NEXT_PUBLIC_APP_VERSION, process.env.NEXT_PUBLIC_COMMIT_HASH);
+}


### PR DESCRIPTION
Neither role could answer "which version is this". Nothing in the app named the version
or the commit it was built from, so a report about odd behaviour could not be tied to a
rollout.

## What the build stamps in

The version comes from `package.json` and the commit from the build. `next.config.ts`
prefers `SHORT_SHA` or `COMMIT_SHA` where the platform names one, and otherwise reads the
repository — so a build that carries neither shows the version alone rather than an
unresolved `$COMMIT_SHA`. `shortCommit` refuses anything that is not hex for the same
reason.

Both arrive as `NEXT_PUBLIC_` variables. `src/lib/build-info.ts` spells the two names out a
second time because Next substitutes a literal `process.env.X` and nothing a shared
constant could stand in for; the test beside it is what ties the two ends together. They
are deliberately **not** in `INJECTED_VARIABLES`: that list is the guest list for
configuration arriving from an apphosting file, and these are facts about the build rather
than settings an environment may hand over.

## Where it shows

A teacher reads it at the foot of the navigation bar, ruled off so it reads as the bar's
footer rather than as something left under the sign-out button, and aligned with the
button's label. A student has no bar, so it closes their one page instead, centred under
the form.

Nothing is rendered at all when the build stamped nothing, so an environment that cannot
supply either value loses no layout.

## Still open

Whether the commit survives a deployment is unproven. App Hosting documents no variable for
it and does not say whether its build workspace keeps a repository. The staging rollout
answers that: a hash means this is done, a bare `v0.1.0` means the fallback is a workflow
that writes the sha into `apphosting.yaml` and deploys with the Firebase CLI — which would
give up branch-based rollouts, so it is worth confirming before building it.

## Gate

`vitest run` (1971), `lint`, `tsc --noEmit`, `prettier --check .`, `license:check` — all
green. `firestore.rules` is untouched, so the rules runner does not apply.
