### PR TITLE
Name a teacher by their address, and the app by what it manages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "Sportsweek",
-  description: "Sportwochen-Verwaltung der HTL Dornbirn",
+  description: "Veranstaltungsverwaltung der HTL Dornbirn",
 };
 
 export default function RootLayout({ children }: LayoutProps<"/">) {

--- a/src/components/auth/sign-in-card.test.tsx
+++ b/src/components/auth/sign-in-card.test.tsx
@@ -174,7 +174,7 @@ describe("SignInCard", () => {
 
     render(<SignInCard />);
 
-    const subtitle = screen.getByText(/Sportwochen-Verwaltung/i, { selector: "p" });
+    const subtitle = screen.getByText(/Veranstaltungsverwaltung/i, { selector: "p" });
     expect(subtitle).toBeInTheDocument();
     expect(subtitle).not.toHaveTextContent(/HTL Dornbirn/i);
   });

--- a/src/components/auth/sign-in-card.tsx
+++ b/src/components/auth/sign-in-card.tsx
@@ -20,7 +20,7 @@ export function SignInCard() {
   return (
     <div className="bg-muted/50 flex flex-1 items-center justify-center p-4">
       <SignInLayout
-        subtitle="Sportwochen-Verwaltung"
+        subtitle="Veranstaltungsverwaltung"
         action="Anmelden über Office 365"
         onSignIn={signIn}
         busy={checking}

--- a/src/components/users/user-permissions-view.test.tsx
+++ b/src/components/users/user-permissions-view.test.tsx
@@ -70,6 +70,14 @@ describe("UserPermissionsView", () => {
     expect(screen.getByText("Berger Bob")).toBeInTheDocument();
   });
 
+  /** Two teachers can share a name, and the address is what tells a reader which one this is. */
+  it("names each teacher by their address rather than by the uid keying them", () => {
+    show();
+
+    expect(screen.getByText(ADA.email)).toBeInTheDocument();
+    expect(screen.queryByText(ADA.uid)).not.toBeInTheDocument();
+  });
+
   it("offers every permission as a tag against each teacher", () => {
     show();
 

--- a/src/components/users/user-permissions-view.tsx
+++ b/src/components/users/user-permissions-view.tsx
@@ -156,7 +156,7 @@ export function UserPermissionsView({ signedInAs }: { signedInAs: string }) {
               <CardContent className="flex flex-col gap-2">
                 <div className="flex flex-wrap items-baseline gap-x-2">
                   <span className="font-medium">{nameOf(teacher)}</span>
-                  <span className="text-muted-foreground text-sm">{teacher.uid}</span>
+                  <span className="text-muted-foreground text-sm">{teacher.email}</span>
                   {teacher.permissions.length === 0 ? (
                     <span className="text-muted-foreground text-sm">{NO_PERMISSIONS_LABEL}</span>
                   ) : null}


### PR DESCRIPTION
Two things noticed on production after #128.

## A teacher was named by their uid

The permissions list showed the opaque Firebase uid beside each name:

```tsx
<span className="text-muted-foreground text-sm">{teacher.uid}</span>
```

That line used to read `{teacher.upn}` and showed an address. Keying records by the uid renamed
the field, and the display followed it into meaninglessness — a teacher looking at
"Benutzerrechte" saw `6Xk2p9QwErTyUiOpAsDf` where they expect to read who this is. It names the
address again, which is what tells two teachers of the same name apart.

The test asserts the address is shown *and* that the uid is not, so the substitution cannot come
back unnoticed.

A sweep found no other place where an identifier reaches a reader. Every remaining use is a
React `key`, an `id`/`htmlFor` pair, a URL segment or a request body. Checked as well:
accessible names and tooltips, the German text of the delete dialogs, the PDF and Excel exports
(whose identity columns are first name, last name and address), the ordering of people (by name,
through the collator), and the clipboard, which carries an invitation link.

## The application is named after one kind of event

The sign-in card and the page description called it "Sportwochen-Verwaltung". It manages event
series of any kind — an event series is the unit, and a sports week is one instance of it — so
both now say "Veranstaltungsverwaltung".

## Testing

2047 unit tests, lint, `tsc`, Prettier and the licence check. `firestore.rules` is untouched, so
the rules runner does not apply.
