### PR TITLE
Record when somebody signed in

### DIFF
--- a/firestore-tests/users.rules.test.ts
+++ b/firestore-tests/users.rules.test.ts
@@ -227,6 +227,60 @@ describe("/users/{uid} create and delete", () => {
   });
 });
 
+/**
+ * When somebody signed in is nobody's to read (US-1). It is written server-side with the Admin
+ * SDK, and no client has a use for it -- so the rule grants none, and these say so.
+ */
+describe("/users/{uid}/logins", () => {
+  async function seedLogin(upn: string) {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context
+        .firestore()
+        .collection(`users/${upn}/logins`)
+        .doc("login1")
+        .set({ at: "2026-08-29T17:04:05+02:00" });
+    });
+  }
+
+  it("denies somebody reading their own sign-ins, which their record does not carry", async () => {
+    await seedUser(ALICE, student());
+    await seedLogin(ALICE);
+    const db = signInAs(ALICE);
+
+    await assertFails(db.collection(`users/${ALICE}/logins`).doc("login1").get());
+  });
+
+  // Reading every user record is what editUsers grants, and it stops at the record.
+  it("denies whoever hands out the permissions reading somebody's sign-ins", async () => {
+    await seedUser(CAROL, admin());
+    await seedUser(ALICE, student());
+    await seedLogin(ALICE);
+    const db = signInAs(CAROL);
+
+    await assertFails(db.collection(`users/${ALICE}/logins`).get());
+  });
+
+  it("denies somebody writing a sign-in of their own", async () => {
+    await seedUser(ALICE, student());
+    const db = signInAs(ALICE);
+
+    await assertFails(
+      db
+        .collection(`users/${ALICE}/logins`)
+        .doc("invented")
+        .set({ at: "2026-08-29T17:04:05+02:00" }),
+    );
+  });
+
+  it("denies somebody deleting one, so a record of a sign-in outlives whoever made it", async () => {
+    await seedUser(ALICE, student());
+    await seedLogin(ALICE);
+    const db = signInAs(ALICE);
+
+    await assertFails(db.collection(`users/${ALICE}/logins`).doc("login1").delete());
+  });
+});
+
 describe("/users/{uid} has no admin role", () => {
   it("grants a document claiming role 'admin' no privileges at all", async () => {
     await seedUser(MALLORY, { accountType: "admin" });

--- a/firestore.rules
+++ b/firestore.rules
@@ -90,6 +90,23 @@ service cloud.firestore {
     }
 
     /**
+     * When somebody signed in, one document per sign-in, written by provisionUser through the
+     * Admin SDK. Closed to everybody in both directions: nothing in the app reads it, so
+     * nothing opens it -- not even the person it is about, and not the rights page, which is
+     * about what somebody may do rather than when they were last here.
+     *
+     * It is a subcollection rather than a field for that reason. A rule grants a whole
+     * document, and the record above is read by whoever hands out the permissions.
+     *
+     * No rule would match this path anyway, since the one below reaches only top-level
+     * collections. This says so out loud, so that opening it reads as the decision it would be.
+     */
+    match /users/{uid}/logins/{loginId} {
+      allow read: if false;
+      allow write: if false;
+    }
+
+    /**
      * A student's own registration (US-11), stored beneath the event series it belongs to so
      * that which series it is in is its path rather than a field it carries (US-26). Its id is
      * the student's UPN, so ownership is the document's own name and a read needs no query.

--- a/src/lib/auth/login-time.test.ts
+++ b/src/lib/auth/login-time.test.ts
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { describe, expect, it } from "vitest";
+import { localTimestamp, SCHOOL_TIME_ZONE } from "@/lib/auth/login-time";
+
+describe("localTimestamp", () => {
+  it("reads as the school's own clock in summer, two hours ahead of UTC", () => {
+    expect(localTimestamp(new Date("2026-08-29T15:04:05Z"))).toBe("2026-08-29T17:04:05+02:00");
+  });
+
+  // The offset is carried rather than assumed, so a winter reading is not two hours out.
+  it("follows the change to winter time", () => {
+    expect(localTimestamp(new Date("2026-01-15T15:04:05Z"))).toBe("2026-01-15T16:04:05+01:00");
+  });
+
+  it("carries the day over when the school's clock is already past midnight", () => {
+    expect(localTimestamp(new Date("2026-08-29T23:30:00Z"))).toBe("2026-08-30T01:30:00+02:00");
+  });
+
+  // Some locales spell the first hour of a day 24, which would name the day before it.
+  it("writes midnight as the start of its own day", () => {
+    expect(localTimestamp(new Date("2026-08-29T22:00:00Z"))).toBe("2026-08-30T00:00:00+02:00");
+  });
+
+  it("pads every field, so one reading is as wide as the next", () => {
+    expect(localTimestamp(new Date("2026-01-02T03:04:05Z"))).toBe("2026-01-02T04:04:05+01:00");
+  });
+
+  it("names the school's time zone, which is the one it is read in", () => {
+    expect(SCHOOL_TIME_ZONE).toBe("Europe/Vienna");
+  });
+});

--- a/src/lib/auth/login-time.ts
+++ b/src/lib/auth/login-time.ts
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+
+/** The one clock these records are read against: the school's own, wherever the server runs. */
+export const SCHOOL_TIME_ZONE = "Europe/Vienna";
+
+const FORMAT = new Intl.DateTimeFormat("en-GB", {
+  timeZone: SCHOOL_TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  // h23 rather than hour12: false, which spells the first hour of a day 24 in some locales.
+  hourCycle: "h23",
+  timeZoneName: "longOffset",
+});
+
+/**
+ * An instant as the school reads it, ISO 8601 with the offset it was in at the time.
+ *
+ * A string rather than a Firestore Timestamp, which is an instant and carries no zone: writing
+ * a shifted one would make the console show a reading that is wrong in the other direction.
+ * The offset is part of the value, so the instant is still recoverable from it.
+ */
+export function localTimestamp(at: Date): string {
+  const parts = Object.fromEntries(FORMAT.formatToParts(at).map((part) => [part.type, part.value]));
+
+  // "GMT+02:00" while the offset is not zero, and a bare "GMT" when it is.
+  const offset = parts.timeZoneName.replace("GMT", "") || "+00:00";
+
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}${offset}`;
+}

--- a/src/lib/auth/provision-user.test.ts
+++ b/src/lib/auth/provision-user.test.ts
@@ -10,7 +10,14 @@ import { storedEventSeries } from "@/test/event-series";
 const docGet = vi.fn();
 const docSet = vi.fn();
 const docUpdate = vi.fn();
-const doc = vi.fn(() => ({ get: docGet, set: docSet, update: docUpdate }));
+const loginAdd = vi.fn();
+const logins = vi.fn(() => ({ add: loginAdd }));
+const doc = vi.fn(() => ({
+  get: docGet,
+  set: docSet,
+  update: docUpdate,
+  collection: logins,
+}));
 // Whether anybody already teaches here, which is what decides the first teacher's roles (US-2).
 const teachersGet = vi.fn();
 const limit = vi.fn(() => ({ get: teachersGet }));
@@ -95,6 +102,15 @@ describe("the deployment's own sign-in policy", () => {
     expect(docSet).not.toHaveBeenCalled();
   });
 
+  // A sign-in that was turned away is not a sign-in, so the record of one would be untrue.
+  it("records no sign-in for somebody the policy turned away", async () => {
+    refuseSignIn.mockReturnValue({ reason: "students-excluded", message: "Nur Lehrpersonen." });
+
+    await provisionUser({ ...studentClaims, ...ENTRA });
+
+    expect(loginAdd).not.toHaveBeenCalled();
+  });
+
   // The role has been derived by then, so the policy never has to parse a UPN itself.
   it("asks with the derived role and the provider Firebase reported", async () => {
     await provisionUser({ ...studentClaims, ...ENTRA });
@@ -124,6 +140,32 @@ describe("provisionUser", () => {
     refuseSignIn.mockReturnValue(null);
     docGet.mockResolvedValue({ exists: false, data: () => undefined });
     fetchEntraName.mockResolvedValue(null);
+  });
+
+  /**
+   * Beneath the person rather than in their record: the record is read by whoever hands out
+   * the permissions, and a history of every sign-in is not what they came for. A subcollection
+   * has a rule of its own, and this one's grants nobody anything.
+   */
+  it("records each sign-in beneath the person who made it, on the school's clock", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T15:04:05Z"));
+
+    await provisionUser(teacherClaims);
+
+    expect(logins).toHaveBeenCalledWith("logins");
+    expect(loginAdd).toHaveBeenCalledWith({ at: "2026-08-29T17:04:05+02:00" });
+
+    vi.useRealTimers();
+  });
+
+  it("records one for somebody signing in again, rather than replacing the last", async () => {
+    existingRecord({ accountType: "teacher", permissions: [] });
+
+    await provisionUser(teacherClaims);
+
+    expect(loginAdd).toHaveBeenCalledTimes(1);
+    expect(docSet).not.toHaveBeenCalled();
   });
 
   it("creates the record on first login using the UPN as the document id", async () => {

--- a/src/lib/auth/provision-user.ts
+++ b/src/lib/auth/provision-user.ts
@@ -12,6 +12,7 @@ import type { Registration } from "@/lib/schemas/registration";
 import { accountTypeSchema, userSchema, type User } from "@/lib/schemas/user";
 import { permissionsSchema, type Permission } from "./permissions";
 import { fetchEntraName, fetchEntraPhoto } from "./graph";
+import { localTimestamp } from "./login-time";
 import { refuseSignIn } from "./sign-in-policy";
 import { accountTypeFromUpn } from "./upn";
 
@@ -159,6 +160,9 @@ export async function provisionUser(
     // written by the seeding script, so there is no race to be the first through the door.
     await ref.set({ firstName, lastName, email: upn, accountType, photo, permissions });
   }
+
+  // Recorded only now, once the sign-in is one: a refusal above returns without writing.
+  await ref.collection(COLLECTIONS.logins).add({ at: localTimestamp(new Date()) });
 
   const user = userSchema.parse({
     id: upn,

--- a/src/lib/schemas/collections.test.ts
+++ b/src/lib/schemas/collections.test.ts
@@ -21,6 +21,8 @@ describe("COLLECTIONS", () => {
         // searched for a secret (US-23).
         "invitations",
         "savedReports",
+        // Beneath the person who signed in, and closed to every client (US-1).
+        "logins",
       ].sort(),
     );
   });

--- a/src/lib/schemas/collections.ts
+++ b/src/lib/schemas/collections.ts
@@ -32,6 +32,13 @@ export const COLLECTIONS = {
    * has to name these as well.
    */
   savedReports: "savedReports",
+  /**
+   * One document per sign-in, beneath the person who made it. Beneath rather than a field on
+   * their record, which is read by whoever hands out the permissions: a rule grants a whole
+   * document, and a history of every sign-in is not what that reader came for. Nobody reads
+   * this one at all -- it is written by the Admin SDK and closed to every client.
+   */
+  logins: "logins",
 } as const;
 
 export type CollectionName = (typeof COLLECTIONS)[keyof typeof COLLECTIONS];


### PR DESCRIPTION
There was no way to tell whether an account had ever been used, or when it was last used —
which is where a question about somebody's access starts.

## Where it goes

Each successful sign-in adds a document at `users/{upn}/logins/{autoId}`:

```
{ at: "2026-08-29T17:04:05+02:00" }
```

Beneath the person rather than a field on their record: a rule grants a whole document, and
that record is read by whoever hands out the permissions — a history of every sign-in is not
what that reader came for. A subcollection has a rule of its own.

It is written by `provisionUser` **after** the refusal checks, so a sign-in that was turned
away leaves no record of one.

## Why a string and not a Timestamp

A Firestore `Timestamp` is an instant and carries no zone. Writing one shifted into Vienna's
offset would make the console show a reading that is wrong in the other direction. An ISO 8601
string carries the offset it was in at the time, which is both what the school reads and enough
to recover the instant from — and it follows the change to winter time rather than assuming an
offset.

`localTimestamp` (`src/lib/auth/login-time.ts`) uses `hourCycle: "h23"` rather than
`hour12: false`, which spells the first hour of a day 24 in some locales and would name the day
before it.

**Known consequence:** a Firestore TTL policy acts on a `Timestamp` field, so this cannot expire
automatically as written. The collection grows with every sign-in. Adding an `expiresAt`
alongside would buy that back, and is deliberately not done here — nothing has asked for a
retention period yet.

## Who may read it

Nobody. `firestore.rules` denies both directions, including to the person it is about and to
the rights page. No rule would match the path anyway — the catch-all reaches only top-level
collections — but it is said out loud, following the `invitations` precedent, so that opening
it later reads as the decision it would be. Four rules tests hold it there.

## Gate

`vitest run` (1983), `test:rules` (121), `lint`, `tsc --noEmit`, `prettier --check .`,
`license:check` — all green.
