### PR TITLE
Give a student's build line the foot of the window

### DIFF
--- a/src/app/app/layout.test.tsx
+++ b/src/app/app/layout.test.tsx
@@ -43,16 +43,18 @@ describe("the app frame", () => {
   });
 
   /**
-   * A student is given no bar, so there is nowhere that stays put while their form scrolls.
-   * The header is that place: a screenshot of the window says which build it was taken from
-   * however far down the form the person taking it had got.
+   * A student is given no bar, so there is nowhere beside their form that stays put. The foot of
+   * the window is that place: a screenshot says which build it was taken from however far down
+   * the form the person taking it had got, and the header's one row is left to the controls — on
+   * a phone the build line was what pushed signing out off the right of the screen.
    */
-  it("gives a student the build line in the header, beside the brand", async () => {
+  it("gives a student the build line along the foot of the window", async () => {
     requireUser.mockResolvedValue({ email: "s@student.at", accountType: "student" });
 
     await show();
 
-    expect(screen.getByRole("banner")).toHaveTextContent("v1.2.3 · a1b2c3d");
+    expect(screen.getByText("v1.2.3 · a1b2c3d")).toBeInTheDocument();
+    expect(screen.getByRole("banner")).not.toHaveTextContent("v1.2.3");
   });
 
   // A teacher reads it at the foot of their bar, which does not scroll either.

--- a/src/components/layout/app-shell.test.tsx
+++ b/src/components/layout/app-shell.test.tsx
@@ -97,10 +97,11 @@ describe("AppShell", () => {
   });
 
   /**
-   * The header does not scroll, so what it says is in a screenshot of the window however far
-   * down the page the person taking it had got.
+   * The header is one row, and on a phone it could not carry the build line as well: at 375px
+   * it pushed the sign-out button off the right of the screen. The foot of the window is out of
+   * the way of every control and still never scrolls, which was the point of the header.
    */
-  it("says which build it is after the brand, for a student who has no bar", () => {
+  it("says which build it is along the foot, for a student who has no bar", () => {
     vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.2.3");
     vi.stubEnv("NEXT_PUBLIC_COMMIT_HASH", "a1b2c3d");
 
@@ -110,13 +111,11 @@ describe("AppShell", () => {
       </AppShell>,
     );
 
-    const header = screen.getByRole("banner");
     const stamp = screen.getByText("v1.2.3 · a1b2c3d");
 
-    expect(header).toContainElement(stamp);
+    expect(screen.getByRole("banner")).not.toContainElement(stamp);
     expect(
-      screen.getByText("Sportsweek").compareDocumentPosition(stamp) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
+      screen.getByText("Inhalt").compareDocumentPosition(stamp) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -21,7 +21,7 @@ import { BusyBar } from "@/components/layout/busy-bar";
  *
  * A grid track is also a definite height, which is what lets the bar reach the foot of the
  * window — Safari will not resolve that from flex-grow. The header track sizes to its content,
- * so it grows when the tags wrap.
+ * so it grows when the tags wrap, and the foot sizes to nothing where it holds nothing.
  */
 export function AppShell({
   children,
@@ -36,21 +36,17 @@ export function AppShell({
 }) {
   return (
     <BusyProvider>
-      <div className="grid h-dvh grid-cols-[auto_minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)]">
+      <div className="grid h-dvh grid-cols-[auto_minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)_auto]">
         {nav ? (
-          <div className="border-border bg-sidebar col-start-1 row-span-2 row-start-1 hidden shrink-0 border-r md:block">
+          <div className="border-border bg-sidebar col-start-1 row-span-3 row-start-1 hidden shrink-0 border-r md:block">
             {nav}
           </div>
         ) : null}
 
-        <header className="border-border bg-background col-start-2 row-start-1 flex items-center gap-4 border-b px-4 py-2 md:px-6">
-          {/* The build line travels with the brand, so it is here for exactly the person whose
-              bar is not carrying it — and the header does not scroll, which is the point. */}
-          {nav ? null : (
-            <Brand>
-              <BuildInfo />
-            </Brand>
-          )}
+        {/* Tighter on a phone, where this one row carries the brand, the scope and signing out:
+            at 375px the gaps alone were the difference between fitting and scrolling sideways. */}
+        <header className="border-border bg-background col-start-2 row-start-1 flex items-center gap-2 border-b px-4 py-2 sm:gap-4 md:px-6">
+          {nav ? null : <Brand />}
           {/* The scope leads the header, because it says what every page below it is about. Its
               slot grows whether or not it has anything in it: a school with no event series yet
               would otherwise leave the row empty, and the indicator would report from the near
@@ -71,6 +67,14 @@ export function AppShell({
           {nav ? <div className="border-border bg-sidebar border-b md:hidden">{nav}</div> : null}
           {children}
         </main>
+
+        {/* Only for the person whose bar is not carrying it. A strip of its own rather than a
+            place in the header: the header is one row, and on a phone the build line was what
+            pushed signing out off the right of the screen. It is a grid track, so it stays put
+            while the form above it scrolls — which is what the header was chosen for. */}
+        {nav ? null : (
+          <BuildInfo className="border-border bg-background col-start-2 row-start-3 border-t px-4 py-2 text-center" />
+        )}
       </div>
     </BusyProvider>
   );

--- a/src/components/layout/brand.tsx
+++ b/src/components/layout/brand.tsx
@@ -3,7 +3,6 @@
  * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
  * Licensed under the MIT License. See LICENSE in the repository root for details.
  */
-import type { ReactNode } from "react";
 import Image from "next/image";
 
 /**
@@ -12,11 +11,8 @@ import Image from "next/image";
  *
  * Laid out as a navigation row is: the logo occupies the same square the icons do and is centred
  * in it, so the name starts where every label below it starts.
- *
- * Anything passed in sits beside the name and on its baseline. Two text spans in one row is what
- * makes that exact — aligning against the logo's box instead would only ever be close.
  */
-export function Brand({ children }: { children?: ReactNode }) {
+export function Brand() {
   return (
     // A control's height, so the name lines up with the tags across the header: both sit one
     // step in from the top of the window, and a taller row here would drop it below them.
@@ -31,10 +27,7 @@ export function Brand({ children }: { children?: ReactNode }) {
           className="h-auto w-6"
         />
       </span>
-      <span className="flex items-baseline gap-2">
-        <span className="font-heading text-xl font-semibold tracking-tight">Sportsweek</span>
-        {children}
-      </span>
+      <span className="font-heading text-xl font-semibold tracking-tight">Sportsweek</span>
     </span>
   );
 }


### PR DESCRIPTION
On a phone, a student could not reach the button that signs them out.

## What was wrong

The student's header is one flex row carrying the brand, the build line, the scope slot, the sign-out button and the busy indicator, and the brand is `shrink-0`. Measured against the live stylesheet at a 375px viewport, that row wanted **485px**. The sign-out button ran from 311 to 445, so two-thirds of it and all of its label sat off the right of the screen, and the page scrolled sideways to reach a control that should never need reaching for.

The build line was 100 of the 110 overflowing pixels. It was not the whole of it: with the line removed the row still wanted **385px**, ten over.

## What changed

The build line moves out of the header and becomes a strip along the foot of the window — centred, above its own rule, with the form scrolling between it and the header.

That keeps what the header was chosen for. The strip is a grid track rather than page content, so it does not scroll: a screenshot of the window still says which build it was taken from, however far down the form the person taking it had got.

The header's gaps close from `4` to `2` below the `sm` breakpoint, which brings the row to **361px** at 375 and leaves room for a longer commit hash than the one measured.

A teacher is untouched, and deliberately so: the third grid row renders only where there is no navigation bar, and a teacher's bar goes on carrying the line at its own foot.

## Fallout

`Brand` accepted `children` for one reason — so the build line could sit on the name's baseline. Nothing passes children now, so the prop and the extra wrapping span go with it.

## Checks

2060 unit tests, lint, `tsc --noEmit`, Prettier and the licence check are green. `firestore.rules` is untouched. The layout was verified by measurement against the running dev server at 375px: after the change the header's `scrollWidth` equals its `clientWidth`, and the sign-out button ends at 351.
