### PR TITLE
Carry only the students the card is showing

### DIFF
--- a/src/components/assignment/assignment-board.test.tsx
+++ b/src/components/assignment/assignment-board.test.tsx
@@ -207,6 +207,17 @@ describe("AssignmentBoard", () => {
     );
   });
 
+  /** What travels is what the card is showing, which is what the tally beside the list counts. */
+  it("leaves behind a picked student the filter is hiding", async () => {
+    setup();
+
+    await userEvent.click(card("Nicht zugeteilt").getByRole("button", { name: "Alle auswählen" }));
+    await userEvent.click(card("Nicht zugeteilt").getByRole("button", { name: "Klasse: 5BHIF" }));
+    await dragTo(handleIn("Nicht zugeteilt", "Berger Bene"), "{ArrowDown}");
+
+    await waitFor(() => expect(onMove).toHaveBeenCalledWith(["record-Berger"], "Montafon"));
+  });
+
   it("leaves a student picked in another card where they are", async () => {
     setup();
 

--- a/src/components/assignment/assignment-board.tsx
+++ b/src/components/assignment/assignment-board.tsx
@@ -236,9 +236,11 @@ function filterStudentsOf(group: AssignmentGroup, filter: StudentFilter | undefi
 }
 
 /**
- * Who a drag started on this tag is carrying. "Alle" stands for everyone the card's filter
- * leaves; a student who is part of that card's selection takes it along, filtered out of sight
- * or not; one who is not travels alone. Asked once, so what the overlay shows is what moves.
+ * Who a drag started on this tag is carrying — never more than the card is showing, which is
+ * what the tally beside its list counts. A filter narrowing the list to one student would
+ * otherwise take everyone it had just hidden along with them. "Alle" stands for exactly that
+ * set; a student who is part of the selection within it takes the rest along, one who is not
+ * travels alone. Asked once, so what the overlay shows is what moves.
  */
 function carriedBy(
   active: DragEndEvent["active"],
@@ -246,12 +248,13 @@ function carriedBy(
   filter: StudentFilter | undefined,
   picked: readonly string[],
 ): RosterStudent[] {
-  if (active.data.current?.all === true) return filterStudentsOf(source, filter);
+  const shown = filterStudentsOf(source, filter);
+  if (active.data.current?.all === true) return shown;
 
   const recordId = String(active.id);
-  const selection = source.students.filter((student) => picked.includes(student.id));
+  const selection = shown.filter((student) => picked.includes(student.id));
 
   return selection.some((student) => student.id === recordId)
     ? selection
-    : source.students.filter((student) => student.id === recordId);
+    : shown.filter((student) => student.id === recordId);
 }


### PR DESCRIPTION
A drag took its selection from everything the card held rather than from what its filter
left, while the tally beside the list counted the intersection of the two. Picking
thirty-one students, narrowing the filter to one class and then dragging the single student
it still showed moved all thirty-one: the card read "1 von 16 ausgewählt" and the board
disagreed with it.

`carriedBy` now starts from the students the filter leaves, so the selection a drag carries
is the one the tally counts. "Alle" was already scoped this way; only the path through a
single tag was not.

The selection itself still survives filtering — clearing the filter brings the others back
as picked. What changed is what travels.
