### PR TITLE
Offer a filter tag for the teachers holding nothing

### DIFF
--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -119,6 +119,8 @@ As a teacher holding `editUsers`, I grant and withdraw what my colleagues may do
 - Each teacher's permissions are shown as a row of tags, one per permission, pressed for what they hold. A teacher holding none says so.
 - Pressing a tag grants that permission; pressing a pressed one withdraws it. What travels with it is US-2's exclusivity rule, so pressing "Berichte bearbeiten" clears "Berichte ansehen" and pressing either clears the other.
 - The list updates live, so two admins working at once see each other's changes.
+- The list is headed by the same filter the report carries (see US-13): a name field, matching first name, surname or address, and one row of tags. The tags are alternatives rather than conditions met at once, as any single category on the report is.
+- That row offers one tag per permission, and last a "Keine Rechte" tag for whoever holds none — which is who the page is most often opened to find. "Alle" clears them all.
 - A holder of `editUsers` cannot withdraw that permission from themselves. Their own tag for it is shown pressed but carries no button, and the server refuses the change regardless. Every other permission of their own remains theirs to change.
 - This is what keeps at least one holder without counting them: only the last holder could be the last one, since anybody else withdrawing it would have to hold it themselves.
 - Permissions cannot be granted to a student, nor to somebody who has never signed in — there is no record to grant against.

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -33,5 +33,9 @@ export default async function AppLandingPage() {
 
   if (destination !== null) redirect(destination);
 
-  return <p className="text-muted-foreground text-sm">{NO_PERMISSIONS_HINT}</p>;
+  return (
+    <div className="p-4 md:p-6">
+      <p className="text-muted-foreground text-sm">{NO_PERMISSIONS_HINT}</p>
+    </div>
+  );
 }

--- a/src/components/users/user-permissions-view.test.tsx
+++ b/src/components/users/user-permissions-view.test.tsx
@@ -4,7 +4,7 @@
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PERMISSIONS, PERMISSION_LABELS } from "@/lib/auth/permissions";
 
@@ -85,7 +85,10 @@ describe("UserPermissionsView", () => {
     teachers(BOB);
     show();
 
-    expect(screen.getByText(NO_PERMISSIONS_LABEL)).toBeInTheDocument();
+    // Scoped to the row: the filter offers a tag by the same name, which is a different thing.
+    expect(
+      within(screen.getByRole("listitem")).getByText(NO_PERMISSIONS_LABEL),
+    ).toBeInTheDocument();
   });
 
   it("grants the permission that was pressed", async () => {
@@ -283,5 +286,41 @@ describe("UserPermissionsView — filtering", () => {
     await userEvent.click(filterTag(PERMISSION_LABELS.editUsers));
 
     expect(apiRequest).not.toHaveBeenCalled();
+  });
+
+  /** Who is waiting for access, which is the question this page is most often opened to answer. */
+  it("narrows to whoever holds nothing", async () => {
+    show();
+
+    await userEvent.click(filterTag(NO_PERMISSIONS_LABEL));
+
+    expect(shown()).toEqual(["Cerny Clara"]);
+  });
+
+  it("reads that tag as an alternative beside a permission", async () => {
+    show();
+
+    await userEvent.click(filterTag(NO_PERMISSIONS_LABEL));
+    await userEvent.click(filterTag(PERMISSION_LABELS.editUsers));
+
+    expect(shown()).toEqual(["Auer Ada", "Cerny Clara"]);
+  });
+
+  it("releases it again when pressed twice", async () => {
+    show();
+
+    await userEvent.click(filterTag(NO_PERMISSIONS_LABEL));
+    await userEvent.click(filterTag(NO_PERMISSIONS_LABEL));
+
+    expect(shown()).toHaveLength(3);
+  });
+
+  it("is cleared by Alle along with the rest", async () => {
+    show();
+    await userEvent.click(filterTag(NO_PERMISSIONS_LABEL));
+
+    await userEvent.click(screen.getByRole("button", { name: `${FILTER_LABEL}: Alle` }));
+
+    expect(shown()).toHaveLength(3);
   });
 });

--- a/src/components/users/user-permissions-view.tsx
+++ b/src/components/users/user-permissions-view.tsx
@@ -25,6 +25,7 @@ import {
   filterTeachers,
   hasNoFilter,
   togglePermissionTag,
+  toggleWithoutPermissions,
 } from "@/lib/users/teacher-filter";
 import { useTeachers, type Teacher } from "@/lib/users/use-teachers";
 
@@ -131,6 +132,14 @@ export function UserPermissionsView({ signedInAs }: { signedInAs: string }) {
                   />
                 </Tag>
               ))}
+              {/* Last, because it is not one of them: it asks who is waiting for access. */}
+              <Tag pressed={filter.withoutPermissions}>
+                <TagName
+                  label={`${FILTER_LABEL}: ${NO_PERMISSIONS_LABEL}`}
+                  text={NO_PERMISSIONS_LABEL}
+                  onPress={() => setFilter(toggleWithoutPermissions(filter))}
+                />
+              </Tag>
             </div>
           </CardContent>
         </Card>

--- a/src/lib/users/teacher-filter.test.ts
+++ b/src/lib/users/teacher-filter.test.ts
@@ -10,6 +10,7 @@ import {
   filterTeachers,
   hasNoFilter,
   togglePermissionTag,
+  toggleWithoutPermissions,
 } from "./teacher-filter";
 
 const teacher = (firstName: string, lastName: string, ...permissions: string[]): Teacher => ({
@@ -82,9 +83,49 @@ describe("filterTeachers", () => {
   });
 
   it("applies the name and the tags together", () => {
-    const filter = { name: "a", permissions: ["editMasterData"] } as const;
+    const filter = { ...EMPTY_TEACHER_FILTER, name: "a", permissions: ["editMasterData"] } as const;
 
     expect(namesOf(filterTeachers(ALL, filter))).toEqual(["Berger"]);
+  });
+});
+
+/**
+ * Who is waiting for access, which is the question the page is most often opened to answer.
+ * It is a tag in the same row, so it reads as one more alternative rather than a mode.
+ */
+describe("filterTeachers — the tag for holding nothing", () => {
+  const without = { ...EMPTY_TEACHER_FILTER, withoutPermissions: true };
+
+  it("keeps only those holding none", () => {
+    expect(namesOf(filterTeachers(ALL, without))).toEqual(["Cerny"]);
+  });
+
+  it("reads as an alternative beside a permission, not a narrowing of it", () => {
+    const filter = { ...without, permissions: ["editUsers"] } as const;
+
+    expect(namesOf(filterTeachers(ALL, filter))).toEqual(["Auer", "Cerny"]);
+  });
+
+  it("still respects the name beside it", () => {
+    expect(namesOf(filterTeachers(ALL, { ...without, name: "zzz" }))).toEqual([]);
+  });
+});
+
+describe("toggleWithoutPermissions", () => {
+  it("presses it, and releases it again", () => {
+    const pressed = toggleWithoutPermissions(EMPTY_TEACHER_FILTER);
+
+    expect(pressed.withoutPermissions).toBe(true);
+    expect(toggleWithoutPermissions(pressed).withoutPermissions).toBe(false);
+  });
+
+  it("leaves the permission tags and the name alone", () => {
+    const filter = { name: "auer", permissions: ["editUsers"], withoutPermissions: false } as const;
+
+    const pressed = toggleWithoutPermissions(filter);
+
+    expect(pressed.permissions).toEqual(["editUsers"]);
+    expect(pressed.name).toBe("auer");
   });
 });
 
@@ -102,7 +143,7 @@ describe("togglePermissionTag", () => {
   });
 
   it("leaves the name alone", () => {
-    const filter = { name: "auer", permissions: [] };
+    const filter = { ...EMPTY_TEACHER_FILTER, name: "auer" };
 
     expect(togglePermissionTag(filter, "editUsers").name).toBe("auer");
   });
@@ -114,11 +155,15 @@ describe("hasNoFilter", () => {
   });
 
   it("is false once a tag is pressed", () => {
-    expect(hasNoFilter({ name: "", permissions: ["editUsers"] })).toBe(false);
+    expect(hasNoFilter({ ...EMPTY_TEACHER_FILTER, permissions: ["editUsers"] })).toBe(false);
+  });
+
+  it("is false once the tag for holding nothing is pressed", () => {
+    expect(hasNoFilter({ ...EMPTY_TEACHER_FILTER, withoutPermissions: true })).toBe(false);
   });
 
   /** The "Alle" tag answers for the tags, not for the name field beside it. */
   it("stays true while only a name is typed", () => {
-    expect(hasNoFilter({ name: "auer", permissions: [] })).toBe(true);
+    expect(hasNoFilter({ ...EMPTY_TEACHER_FILTER, name: "auer" })).toBe(true);
   });
 });

--- a/src/lib/users/teacher-filter.ts
+++ b/src/lib/users/teacher-filter.ts
@@ -14,13 +14,19 @@ import type { Teacher } from "./use-teachers";
 export type TeacherFilter = {
   name: string;
   permissions: readonly Permission[];
+  /** Who is waiting for access — a tag in the same row, so it reads as one more alternative. */
+  withoutPermissions: boolean;
 };
 
-export const EMPTY_TEACHER_FILTER: TeacherFilter = { name: "", permissions: [] };
+export const EMPTY_TEACHER_FILTER: TeacherFilter = {
+  name: "",
+  permissions: [],
+  withoutPermissions: false,
+};
 
 /** Whether the tag row is showing everybody, which is what its "Alle" tag reports. */
 export function hasNoFilter(filter: TeacherFilter): boolean {
-  return filter.permissions.length === 0;
+  return filter.permissions.length === 0 && !filter.withoutPermissions;
 }
 
 export function togglePermissionTag(filter: TeacherFilter, permission: Permission): TeacherFilter {
@@ -34,8 +40,12 @@ export function togglePermissionTag(filter: TeacherFilter, permission: Permissio
   };
 }
 
+export function toggleWithoutPermissions(filter: TeacherFilter): TeacherFilter {
+  return { ...filter, withoutPermissions: !filter.withoutPermissions };
+}
+
 export function clearPermissionTags(filter: TeacherFilter): TeacherFilter {
-  return { ...filter, permissions: [] };
+  return { ...filter, permissions: [], withoutPermissions: false };
 }
 
 /** The address is searched as well as the name: a colleague is as often looked up by it. */
@@ -48,14 +58,19 @@ function matchesName(teacher: Teacher, name: string): boolean {
   );
 }
 
+/** The tags are one row, so they are alternatives: whoever answers to any pressed one is kept. */
+function matchesTags(teacher: Teacher, filter: TeacherFilter): boolean {
+  if (hasNoFilter(filter)) return true;
+  if (filter.withoutPermissions && teacher.permissions.length === 0) return true;
+
+  return filter.permissions.some((permission) => teacher.permissions.includes(permission));
+}
+
 export function filterTeachers(
   teachers: readonly Teacher[],
   filter: TeacherFilter,
 ): readonly Teacher[] {
   return teachers.filter(
-    (teacher) =>
-      matchesName(teacher, filter.name) &&
-      (filter.permissions.length === 0 ||
-        filter.permissions.some((permission) => teacher.permissions.includes(permission))),
+    (teacher) => matchesName(teacher, filter.name) && matchesTags(teacher, filter),
   );
 }


### PR DESCRIPTION
Who is waiting for access is the question the rights page is most often
opened to answer, and it was the one thing the filter could not express.
Each tag named a permission, so there was no way to ask for the absence
of all of them.

There is now a "Keine Rechte" tag, last in the same row.

It reads the way the others do — an alternative rather than a mode — so
pressing it together with a permission asks for either. "Alle" clears it
along with the rest.

The filter gained a third field rather than a sentinel inside the list of
permissions, so `Permission` still means only what the application
actually grants and nothing has to know that one of its values is not
one.

---

Also: the landing page shown to a teacher who may reach nothing had no
padding, so the sentence explaining that sat flush against the header
instead of where a page begins. It now uses the same `p-4 md:p-6` every
other view carries.
