### PR TITLE
Fix the 404 leaving a program's equipment list

### DIFF
--- a/src/app/app/(teacher)/[eventSeriesId]/master-data/programs/page.test.tsx
+++ b/src/app/app/(teacher)/[eventSeriesId]/master-data/programs/page.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+// Stubbed for their props alone: what this page decides is which view is opened and what it is
+// told, and the real ones reach for the Firebase client on import.
+const ProgramsView = () => null;
+const ProgramEquipmentView = () => null;
+
+vi.mock("@/components/master-data/programs-view", () => ({ ProgramsView }));
+vi.mock("@/components/master-data/program-equipment-view", () => ({ ProgramEquipmentView }));
+
+const { default: ProgramsPage } =
+  await import("@/app/app/(teacher)/[eventSeriesId]/master-data/programs/page");
+
+type Opened = { type: unknown; props: Record<string, unknown> };
+
+function open(eventSeriesId: string, searchParams: { equipment?: string }) {
+  return ProgramsPage({
+    params: Promise.resolve({ eventSeriesId }),
+    searchParams: Promise.resolve(searchParams),
+  }) as unknown as Promise<Opened>;
+}
+
+/**
+ * One page serves both lists, told apart by the equipment parameter. It is also the only place
+ * the series id is in reach, so a view it forgets to hand the id to cannot build a link back to
+ * this address — which is how the way out of the equipment list came to answer 404.
+ */
+describe("ProgramsPage", () => {
+  it("opens the programs list when no program is named", async () => {
+    const page = await open("s1", {});
+
+    expect(page.type).toBe(ProgramsView);
+    expect(page.props).toEqual({ eventSeriesId: "s1" });
+  });
+
+  it("opens the equipment list of the program the parameter names", async () => {
+    const page = await open("s1", { equipment: "Tennis" });
+
+    expect(page.type).toBe(ProgramEquipmentView);
+    expect(page.props).toEqual({ program: "Tennis", eventSeriesId: "s1" });
+  });
+
+  /** A name is the identity (US-21), so it may hold a character a path segment cannot carry. */
+  it("passes a program name a URL cannot spell in a segment through untouched", async () => {
+    const page = await open("s1", { equipment: "Ski & Board" });
+
+    expect(page.props.program).toBe("Ski & Board");
+  });
+});

--- a/src/components/master-data/program-equipment-view.tsx
+++ b/src/components/master-data/program-equipment-view.tsx
@@ -72,7 +72,7 @@ export function ProgramEquipmentView({
       )}
     >
       <Link
-        href="/app/master-data/programs"
+        href={`/app/${encodeURIComponent(eventSeriesId)}/master-data/programs`}
         className="text-muted-foreground hover:text-foreground flex w-fit items-center gap-1 text-sm transition-colors"
       >
         <ArrowLeft aria-hidden className="size-4" />

--- a/src/components/master-data/programs-view.test.tsx
+++ b/src/components/master-data/programs-view.test.tsx
@@ -24,12 +24,18 @@ const { ProgramEquipmentView: ScopedProgramEquipmentView } =
   await import("./program-equipment-view");
 
 // Which series the lists belong to comes from the page (Q8); the data hooks are mocked here.
-function ProgramsView() {
-  return <ScopedProgramsView eventSeriesId="s1" />;
+function ProgramsView({ eventSeriesId = "s1" }: { eventSeriesId?: string }) {
+  return <ScopedProgramsView eventSeriesId={eventSeriesId} />;
 }
 
-function ProgramEquipmentView({ program }: { program: string }) {
-  return <ScopedProgramEquipmentView program={program} eventSeriesId="s1" />;
+function ProgramEquipmentView({
+  program,
+  eventSeriesId = "s1",
+}: {
+  program: string;
+  eventSeriesId?: string;
+}) {
+  return <ScopedProgramEquipmentView program={program} eventSeriesId={eventSeriesId} />;
 }
 
 const ski = { name: "Ski", requiredEquipment: ["Helm", "Stöcke"] };
@@ -144,12 +150,41 @@ describe("ProgramEquipmentView", () => {
     expect(screen.getByText("Stöcke")).toBeInTheDocument();
   });
 
-  it("offers a way back to the programs list", () => {
+  it("offers a way back to the programs list of the same series", () => {
     render(<ProgramEquipmentView program="Ski" />);
 
     expect(screen.getByRole("link", { name: /alle programme/i })).toHaveAttribute(
       "href",
-      "/app/master-data/programs",
+      "/app/s1/master-data/programs",
+    );
+  });
+
+  /**
+   * Both views are the same page, told apart by the equipment parameter — so the way in and the
+   * way back are one address. Checking each against its own literal is what let the way back keep
+   * a path from before the series was a segment, which answers 404.
+   */
+  it("goes back to the address the equipment link came from", () => {
+    const { unmount } = render(<ProgramsView />);
+    const wayIn = screen
+      .getByRole("link", { name: "Benötigte Ausrüstung für Ski" })
+      .getAttribute("href");
+    unmount();
+
+    render(<ProgramEquipmentView program="Ski" />);
+
+    expect(screen.getByRole("link", { name: /alle programme/i })).toHaveAttribute(
+      "href",
+      wayIn?.split("?")[0],
+    );
+  });
+
+  it("percent-encodes a series id a URL would otherwise read as structure", () => {
+    render(<ProgramEquipmentView program="Ski" eventSeriesId="winter 2026/27" />);
+
+    expect(screen.getByRole("link", { name: /alle programme/i })).toHaveAttribute(
+      "href",
+      "/app/winter%202026%2F27/master-data/programs",
     );
   });
 


### PR DESCRIPTION
## What

The way back out of a program's required equipment — "Alle Programme" — pointed at `/app/master-data/programs`, from before a teacher's pages were scoped to the selected event series. That path no longer resolves, so the link answered 404.

Both lists are the same page, told apart by the `equipment` search parameter, so the link back is that page's own address. It now carries the series id.

## Tests

The link was already covered, and the test passed the whole time: it compared the `href` with its own literal, which says nothing about whether the route it names exists. Two tests join it:

- one that derives the expected address from the equipment link itself, so the way in and the way out cannot drift apart again;
- one that pins the series id through `encodeURIComponent`, as the way in already had for the program name.

The page gets its first test as well. It is the only place the series id is in reach, and a view it forgets to hand the id to cannot build a link back at all — checked by dropping the id and watching the test fail.

## Checks

`npx vitest run` (2065 passed), `npm run lint`, `npx tsc --noEmit`, `npx prettier --check .`, `npm run license:check`.
