### PR TITLE
Plan per-event categories, and write down Clean Code

### DIFF
--- a/.github/instructions/clean-code.instructions.md
+++ b/.github/instructions/clean-code.instructions.md
@@ -1,5 +1,5 @@
 ---
-description: "Clean Code — names that carry intent, functions that do one thing, arguments that read at the call site, command-query separation, and tidying only what the change already touches."
+description: "Clean Code — names that carry intent, functions that do one thing, arguments that read at the call site, command-query separation, not reaching through chains, failure as a value, and tidying only what the change already touches."
 applyTo: "**/*.ts, **/*.tsx, **/*.mjs"
 ---
 
@@ -16,19 +16,30 @@ when it was written. Everything below follows from that one fact.
 
 ## A name carries the intent
 
-A name answers why the thing exists and what it is for. If a comment is needed to say what a
-name means, the name was the wrong one.
+A name answers why the thing exists, what it does and how it is used. If a comment is needed to
+say what a name means, the name was the wrong one.
 
-- **Name the concept, not the mechanism.** `attendingStudents`, not `filtered`; `isNameTaken`,
-  not `queryResult`.
+- **Name the concept, not the mechanism.** `activeMembers`, not `filtered`; `isNameTaken`, not
+  `queryResult`.
+- **No disinformation.** Do not call something a `list` when it is a map, or `accounts` when it
+  holds one. A name that is nearly true is worse than one that says nothing at all.
+- **Distinctions must mean something.** `record` and `recordData`, `a1` and `a2`, `Info` and
+  `Data` are noise: a reader cannot choose between them, so eventually they will choose wrong.
+- **Pronounceable and searchable.** Code is discussed aloud and grepped daily. A name of one or
+  two characters can be neither said nor found.
 - **No abbreviation** unless it is the word the domain itself uses. `registration`, not `reg`.
-- **No type or scope in the name.** Not `studentArray`, not `strName`, not `m_count` — the type
-  is already declared and the compiler already knows it.
+- **No type or scope in the name.** Not `itemArray`, not `strName`, not `m_count` — the type is
+  already declared and the compiler already knows it.
 - **One word per concept, across the whole codebase.** Pick `fetch` or `load` or `read` and keep
-  it; three words for one idea make the codebase unsearchable.
+  it. Three words for one idea make the codebase unsearchable and imply a distinction that is
+  not there.
+- **No mental mapping.** A reader should never have to hold "in this loop, `n` is the current
+  attempt" in their head. Say `attempt`.
 - **Name length follows scope.** A two-line `map` may call its parameter `one`; something visible
   across a module earns a full name.
-- **A boolean reads as an assertion**: `isArchived`, `hasRegistrations`, `mayEdit`.
+- **Things are nouns, what they do are verbs.** `PaymentGateway`, `charge()`, `isSettled`.
+- **A boolean reads as an assertion**: `isArchived`, `hasEntries`, `mayEdit`.
+- **Nothing cute.** A joke name is funny once and obstructive thereafter.
 
 ```ts
 // no — every name asks the reader to go and look
@@ -51,8 +62,14 @@ restatement of its body, then the original was doing more than one thing.
   levels; a function that does both makes the reader change altitude mid-paragraph.
 - **The file reads top-down.** A function is followed by the ones it calls, each a level lower,
   so the file can be read as prose from its first line rather than assembled from its last.
-- **Extract a condition worth a sentence.** `if (isStillOffered(series, answer))` says what
-  `if (series.programs.some(…) && !series.isArchived)` makes the reader work out.
+- **A long descriptive name beats a short enigmatic one.** Naming is where the design gets worked
+  out, and a name that is hard to write is usually saying the function does too much.
+- **Extract a condition worth a sentence.** `if (isStillAvailable(catalogue, choice))` says what
+  `if (catalogue.entries.some(…) && !catalogue.isClosed)` makes the reader work out.
+- **Handling failure is a thing of its own.** A function containing a `try` should contain little
+  else, so the ordinary path is not buried inside a mechanism.
+- **Prefer a lookup to a repeated branch.** A `switch` written once to choose a strategy is fine;
+  the same `switch` appearing in four functions is a table waiting to be declared.
 
 ## Arguments read at the call site
 
@@ -65,13 +82,15 @@ The call site is what a reader sees first, and often all they see.
 - **No output parameters.** Return the value; do not fill in a caller's object.
 - **Null is not an argument.** Passing null to mean "not applicable" makes every reader check
   the body. Give the case its own function, or a type that admits it honestly.
+- **Order should read.** `writeField(name, value)` reads; `writeField(value, name)` has to be
+  looked up every time.
 
 ```ts
 // no — what is `true`?
-saveRegistration(input, true);
+saveDraft(document, true);
 
 // yes
-saveRegistration(input, { closeAfterwards: true });
+saveDraft(document, { closeAfterwards: true });
 ```
 
 ## A function commands or answers, never both
@@ -82,23 +101,91 @@ validator that also stores are the surprises that cost an afternoon.
 Where both genuinely belong in one atomic step — a transaction that decides and then writes —
 say so in the name: `claimName`, not `checkName`.
 
+## Do not reach through a chain
+
+A function should speak to what it was handed and what it owns, not to whatever it can reach
+through them. `a.getB().getC().act()` couples the caller to three types where one was needed, and
+every link is something that may be renamed, become absent, or acquire a rule of its own.
+
+```ts
+// no — the caller now knows about the profile and the address as well
+const city = user.profile().address().city;
+
+// yes — ask for what is actually wanted
+const city = user.cityName();
+```
+
+**Tell, do not ask.** Where a caller pulls values out of something only to decide something and
+hand the answer back, the decision belonged with the data.
+
+This is a rule about objects, which hide their data behind behaviour. A plain data structure — a
+parsed record, a response body — exists to be read, and reading `order.shippingAddress.postcode`
+is the point of it rather than a violation. What to avoid is the hybrid: a type with public fields
+**and** significant behaviour, which offers two ways to do everything and no reason to prefer
+either.
+
 ## Failure is a value the caller must handle
 
 - **No sentinel returns.** Do not signal failure with `null`, `-1` or an empty string that also
   means something else; give the caller a result it cannot silently ignore.
 - **Never return null for a collection.** An empty array is the empty case, and it needs no
   guard at every call site.
+- **Define the normal flow.** Where every caller would otherwise test for absence, hand back
+  something that behaves correctly and does nothing — the special case belongs behind the seam,
+  not in front of each caller.
+- **Exceptions are not control flow.** Throwing to leave a loop, or to report an outcome the
+  caller expects, hides the ordinary path inside a mechanism meant for the extraordinary one.
 - **Fail with context.** What was attempted, and on what — never a bare rethrow that loses the
   only information anyone will want.
+
+## Keep together what is read together
+
+Layout is a tool's job; _distance_ is a design decision, and no formatter has an opinion on it.
+
+- **A variable is declared just above its first use**, not at the top of a function that uses it
+  two screens below.
+- **A caller sits above its callee**, so reading downwards follows the flow of control.
+- **One thought is a block, and blocks are separated by a blank line.** A blank line in the
+  middle of a single thought misleads as much as no line between two.
+
+## Wrap what you do not own
+
+Third-party code changes on somebody else's schedule. Reach it through a narrow surface of our
+own, so a breaking change is a change in one file rather than in fifty call sites — and so there
+is somewhere for the seam to live when the dependency is swapped or stubbed.
+
+Where a third-party behaviour is not obvious, a small test pinning what it actually does is worth
+more than reading the documentation twice: it states what the version in use really does, and it
+fails when an upgrade changes it.
 
 ## Structure
 
 - **One reason to change per module.** When a file is edited for two unrelated reasons, it is two
   files.
+- **Cohesion.** A module whose parts are each used by a different caller is several modules
+  sharing a filename.
 - **Keep together what changes together**, and expose only what a caller needs; a helper nobody
   outside the file calls is not exported.
+- **Depend on the shape you need, not the shape that exists.** A function taking the two fields
+  it reads can be called from anywhere and tested with a literal; one taking the whole record
+  drags everything behind it.
+- **An abstraction with one implementation is not an abstraction.** A wrapper that only forwards
+  is a level of indirection charged to every future reader.
 - **Delete dead code.** Nothing is kept "in case", and nothing is commented out — version control
   already remembers, and it remembers accurately.
+
+## Tests are code, held to the same standard
+
+A test is read more often than the code it covers, because it is what a reader consults to learn
+what that code is _for_. Messy tests rot until nobody trusts them, and untrusted tests get
+deleted.
+
+- **Fast** enough to run without thinking about it; **independent**, so none depends on another's
+  leftovers or on the order they run in; **repeatable**, giving the same answer on any machine and
+  offline; **self-validating**, passing or failing rather than printing something to be read.
+- **One concept per test.** A test asserting four unrelated things reports one failure and hides
+  three.
+- **The name is a sentence about behaviour**, not about the function it happens to call.
 
 ## Tidy where you passed, and no further
 
@@ -108,6 +195,27 @@ flattened, a function split where the change made the seam obvious.
 That licence stops at the edge of the change. Tidying code the change never touched enlarges the
 diff and buries the thing a reviewer came to read — so it is a change of its own, made on its own
 terms.
+
+## Smells worth being able to name
+
+| Smell                    | What it looks like                                                          |
+| ------------------------ | --------------------------------------------------------------------------- |
+| Feature envy             | A function reading more of another module's data than of its own            |
+| Misplaced responsibility | Something put where it was convenient, not where a reader would look for it |
+| Artificial coupling      | Two things bound together only because they were typed in the same sitting  |
+| Selector argument        | A parameter whose sole job is to choose a branch inside                     |
+| Obscured intent          | A dense expression, an unexplained constant, a name that hides what it does |
+| Inconsistent convention  | Two spellings of one idea, or two shapes for one job                        |
+| Fragility                | A change in one place that reliably breaks something unrelated              |
+
+## The four rules, in order
+
+Where two of these pull against each other, the earlier one wins. Code is finished when it
+
+1. passes its tests,
+2. reveals its intent,
+3. contains no duplication, and
+4. has the fewest parts that can do so.
 
 ## Why
 

--- a/.github/instructions/clean-code.instructions.md
+++ b/.github/instructions/clean-code.instructions.md
@@ -1,0 +1,116 @@
+---
+description: "Clean Code — names that carry intent, functions that do one thing, arguments that read at the call site, command-query separation, and tidying only what the change already touches."
+applyTo: "**/*.ts, **/*.tsx, **/*.mjs"
+---
+
+<!--
+SPDX-License-Identifier: MIT
+Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+Licensed under the MIT License. See LICENSE in the repository root for details.
+-->
+
+# Clean Code
+
+Code is read far more often than it is written, and almost always by someone who was not there
+when it was written. Everything below follows from that one fact.
+
+## A name carries the intent
+
+A name answers why the thing exists and what it is for. If a comment is needed to say what a
+name means, the name was the wrong one.
+
+- **Name the concept, not the mechanism.** `attendingStudents`, not `filtered`; `isNameTaken`,
+  not `queryResult`.
+- **No abbreviation** unless it is the word the domain itself uses. `registration`, not `reg`.
+- **No type or scope in the name.** Not `studentArray`, not `strName`, not `m_count` — the type
+  is already declared and the compiler already knows it.
+- **One word per concept, across the whole codebase.** Pick `fetch` or `load` or `read` and keep
+  it; three words for one idea make the codebase unsearchable.
+- **Name length follows scope.** A two-line `map` may call its parameter `one`; something visible
+  across a module earns a full name.
+- **A boolean reads as an assertion**: `isArchived`, `hasRegistrations`, `mayEdit`.
+
+```ts
+// no — every name asks the reader to go and look
+function check(list: Item[], f: string): Item[] {
+  return list.filter((x) => x.n === f);
+}
+
+// yes — the signature is the explanation
+function itemsNamed(items: readonly Item[], name: string): Item[] {
+  return items.filter((item) => item.name === name);
+}
+```
+
+## A function does one thing
+
+The test is mechanical: if a section can be extracted into a function whose name is not simply a
+restatement of its body, then the original was doing more than one thing.
+
+- **One level of abstraction per function.** Deciding a policy and formatting a string are two
+  levels; a function that does both makes the reader change altitude mid-paragraph.
+- **The file reads top-down.** A function is followed by the ones it calls, each a level lower,
+  so the file can be read as prose from its first line rather than assembled from its last.
+- **Extract a condition worth a sentence.** `if (isStillOffered(series, answer))` says what
+  `if (series.programs.some(…) && !series.isArchived)` makes the reader work out.
+
+## Arguments read at the call site
+
+The call site is what a reader sees first, and often all they see.
+
+- **Fewer arguments is better.** Three is already a lot; beyond that, the arguments are usually a
+  concept that has not been given a name yet.
+- **No boolean flag parameter.** A flag announces that the function does two things — so write
+  the two, or take an options object whose field name speaks at the call site.
+- **No output parameters.** Return the value; do not fill in a caller's object.
+- **Null is not an argument.** Passing null to mean "not applicable" makes every reader check
+  the body. Give the case its own function, or a type that admits it honestly.
+
+```ts
+// no — what is `true`?
+saveRegistration(input, true);
+
+// yes
+saveRegistration(input, { closeAfterwards: true });
+```
+
+## A function commands or answers, never both
+
+Either it changes something, or it tells the caller something. A getter that also writes and a
+validator that also stores are the surprises that cost an afternoon.
+
+Where both genuinely belong in one atomic step — a transaction that decides and then writes —
+say so in the name: `claimName`, not `checkName`.
+
+## Failure is a value the caller must handle
+
+- **No sentinel returns.** Do not signal failure with `null`, `-1` or an empty string that also
+  means something else; give the caller a result it cannot silently ignore.
+- **Never return null for a collection.** An empty array is the empty case, and it needs no
+  guard at every call site.
+- **Fail with context.** What was attempted, and on what — never a bare rethrow that loses the
+  only information anyone will want.
+
+## Structure
+
+- **One reason to change per module.** When a file is edited for two unrelated reasons, it is two
+  files.
+- **Keep together what changes together**, and expose only what a caller needs; a helper nobody
+  outside the file calls is not exported.
+- **Delete dead code.** Nothing is kept "in case", and nothing is commented out — version control
+  already remembers, and it remembers accurately.
+
+## Tidy where you passed, and no further
+
+Leave the code you touched better than you found it: a name clarified, a nested condition
+flattened, a function split where the change made the seam obvious.
+
+That licence stops at the edge of the change. Tidying code the change never touched enlarges the
+diff and buries the thing a reviewer came to read — so it is a change of its own, made on its own
+terms.
+
+## Why
+
+Every rule here trades a moment of the writer's convenience for an hour of a reader's. The
+codebase is the design; if it cannot be read, it cannot be reasoned about, and it cannot be
+safely changed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,50 @@ permissions:
   contents: read
 
 jobs:
+  # Which gates a pull request has to pass depends on what it touches, and the condition has to
+  # live on the jobs rather than on the workflow: a workflow filtered out by `paths-ignore`
+  # reports nothing at all, and a required check that never reports leaves the pull request
+  # pending for ever. A job skipped by a condition still reports, so the branch rule is met.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.classify.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The comparison reaches back to the base commit, which a shallow clone does not hold.
+          fetch-depth: 0
+      - id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          # Nothing to compare against on a manual dispatch, and the cheap answer is the unsafe
+          # one, so it is never the default.
+          if [ -z "${BASE_SHA}" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed=$(git diff --name-only "${BASE_SHA}" HEAD)
+          echo "Changed files:"
+          echo "${changed}"
+
+          # `spec/` is prose the application never reads. Everything else — source,
+          # configuration, the workflows themselves — counts as code. An empty diff matches
+          # nothing here and so reads as code, which errs towards running the gates.
+          if printf '%s\n' "${changed}" | grep -qvE '^spec/'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Runs whatever a pull request touches, because the licence headers and the formatting cover
+  # `spec/` as well — a specification arrives unstamped or unformatted as easily as anything
+  # else. Only the steps that read the source are conditional.
   lint-and-unit:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -30,16 +73,22 @@ jobs:
       - run: npm ci
       - run: npm run license:check
       - run: npm run format:check
-      - run: npm run lint
+      - if: needs.changes.outputs.code == 'true'
+        run: npm run lint
       # Route types follow pageExtensions, which follows the sign-in mode: generated for
       # production they would omit /api/auth/fake, and the code that calls it fails to compile.
-      - run: npx next typegen
+      - if: needs.changes.outputs.code == 'true'
+        run: npx next typegen
         env:
           APP_HOSTING_ENV: development
-      - run: npx tsc --noEmit
-      - run: npm test
+      - if: needs.changes.outputs.code == 'true'
+        run: npx tsc --noEmit
+      - if: needs.changes.outputs.code == 'true'
+        run: npm test
 
   rules:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -57,6 +106,8 @@ jobs:
   # Asserts on the artifact rather than on the decision that produces it: every unit test
   # still passes if a page extension or an import puts the fake login back into production.
   production-build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -68,6 +119,8 @@ jobs:
       - run: npm run check:production-build
 
   e2e:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -243,6 +243,18 @@ So the event joins it: `?event=`, beside the `?equipment=` that is already there
 stops reading as a hierarchy at that level, which is a real loss on the pages where the hierarchy
 is the point — and the breadcrumb, not the address bar, is what the concept relies on to show it.
 
+The asymmetry is not about the encoding but about what is re-normalised afterwards. A path is
+structural, so routers and proxies resolve `.` and `..`, collapse `//`, and may decode `%2F` back
+to a separator before matching — the encoding was right, and something downstream undid it. A
+query string has no structure to normalise, so nothing between the browser and the handler
+re-splits it, and the only parser is the application's own.
+
+One trap remains on that side and it must not be forgotten: a query is read with
+form-urlencoded semantics, where a **literal** `+` decodes as a space — so an event named
+"Woche 1+2" would come back as "Woche 1 2". `encodeURIComponent` escapes it to `%2B`, which is
+why the name survives. Every such link is therefore built by encoding the value, never by joining
+strings.
+
 The alternatives were weighed and set aside:
 
 |       | What names the event                     | Why not                                                                                                                                                                                      |

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -126,30 +126,38 @@ Two consequences worth stating, because they are the ones that surprise:
   at its own level. Uniqueness, length and count are checked within one list, so the same
   constraints apply per event as per series, independently.
 
-### What bounds the document
+### The document's real limit, handled rather than guessed at
 
 Everything above lives in one Firestore document, and Firestore caps a document at 1 MiB. The
-caps declared today multiply badly: 100 events, each with five lists of up to 100 entries of up
-to 120 characters, programs carrying 10 equipment items apiece, is several megabytes — a
-document a teacher could make unwritable through the UI alone.
+caps the lists already declare multiply badly against that: a hundred events, each carrying five
+lists of up to a hundred entries, is megabytes on paper.
 
-So the caps come down to **10 events** and **10 entries per list**, equipment staying at 10:
+**No new cap is introduced for it.** A number chosen to make the arithmetic safe would be a
+number invented against a case nobody has met — a realistic series is a few tens of kilobytes,
+and a cap tight enough to guarantee the worst case would be tight enough to obstruct the normal
+one. If a school ever does reach the limit, that is the moment to change how the data is stored,
+and the refactoring will be informed by a real shape rather than a guessed one.
 
-|                                                                         | Worst case at the new caps             |
-| ----------------------------------------------------------------------- | -------------------------------------- |
-| One event's programs — 10 × (name + 10 equipment), 120 chars at 2 bytes | ≈ 26 KB                                |
-| Its other four lists — 4 × 10 × 120 chars                               | ≈ 10 KB                                |
-| **One event**                                                           | **≈ 36 KB**                            |
-| Ten events                                                              | ≈ 360 KB                               |
-| The series' own six lists                                               | ≈ 38 KB                                |
-| **The whole document**                                                  | **≈ 400 KB — under 40% of the budget** |
+What the limit gets instead is **an honest failure**. Firestore refuses a write that would exceed
+it, and that refusal must reach the teacher as a sentence saying what happened and what to do,
+not as a generic save error. The write path recognises that one refusal and answers with its own
+message; every other fault keeps the sanitised message it has today.
 
-A realistic series — five events, five programs of three items each, names of about thirty
-characters — is well under 30 KB. The caps are what keeps the worst case bounded; they are not
-what anyone is expected to reach.
+### Concurrent edits: the last write wins
 
-One cap serves both levels, so a per-event list can never be bounded differently from the
-per-series list it overrides.
+All the master data of one series is one document, so two teachers editing different categories
+are still editing one record. The rule is the simple one: **the last write wins.** Nothing
+versions the document, nothing refuses a write because somebody else got there first, and a
+teacher is never shown a conflict to resolve.
+
+This is a deliberate trade against a bounded audience. Master data is maintained by one or two
+people who are in touch with each other, and for them a merge dialogue would be a cost paid on
+every save to guard against something that does not happen. The consequence is real and
+accepted: if two people do edit at the same time, one of them can silently lose an entry.
+
+If that assumption stops holding — more maintainers, or edits that are not coordinated — the
+answer is not to bolt locking on, but to revisit how the lists are stored, which is the same
+refactoring the size limit would eventually force.
 
 ## The master data editor: drill-down record pages (Concept A)
 
@@ -212,6 +220,36 @@ A series-level program's equipment is the same leaf one level up, at
 whose entries have children of their own and a static segment wins over a dynamic one. Equipment
 keeps the `?equipment=` search parameter rather than a segment, because a program name is its
 identity and may hold characters a segment cannot carry.
+
+### An event needs something a URL can carry — open, see Q5
+
+`{event}` is the one segment naming a record a teacher typed. That is a problem the rest of the
+tree does not have: a program name was deliberately kept out of a segment for exactly this reason,
+and an event name is no different — it is editable, it is the identity (US-21), and nothing stops
+it holding a `/`, a `%` or a `#`.
+
+Percent-encoding it is the obvious answer and it is not a reliable one. `%2F` inside a path
+segment is normalised by proxies and frameworks at several points between the browser and the
+page, and where it is decoded early the segment splits in two and the route stops matching. It
+works until the day somebody names an event "Woche 1/2".
+
+|       | What names the event                     | What it costs                                                                                                                                                                                     |
+| ----- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **a** | The percent-encoded name, in the segment | Reads well and needs no stored change. Fails on the characters a path cannot carry, and fails in a way that looks like a routing bug rather than a bad name.                                      |
+| **b** | The name, in a search parameter          | Cannot fail, and it is the precedent equipment already sets. The address stops reading as a hierarchy at the level where the hierarchy is the point.                                              |
+| **c** | A stored id on the event                 | Safe, opaque, survives a rename — and a rename becomes free, because nothing points at the name any more. Costs a generated id per event, and forces a decision about what a registration stores. |
+| **d** | The event's array index                  | **A trap.** An index is a position, not an identity: reordering or deleting silently re-points every link, bookmark and open tab at a different event. Do not use it.                             |
+|       |                                          |                                                                                                                                                                                                   |
+
+Option **c** carries a second decision with it, which is why it is not simply the best answer. A
+registration stores `event` as a name today, so an id would mean either registrations start
+storing the id — after which renaming an event no longer has to be refused while students are
+assigned to it, because nothing needs rewriting — or they keep the name, and the event then has
+two identities, which is the thing this codebase most consistently refuses.
+
+Slugging the name is a fifth option and a worse version of **c**: a slug is safe in a path but two
+names can produce one slug, so it needs a uniqueness rule of its own, and it has to be stored to
+survive a rename — at which point it is an id that merely looks readable.
 
 ### What the four screens share
 
@@ -373,6 +411,30 @@ card is now there — filled from their event's lists, or the series' where the 
 
 Nothing about Veranstaltung is stored during the first step.
 
+### Assignment is a step forward, and it does not go back
+
+Assigning is what begins step two, so it needs its own preconditions and one refusal.
+
+**A student may only be assigned once their registration is complete** — in whichever sense
+applies: everything answered in a one-step series, everything outside Veranstaltung in a two-step
+one. Assigning somebody who has not finished answering produces a registration that is incomplete
+for two unrelated reasons at once, and a teacher cannot tell from the board which one they are
+looking at. Today the board's rule is only that the student is attending; this narrows it.
+
+**A student whose Veranstaltung answers are complete may not be un-assigned, and may not be moved
+to another event.** Their answers were drawn from that event's lists, and taking the event away
+would leave answers that came from nowhere, while moving them to another event would leave
+answers that came from the wrong place. Both are refused rather than silently cleared — clearing
+is a decision about somebody else's data, made by the person least likely to notice it happened.
+Un-assigning a student who has not yet answered Veranstaltung is free, because there is nothing
+to lose.
+
+What that means for the teacher is a running order rather than a rule to remember: close the
+series to students, then assign. A series still open is one where a student can be answering
+Veranstaltung at the moment the teacher moves them. The teachers who do this are the skilled
+users of the application and the order is theirs to keep — whether the application should enforce
+it rather than rely on it is Q6.
+
 ## User stories
 
 ### US-33: Teacher maintains master data as a hierarchy
@@ -418,6 +480,10 @@ Nothing about Veranstaltung is stored during the first step.
 - Step one is everything but Veranstaltung, and a registration that has it all reads complete.
 - Assignment to an event begins step two: Veranstaltung appears and the registration reads
   incomplete until it is answered.
+- A student may only be assigned once their registration is complete in the sense that applies to
+  their series.
+- A student whose Veranstaltung answers are complete may be neither un-assigned nor moved to
+  another event; the attempt is refused, and nothing is cleared on their behalf.
 - A student may amend either step at any time while the series is open to them.
 
 ## Sequencing
@@ -439,24 +505,20 @@ Environments are purged and reseeded after slices 2, 3 and 4.
 
 ## Open questions
 
-### Q3 — Is ten entries enough for every list, or only for the ones that multiply?
+### Q5 — What names an event in a URL?
 
-The caps are settled at ten events and ten entries per list, and the arithmetic is in "What
-bounds the document" above. What is left is which lists the ten applies to.
+See "An event needs something a URL can carry" above. The four candidates and what each costs are
+stated there; what is open is which of them the events get.
 
-The number only multiplies where a list hangs off an event. A series-level list appears once, so
-it could stay at a hundred and the document would still fit — the worst case rises to about
-740 KB, roughly 70% of the budget, rather than 400 KB.
+### Q6 — Should assignment be refused while the series is open to students?
 
-The one that matters is **Klassen**: it exists only at series level and it is the list most
-likely to want more than ten entries, since it names every class taking part. Ten programs, ten
-skill levels, ten access cards, ten pickup points and ten catering options are all generous.
+The order that keeps a teacher out of trouble is: close the series, then assign. The question is
+whether the application enforces it or merely relies on it.
 
-So: does ten bound every list, or does it bound only the five that hang off an event, leaving
-Klassen — and perhaps the other series-level lists — at a hundred?
+Enforcing it makes a race impossible — a student cannot be answering Veranstaltung at the moment
+their event changes underneath them. It also makes assignment unavailable during the window a
+teacher may reasonably want it, since a series is opened by generating its invitation link and
+is not closed again as a matter of course.
 
-### Q4 — Does the answer order follow the menu?
-
-Putting Klassen before Events reorders the report's field row, the filter's category row and the
-registration form's card, because all three are pinned to the menu order by tests. Confirm that
-this is wanted, or the menu stops being the single source of that order.
+Relying on it keeps the workflow open and leaves the two refusals above as the only guard, which
+is what the skilled users this page is built for would expect.

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -126,6 +126,31 @@ Two consequences worth stating, because they are the ones that surprise:
   at its own level. Uniqueness, length and count are checked within one list, so the same
   constraints apply per event as per series, independently.
 
+### What bounds the document
+
+Everything above lives in one Firestore document, and Firestore caps a document at 1 MiB. The
+caps declared today multiply badly: 100 events, each with five lists of up to 100 entries of up
+to 120 characters, programs carrying 10 equipment items apiece, is several megabytes — a
+document a teacher could make unwritable through the UI alone.
+
+So the caps come down to **10 events** and **10 entries per list**, equipment staying at 10:
+
+|                                                                         | Worst case at the new caps             |
+| ----------------------------------------------------------------------- | -------------------------------------- |
+| One event's programs — 10 × (name + 10 equipment), 120 chars at 2 bytes | ≈ 26 KB                                |
+| Its other four lists — 4 × 10 × 120 chars                               | ≈ 10 KB                                |
+| **One event**                                                           | **≈ 36 KB**                            |
+| Ten events                                                              | ≈ 360 KB                               |
+| The series' own six lists                                               | ≈ 38 KB                                |
+| **The whole document**                                                  | **≈ 400 KB — under 40% of the budget** |
+
+A realistic series — five events, five programs of three items each, names of about thirty
+characters — is well under 30 KB. The caps are what keeps the worst case bounded; they are not
+what anyone is expected to reach.
+
+One cap serves both levels, so a per-event list can never be bounded differently from the
+per-series list it overrides.
+
 ## The master data editor: drill-down record pages (Concept A)
 
 The most common editor for a master-detail relationship, and the one this adopts: a master list
@@ -320,17 +345,21 @@ data rows.
 | **c** | Starting an override copies the series' entries in as real, editable rows.                                                                                                     | Familiar, but it severs inheritance at the first press: a later change to the series list never reaches the event, and "not overridden" becomes indistinguishable from "overridden identically". |
 | **d** | An explicit switch per category — "own entries for this event" — off by default, with option a's greyed list beneath it while off.                                             | Makes the state a control rather than an inference. One more control per page.                                                                                                                   |
 
-### Q3 — What bounds the document?
+### Q3 — Is ten entries enough for every list, or only for the ones that multiply?
 
-All of this lives in one event series document, and Firestore caps a document at 1 MiB. At the
-caps the schema allows today — 100 events, each with five lists of up to 100 entries of up to 120
-characters, programs carrying up to 10 equipment items — the worst case is several megabytes, so
-the document can be made unwritable through the UI alone. A realistic series is a few tens of
-kilobytes.
+The caps are settled at ten events and ten entries per list, and the arithmetic is in "What
+bounds the document" above. What is left is which lists the ten applies to.
 
-Candidates: cap the number of events far lower than the number of list entries; cap a per-event
-list lower than a per-series one; or validate the encoded size of the whole document on write and
-refuse with a message that says what to remove. This must be settled before slice 3.
+The number only multiplies where a list hangs off an event. A series-level list appears once, so
+it could stay at a hundred and the document would still fit — the worst case rises to about
+740 KB, roughly 70% of the budget, rather than 400 KB.
+
+The one that matters is **Klassen**: it exists only at series level and it is the list most
+likely to want more than ten entries, since it names every class taking part. Ten programs, ten
+skill levels, ten access cards, ten pickup points and ten catering options are all generous.
+
+So: does ten bound every list, or does it bound only the five that hang off an event, leaving
+Klassen — and perhaps the other series-level lists — at a hundred?
 
 ### Q4 — Does the answer order follow the menu?
 

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -54,7 +54,7 @@ no correct answer at the time it is put.
 | Seven sibling category pages                                         | A master list, a record page per series, a record page per event                 |
 | Nav: Eventreihen · Events · Klassen · …                              | Nav: five fixed entries; the categories move onto the record page as a tag row   |
 | Gender is male or female                                             | Gender is male, female or diverse                                                |
-| Form: Registrierung · Persönliches · Notfallkontakt · … · Gesundheit | Form: Registrierung · Persönliches · Gesundheit · Notfallkontakt · Veranstaltung |
+| Form: Registrierung · Persönliches · Notfallkontakt · … · Gesundheit | Form: Registrierung · Persönliches · Notfallkontakt · Gesundheit · Veranstaltung |
 | One registration step, complete only when everything is answered     | Two steps where any event carries lists of its own                               |
 
 ## The shape it moves to
@@ -424,11 +424,13 @@ reads the way the form asks:
 
 1. **Registrierung** — name, class, attendance
 2. **Persönliches** — gender, then date of birth, then phone number
-3. **Gesundheit**
-4. **Notfallkontakt**
+3. **Notfallkontakt**
+4. **Gesundheit**
 5. **Veranstaltung** — the answers drawn from the five overridable lists
 
-Gender moves above date of birth, and Gesundheit moves above Notfallkontakt.
+Gender moves above date of birth, and Gesundheit moves ahead of Veranstaltung rather than
+trailing it. Everything a student can answer about themselves is then asked before anything that
+depends on where they are going — which is also the seam the two-step registration cuts along.
 
 ### Gender gains a third value
 
@@ -478,23 +480,22 @@ seasonPassOption · busPickupPoint · foodOption · health · completeness
 The schema declares its fields in the form's order, so the stored record reads the way the
 student was asked. Cards, and the fields within them, exactly as the form section above states.
 
-### What is not settled: where "Gesundheit" sits in the report
+### The report's field row does not follow the form
 
-The field row above quietly assumes the report does **not** follow the form's card reshuffle, and
-that assumption should be made deliberately rather than inherited.
+Only one thing moves in the field row: class ahead of event, following the menu. The form's card
+reshuffle deliberately does **not** propagate, so `health` stays where it is, after the
+Veranstaltung answers, even though Gesundheit now precedes them in the form.
 
-Today the field row already mirrors the form's cards: `contact` sits where Notfallkontakt sat, and
-`health` after the Veranstaltung answers, where Gesundheit sat. Moving Gesundheit above
-Notfallkontakt in the form therefore argues for `health` moving above `contact` in the report —
-and, through the field row, up the filter row as well.
+The two orders answer different questions. A form is asked in the order that suits a student
+filling it in; a report is read in the order that suits a teacher scanning a class, and the
+registration's own facts sit better at its end. Tying them together would also force a decision
+nobody wants: `contact` bundles the student's own `phoneNumber`, which the form asks in
+Persönliches, with the three emergency contact fields it asks in Notfallkontakt — so a strict
+mirror is unavailable without splitting that tag, which changes what a teacher can switch on and
+off in a report.
 
-What stops that being automatic is that **`contact` spans two cards**: it bundles the student's own
-`phoneNumber`, which the form asks in Persönliches, with the three emergency contact fields, which
-it asks in Notfallkontakt. A strict mirror is therefore not available without splitting that tag
-in two, which is a change to what a teacher can switch on and off in a report.
-
-So: leave the report row as written above, or move `health` ahead of `contact` — and if the
-latter, does `contact` split so the student's own number stays with Persönliches?
+What stays tied is the part that has one source: the six list-backed fields follow the master data
+menu, and the filter row follows the field row. Those are the invariants tests pin.
 
 ### Two steps, when the events differ
 

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -249,10 +249,62 @@ single source of answer order: the report fields, the filter categories and the 
 card all follow it, each pinned by a test. Putting Klassen before Events moves class ahead of event
 in all four.
 
-### Inherited state — open, see Q2
+### An inherited list says so where its entries would be
 
-A per-event list page has to show that an empty list is not "nothing offered" but "whatever the
-series offers". Q2 states the candidates.
+An empty per-event list does not mean "nothing offered", it means "whatever the series offers",
+and the page has to say which. It says it in the plainest way available: the list area shows its
+ordinary empty state, and beneath it one sentence naming what applies instead.
+
+```
+[Programme ＋]  Leistungsstufen  Zugangskarten  Zustiegsstellen  Verpflegung
+
+Es gibt noch kein Programm.
+Dieses Event verwendet die Programme der Eventreihe.
+```
+
+The sentence carries **no link**. Where the series' entries are maintained is one breadcrumb away
+and a teacher who wants them is going there anyway; a link inside an empty state invites a detour
+from the page they meant to fill in.
+
+One template serves all five categories, built from the category's own title — "die Programme",
+"die Leistungsstufen", "die Zugangskarten", "die Zustiegsstellen", "die Verpflegung" — so a
+relabelled category cannot leave a stale sentence behind.
+
+**There is no override control, because none is needed.** Adding the first entry is what makes the
+event stop inheriting, and removing the last is what makes it start again. The add control on the
+marked tag and the row delete already do both, so the state is a consequence of the list rather
+than a switch that could disagree with it.
+
+The cost, accepted deliberately: this page does not show _which_ entries are currently in effect,
+only that the series supplies them.
+
+### Empty means inherit in exactly one place
+
+The sentence belongs to the five lists an event may override, and nowhere else. An empty list
+means something different at every other level, and saying "inherited" at any of them would be
+wrong:
+
+| An empty list            | Means                                                           |
+| ------------------------ | --------------------------------------------------------------- |
+| Eventreihen, at the root | The school has no event series yet                              |
+| One of a series' lists   | The students of that series are never asked that question       |
+| One of an event's five   | The series' list applies — the only place the sentence is shown |
+| A program's equipment    | **That program requires no equipment**                          |
+
+The last is the one to be careful of. Equipment is not a sixth overridable category: it belongs to
+the program that requires it and travels with it, so a per-event programs list carries its own
+programs' equipment already. A per-event "Ski" with nothing in its equipment list is a deliberate
+statement that this event's Ski needs nothing — not a request to fall back on the series' Ski,
+which the event stopped using the moment it named a program of its own.
+
+So the equipment leaf keeps the empty state it has today, which says exactly that and needs no
+second sentence beneath it:
+
+```
+[Benötigte Ausrüstung ＋]
+
+Dieses Programm benötigt keine Ausrüstung.
+```
 
 ## Registration
 
@@ -319,8 +371,9 @@ Nothing about Veranstaltung is stored during the first step.
 - Each list is maintained exactly as its series-level counterpart, under the same constraints:
   the same maximum count, the same maximum name length, uniqueness within the list.
 - A per-event name may equal a per-series name.
-- A list left empty is inherited from the series; a list with entries replaces the series' list
-  outright.
+- A list left empty is inherited from the series and says so where its entries would be; a list
+  with entries replaces the series' list outright. Adding the first entry is what overrides, and
+  removing the last is what returns to inheriting — there is no separate control.
 - An event whose program is renamed or removed is refused while a student of that event has
   chosen it, on the same terms as the series-level rule.
 
@@ -359,15 +412,6 @@ emulator. Test-driven throughout: the failing test that states the new behaviour
 Environments are purged and reseeded after slices 2, 3 and 4.
 
 ## Open questions
-
-### Q2 — How is an inherited list shown on a per-event page?
-
-|       | Option                                                                                                                                                                         | Consequence                                                                                                                                                                                      |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **a** | The series' entries are listed **greyed** — muted text, no drag handle, no rename or delete — under a strip naming where they come from, with one button to start an own list. | The teacher sees what students of this event will actually be offered without leaving the page. A greyed row that ignores a drag needs the strip to explain why.                                 |
-| **b** | The normal empty state, plus a sentence naming the series the list falls back to and a link to it.                                                                             | Simplest, and nothing looks editable that is not. What is currently in effect can only be seen by navigating away.                                                                               |
-| **c** | Starting an override copies the series' entries in as real, editable rows.                                                                                                     | Familiar, but it severs inheritance at the first press: a later change to the series list never reaches the event, and "not overridden" becomes indistinguishable from "overridden identically". |
-| **d** | An explicit switch per category — "own entries for this event" — off by default, with option a's greyed list beneath it while off.                                             | Makes the state a control rather than an inference. One more control per page.                                                                                                                   |
 
 ### Q3 — Is ten entries enough for every list, or only for the ones that multiply?
 

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -1,0 +1,339 @@
+<!--
+SPDX-License-Identifier: MIT
+Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+Licensed under the MIT License. See LICENSE in the repository root for details.
+-->
+
+# Refactoring: Per-Event Categories and a Two-Step Registration
+
+This document specifies one change with three faces: master data becomes a hierarchy an editor
+can show, an event gains lists of its own that override the series', and — where events differ
+in what they offer — a student registers in two steps instead of one.
+
+It is a companion to `spec/requirements.md` and to `spec/refactoring-event-series.md`. The user
+stories below are numbered on from the ones already there. Once this has landed, all three are
+merged into `spec/requirements.md` and the two refactoring documents are deleted.
+
+The user story numbers are stable, not positional. US-33 onwards are appended by number and
+placed by topic when merged.
+
+No data migrates. Every environment is purged and reseeded, so a stored shape may change freely.
+
+## Why
+
+**The lists describe the wrong thing.** An event series holds one set of programs, skill levels,
+access cards, pickup points and catering options, and every event under it is made to offer that
+same set. A series that runs one week in Montafon and one in Lech cannot say so: the two weeks
+have different pickup points and different access cards, and the only way to express that today
+is to put the union in one list and rely on the students to pick correctly.
+
+**The editor hides the hierarchy it is editing.** The seven categories are seven sibling pages,
+scoped by a selection made in the header — the same selection that scopes the registrations, the
+assignment and the report. Nothing on the screen says that classes belong to a series while an
+assignment belongs to a series' students; they look like seven global lists that happen to change
+when a tag in the header is pressed.
+
+**The header selection means two different things.** For registrations, assignments and reports it
+is "which series am I looking at" — a filter over data. In Stammdaten it is "which series am I
+editing" — a record being maintained. One control doing both is why editing master data feels
+like changing a view setting.
+
+**Registration asks a question that cannot yet be answered.** A student is asked which program
+they want before anyone knows which event they are in. Where the events differ, that question has
+no correct answer at the time it is put.
+
+## What changes, in one page
+
+| Today                                                                | After                                                                            |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| An event is a name in a list of strings                              | An event is a record: a name plus five lists of its own                          |
+| Master data belongs to the series only                               | Five categories belong to a series **and** to each of its events                 |
+| A student is offered the series' lists                               | A student is offered their event's lists, falling back to the series'            |
+| `/app/{seriesId}/master-data/{category}`                             | `/app/event-series/{seriesId}/{category}` — no `master-data` segment left        |
+| The header selection scopes Stammdaten too                           | The header rows are hidden in Stammdaten; the record being edited is the URL     |
+| Seven sibling category pages                                         | A master list, a record page per series, a record page per event                 |
+| Nav: Eventreihen · Events · Klassen · …                              | Nav: Eventreihen · Klassen · Events · … , the categories indented under it       |
+| Gender is male or female                                             | Gender is male, female or diverse                                                |
+| Form: Registrierung · Persönliches · Notfallkontakt · … · Gesundheit | Form: Registrierung · Persönliches · Gesundheit · Notfallkontakt · Veranstaltung |
+| One registration step, complete only when everything is answered     | Two steps where any event carries its own programs                               |
+
+## The shape it moves to
+
+All master data stays on the one event series document, as it does today. A per-event list is an
+array property of the event object, exactly as a per-series list is an array property of the
+series.
+
+```jsonc
+// eventSeries/{eventSeriesId}
+{
+  "name": "Wintersportwoche 2026/2027",
+  // …archive, template, open-to-students and ordering fields as they are today…
+
+  // Asked of every student of this series, whatever event they end up in.
+  "classOptions": ["2aWI", "2bWI"],
+
+  // The five overridable categories, at series level. These apply to any event that names none
+  // of its own.
+  "programs": [{ "name": "Ski", "requiredEquipment": ["Helm", "Stöcke"] }],
+  "skillLevels": ["Keine Vorkenntnisse", "Fortgeschritten"],
+  "seasonPassOptions": ["Montafon"],
+  "busPickupPoints": ["Dornbirn"],
+  "foodOptions": ["Vegetarisch"],
+
+  "events": [
+    {
+      // The name is still the identity (US-21) — unique within this list, and what a
+      // registration stores.
+      "name": "Woche 1",
+      // Empty means "take the series' list". A non-empty list replaces it outright; there is no
+      // merging, and the two lists never mix.
+      "programs": [],
+      "skillLevels": [],
+      "seasonPassOptions": [],
+      "busPickupPoints": [],
+      "foodOptions": [],
+    },
+    {
+      "name": "Woche 2",
+      // This event runs elsewhere, so it names its own programs — and with them their equipment,
+      // because equipment belongs to the program that requires it and travels with it.
+      "programs": [{ "name": "Ski", "requiredEquipment": ["Helm", "Stöcke", "Lawinenpiepser"] }],
+      "skillLevels": [],
+      "seasonPassOptions": ["Arlberg"],
+      "busPickupPoints": [],
+      "foodOptions": [],
+    },
+  ],
+}
+```
+
+### The resolution rule
+
+One function answers what a given event offers, and every caller asks it — the form, the
+completeness check, the report, the filter and the server-side validation of a saved answer:
+
+> For each of the five overridable categories: if the event names entries of its own, those are
+> what applies. Otherwise the series' entries apply. An event that names none of its own is
+> exactly the application as it behaves today.
+
+Two consequences worth stating, because they are the ones that surprise:
+
+- **Equipment is never overridden on its own.** It belongs to the program that requires it, so a
+  per-event programs list replaces the series' programs _including_ their equipment. An event
+  whose "Ski" requires nothing, under a series whose "Ski" requires three items, is expressed by
+  the event naming a "Ski" with an empty equipment list — not by an equipment override.
+- **A per-event entry may be spelled exactly like a per-series one**, and means whatever it means
+  at its own level. Uniqueness, length and count are checked within one list, so the same
+  constraints apply per event as per series, independently.
+
+## The master data editor: drill-down record pages (Concept A)
+
+The most common editor for a master-detail relationship, and the one this adopts: a master list
+page; opening a row navigates to that record's page; the record's child collections are reached
+from there; a breadcrumb names the trail back.
+
+The event series id leaves the global scope segment, which is what takes Stammdaten out of the
+header selection. `/app/event-series` is already a segment the selection ignores, so the whole
+tree moves beneath it and the `master-data` segment disappears:
+
+```
+/app/event-series                                   Eventreihen — the master list
+/app/event-series/{series}                          → redirects to classes
+/app/event-series/{series}/classes                  ┐
+/app/event-series/{series}/events                   │ the Eventreihe's own lists
+/app/event-series/{series}/programs      ?equipment=│
+/app/event-series/{series}/skill-levels             │
+/app/event-series/{series}/season-pass-options      │
+/app/event-series/{series}/bus-pickup-points        │
+/app/event-series/{series}/food-options             ┘
+/app/event-series/{series}/events/{event}           → redirects to programs
+/app/event-series/{series}/events/{event}/programs  ?equipment=   ┐ the five overridable
+/app/event-series/{series}/events/{event}/skill-levels            │ lists, at event level
+/app/event-series/{series}/events/{event}/season-pass-options     │
+/app/event-series/{series}/events/{event}/bus-pickup-points       │
+/app/event-series/{series}/events/{event}/food-options            ┘
+/app/users                                          Benutzerrechte
+```
+
+The header's event series rows are **not rendered** anywhere under `/app/event-series`. What is
+being edited is named by the page and by the breadcrumb, which is a place the reader is already
+looking, and which can name an archived series the header would not offer.
+
+Equipment keeps the `?equipment=` search parameter rather than a path segment, because a program
+name is its identity and may hold characters a segment cannot carry.
+
+### Navigation — open, see Q1
+
+The requested order and indentation is settled at the series level:
+
+```
+Registrierungen                 ┐
+Zuteilungen                     │ scoped by the header selection
+Berichte                        ┘
+Stammdaten
+  Eventreihen                   ← the master list
+    Klassen
+    Events
+    Programme
+    Leistungsstufen
+    Zugangskarten
+    Zustiegsstellen
+    Verpflegung
+  Benutzerrechte
+```
+
+Where the **per-event** lists belong is the open question. The nav cannot list them per event —
+there are as many sets as there are events, and data does not go in a navigation. Q1 states the
+candidates.
+
+**Reordering the menu is not local.** The master data menu is the single source of answer order:
+the report fields, the filter categories and the registration form's card all follow it, each
+pinned by a test. Putting Klassen before Events moves class ahead of event in all four.
+
+### Inherited state — open, see Q2
+
+A per-event list page has to show that an empty list is not "nothing offered" but "whatever the
+series offers". Q2 states the candidates.
+
+## Registration
+
+### The form, reordered
+
+Cards in this order, which is also the order the schema declares the fields in, so the record
+reads the way the form asks:
+
+1. **Registrierung** — name, class, attendance
+2. **Persönliches** — gender, then date of birth, then phone number
+3. **Gesundheit**
+4. **Notfallkontakt**
+5. **Veranstaltung** — the answers drawn from the five overridable lists
+
+Gender moves above date of birth, and Gesundheit moves above Notfallkontakt.
+
+### Gender gains a third value
+
+`"male" | "female"` becomes `"male" | "female" | "diverse"`, labelled `"Divers"`. It is a value
+like the other two, not a fallback: the report prints it, the filter offers it as a tag, and the
+figures table counts it in a column of its own beside `"Männlich"` and `"Weiblich"`.
+
+### Two steps, when the events differ
+
+The steering condition is per series and derived, never stored:
+
+> If **any** event of the series names programs of its own, this series registers in two steps.
+> Otherwise it registers in one, exactly as today.
+
+|                                | One step (today)   | Two steps                                                                  |
+| ------------------------------ | ------------------ | -------------------------------------------------------------------------- |
+| What the invitation link opens | The whole form     | The form without **Veranstaltung**                                         |
+| What is asked                  | Everything         | Everything but the event's own questions                                   |
+| Complete when                  | Nothing is missing | Nothing outside Veranstaltung is missing                                   |
+| Then                           | —                  | A teacher assigns the student to an event                                  |
+| After the assignment           | —                  | Veranstaltung appears; the registration is incomplete until it is answered |
+
+So a student pre-registers, says whether they are coming and answers everything that does not
+depend on which event they land in. Their registration reads complete. A teacher assigns them.
+The registration becomes incomplete again, the student opens the same link, and the Veranstaltung
+card is now there — filled from their event's lists, or the series' where the event names none.
+
+Nothing about Veranstaltung is stored during the first step.
+
+## User stories
+
+### US-33: Teacher maintains master data as a hierarchy
+
+- Stammdaten opens on the list of Eventreihen. Opening one shows what that series is made of.
+- The lists of one series are reached from that series' record, never from a header selection;
+  the header's series rows are not shown anywhere in Stammdaten.
+- A breadcrumb names the trail and every step of it is a link.
+- Menu order is Eventreihen, then Klassen, Events, Programme, Leistungsstufen, Zugangskarten,
+  Zustiegsstellen, Verpflegung; the categories are indented under Eventreihen, and Benutzerrechte
+  sits beside Eventreihen rather than under it.
+
+### US-34: An event carries master data of its own
+
+- An event is a record with a name and five lists: programs (with their equipment), skill levels,
+  access cards, pickup points and catering options.
+- Each list is maintained exactly as its series-level counterpart, under the same constraints:
+  the same maximum count, the same maximum name length, uniqueness within the list.
+- A per-event name may equal a per-series name.
+- A list left empty is inherited from the series; a list with entries replaces the series' list
+  outright.
+- An event whose program is renamed or removed is refused while a student of that event has
+  chosen it, on the same terms as the series-level rule.
+
+### US-35: A student is offered their event's lists
+
+- The questions a student is asked, the answers offered for each, and what counts as a complete
+  registration are resolved from the student's event, falling back to the series.
+- A student with no event yet is offered the series' lists in a one-step series, and is not asked
+  the Veranstaltung questions at all in a two-step one.
+- Changing a student's event re-resolves the questions; an answer the new event does not offer is
+  reported as missing rather than silently kept.
+
+### US-36: Registering in two steps
+
+- A series in which any event names its own programs registers in two steps.
+- Step one is everything but Veranstaltung, and a registration that has it all reads complete.
+- Assignment to an event begins step two: Veranstaltung appears and the registration reads
+  incomplete until it is answered.
+- A student may amend either step at any time while the series is open to them.
+
+## Sequencing
+
+Each slice is a pull request of its own, and each is green on the whole gate before the next
+starts — tests, lint, types, formatting, licence headers, and the rules tests against the
+emulator. Test-driven throughout: the failing test that states the new behaviour comes first.
+
+| Slice | What lands                                                                                                                                                                                             |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **1** | The editor concept: the route tree moves under `/app/event-series/{id}`, the nav is reordered and indented, the breadcrumb arrives, the header rows are hidden in Stammdaten. No stored shape changes. |
+| **2** | An event becomes a record — `events` goes from `string[]` to objects with a name. Registrations still store the event's name.                                                                          |
+| **3** | The five per-event lists, the resolution rule, and the per-event editor pages.                                                                                                                         |
+| **4** | The registration form order, the schema field order, and `"diverse"`.                                                                                                                                  |
+| **5** | The two-step registration and its steering condition.                                                                                                                                                  |
+| **6** | Merge this document and `spec/refactoring-event-series.md` into `spec/requirements.md`, and delete both.                                                                                               |
+
+Environments are purged and reseeded after slices 2, 3 and 4.
+
+## Open questions
+
+### Q1 — Where do the per-event lists live in the navigation?
+
+The nav is three levels deep already (Stammdaten › Eventreihen › Klassen), it collapses to an
+icon rail on a wide screen and to a strip across the top on a narrow one, and it may not contain
+data rows.
+
+|       | Option                                                                                                                                                   | Consequence                                                                                                                      |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **a** | Nav stops at the Eventreihe. Per-event lists are reached by opening an event; the breadcrumb carries the trail.                                          | Three levels, unchanged shape. While editing an event's programs the nav marks only "Events".                                    |
+| **b** | Nav grows a fourth, contextual level under Events while an event is open, headed by the event name.                                                      | The whole trail is visible, but the nav's contents change as you navigate, and a fourth level cannot survive the collapsed rail. |
+| **c** | Drop "Stammdaten" as a level: Eventreihen and Benutzerrechte become top-level items with icons of their own. Option b then costs three levels, not four. | Buys back the level option b needs; costs the grouping that tells the two apart from the header-scoped pages.                    |
+| **d** | Nav lists only Eventreihen and Benutzerrechte; every category becomes a tab on its record page.                                                          | Purest Concept A and it scales to any depth, but it drops the indented category list that was asked for.                         |
+
+### Q2 — How is an inherited list shown on a per-event page?
+
+|       | Option                                                                                                                                                                         | Consequence                                                                                                                                                                                      |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **a** | The series' entries are listed **greyed** — muted text, no drag handle, no rename or delete — under a strip naming where they come from, with one button to start an own list. | The teacher sees what students of this event will actually be offered without leaving the page. A greyed row that ignores a drag needs the strip to explain why.                                 |
+| **b** | The normal empty state, plus a sentence naming the series the list falls back to and a link to it.                                                                             | Simplest, and nothing looks editable that is not. What is currently in effect can only be seen by navigating away.                                                                               |
+| **c** | Starting an override copies the series' entries in as real, editable rows.                                                                                                     | Familiar, but it severs inheritance at the first press: a later change to the series list never reaches the event, and "not overridden" becomes indistinguishable from "overridden identically". |
+| **d** | An explicit switch per category — "own entries for this event" — off by default, with option a's greyed list beneath it while off.                                             | Makes the state a control rather than an inference. One more control per page.                                                                                                                   |
+
+### Q3 — What bounds the document?
+
+All of this lives in one event series document, and Firestore caps a document at 1 MiB. At the
+caps the schema allows today — 100 events, each with five lists of up to 100 entries of up to 120
+characters, programs carrying up to 10 equipment items — the worst case is several megabytes, so
+the document can be made unwritable through the UI alone. A realistic series is a few tens of
+kilobytes.
+
+Candidates: cap the number of events far lower than the number of list entries; cap a per-event
+list lower than a per-series one; or validate the encoded size of the whole document on write and
+refuse with a message that says what to remove. This must be settled before slice 3.
+
+### Q4 — Does the answer order follow the menu?
+
+Putting Klassen before Events reorders the report's field row, the filter's category row and the
+registration form's card, because all three are pinned to the menu order by tests. Confirm that
+this is wanted, or the menu stops being the single source of that order.

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -55,7 +55,7 @@ no correct answer at the time it is put.
 | Nav: Eventreihen · Events · Klassen · …                              | Nav: five fixed entries; the categories move onto the record page as a tag row   |
 | Gender is male or female                                             | Gender is male, female or diverse                                                |
 | Form: Registrierung · Persönliches · Notfallkontakt · … · Gesundheit | Form: Registrierung · Persönliches · Gesundheit · Notfallkontakt · Veranstaltung |
-| One registration step, complete only when everything is answered     | Two steps where any event carries its own programs                               |
+| One registration step, complete only when everything is answered     | Two steps where any event carries lists of its own                               |
 
 ## The shape it moves to
 
@@ -414,8 +414,15 @@ figures table counts it in a column of its own beside `"Männlich"` and `"Weibli
 
 The steering condition is per series and derived, never stored:
 
-> If **any** event of the series names programs of its own, this series registers in two steps.
-> Otherwise it registers in one, exactly as today.
+> If **any** event of the series names **any** list of its own, this series registers in two
+> steps. Otherwise it registers in one, exactly as today.
+
+It is deliberately not "names programs of its own", though programs are what the case that
+prompted this looks like. Any of the five carries the same problem: an event with its own access
+cards, under a series that registers in one step, would ask a student for an access card before
+anybody knows which event they are in — and then, on assignment, their answer turns out not to be
+one their event offers. That is precisely what two steps exist to prevent, so the trigger is the
+condition itself rather than one instance of it.
 
 |                                | One step (today)   | Two steps                                                                  |
 | ------------------------------ | ------------------ | -------------------------------------------------------------------------- |
@@ -462,6 +469,23 @@ The last rule is narrow on purpose. It does not apply in a one-step series, wher
 from the series and survives any move; and it does not fire before a program is chosen, when there
 is nothing yet to invalidate.
 
+### An event that students have answered against cannot be removed
+
+The refusals compose into a dead end, and it is the intended one. Removing an event is already
+refused while a registration names it, and un-assigning is now refused once the student has
+answered against it — so in a two-step series an event with answered students cannot be taken
+away at all.
+
+That is the right answer rather than a gap to be patched. Removing an event mid-series is not a
+correction, it is a change of plan: the students assigned to it answered questions that only that
+event asked, and there is no state to put them back into that is not simply a different plan. The
+means for a change of that size is to archive the series and create the next one from a copy of
+it — which keeps what the students already said where it belongs, in a series that still describes
+what happened.
+
+Deleting the whole series remains possible, and takes its registrations with it. That is the only
+way out, and it says what it is doing.
+
 ## User stories
 
 ### US-33: Teacher maintains master data as a hierarchy
@@ -503,7 +527,7 @@ is nothing yet to invalidate.
 
 ### US-36: Registering in two steps
 
-- A series in which any event names its own programs registers in two steps.
+- A series in which any event names any list of its own registers in two steps.
 - Step one is everything but Veranstaltung, and a registration that has it all reads complete.
 - Assignment to an event begins step two: Veranstaltung appears and the registration reads
   incomplete until it is answered.
@@ -530,3 +554,20 @@ emulator. Test-driven throughout: the failing test that states the new behaviour
 | **6** | Merge this document and `spec/refactoring-event-series.md` into `spec/requirements.md`, and delete both.                                                                                                                                      |
 
 Environments are purged and reseeded after slices 2, 3 and 4.
+
+## Open questions
+
+### Q7 — Does the reassignment refusal follow the steering condition?
+
+The trigger for two steps is now any per-event list, not programs alone. The refusal that protects
+an answer did not move with it: it still names the program.
+
+The reason given for it generalises word for word. A student's access card, drawn from their
+event's own list, is invalidated by a move exactly as their program is — so on the same argument
+the rule reads "a student who has answered anything drawn from their event's own list cannot be
+reassigned", and the program is one case of it.
+
+Against that: the narrower rule is easier to explain to a teacher, and the program is the answer
+most likely to exist. It would leave a student whose only per-event answer was a pickup point
+movable, and their pickup point silently unoffered afterwards — which the completeness check would
+report, though only after the fact.

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -107,6 +107,32 @@ series.
 }
 ```
 
+### An event is a place as well as a week
+
+Which five categories an event may override is not an arbitrary selection, and the reason is worth
+stating because it decides what belongs in the list and what does not. In this application an
+event names **where** the school goes as much as **when** it goes there — "Woche 2" is a week in
+Lech, not merely the second week.
+
+Everything that follows from the place is therefore the event's to say:
+
+| Category                      | Why it moves with the event                                                      |
+| ----------------------------- | -------------------------------------------------------------------------------- |
+| "Zugangskarten"               | A lift pass is sold by the resort; another resort sells another pass             |
+| "Zustiegsstellen"             | The coach picks up on the way to _this_ destination                              |
+| "Programme"                   | A place offers what its terrain and its school offer                             |
+| "Leistungsstufen"             | Follows the programs — different programs are graded differently                 |
+| "Verpflegung"                 | Weakest of the five: catering is often identical everywhere, but need not be     |
+| "Klassen" — **not** per event | A class is the school's own structure and has nothing to do with the destination |
+
+Two of those are worth their own note. "Leistungsstufen" is per event because it follows the
+programs rather than the place directly, so an event that names its own programs will usually want
+its own levels too. "Verpflegung" earns its place by consistency rather than by need — a school
+that caters the same everywhere simply never overrides it, which costs nothing.
+
+And "Klassen" is the one that stays with the series precisely because it describes the school
+rather than the trip. That is why it is not among the five, and why an event never has one.
+
 ### The resolution rule
 
 One function answers what a given event offers, and every caller asks it — the form, the
@@ -566,6 +592,12 @@ The reason given for it generalises word for word. A student's access card, draw
 event's own list, is invalidated by a move exactly as their program is — so on the same argument
 the rule reads "a student who has answered anything drawn from their event's own list cannot be
 reassigned", and the program is one case of it.
+
+Reading an event as a place rather than a week makes that stronger rather than weaker. Moving a
+student from Montafon to Lech invalidates their lift pass and their pickup point as surely as
+their program — arguably more plainly, since a pass bought for one resort is worthless at the
+other, while a program named "Ski" may well exist at both. A refusal that names only the program
+would let exactly the moves through that the place makes wrong.
 
 Against that: the narrower rule is easier to explain to a teacher, and the program is the answer
 most likely to exist. It would leave a student whose only per-event answer was a pickup point

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -432,6 +432,9 @@ Gender moves above date of birth, and Gesundheit moves out from behind Veranstal
 student can answer about themselves is then asked before anything that depends on where they are
 going — which is also the seam the two-step registration cuts along.
 
+Within Veranstaltung the measurements a rental asks for are weight, then height, then shoe size,
+which is the reverse of the order the form uses today.
+
 ### Gender gains a third value
 
 `"male" | "female"` becomes `"male" | "female" | "diverse"`, labelled `"Divers"`. It is a value
@@ -469,16 +472,17 @@ completeness
 ```
 
 The order runs inside a tag as well as between them, because a tag that gathers several fields is
-still read as one run of lines. Each is in the order the form asks for it:
+still read as one run of lines:
 
-| Tag            | Its fields, in order                                                                   |
-| -------------- | -------------------------------------------------------------------------------------- |
-| `contact`      | the student's own number, then the emergency contact's name, relationship and number   |
-| `health`       | the illness note, then whether medication is carried                                   |
-| `measurements` | **shoe size, then height, then weight** — the form's order, and the reverse of today's |
+| Tag            | Its fields, in order                                                                 |
+| -------------- | ------------------------------------------------------------------------------------ |
+| `contact`      | the student's own number, then the emergency contact's name, relationship and number |
+| `health`       | the illness note, then whether medication is carried                                 |
+| `measurements` | **weight, then height, then shoe size**                                              |
 
-`measurements` is the one that actually moves: it currently reads weight, height, shoe size while
-the form asks the other way round.
+`measurements` is the one that actually moves, and it moves in the **form** rather than the
+report: the form asks shoe size, height, weight today, and is reordered to agree with the report.
+The other two already agree.
 
 ### The filter's category row
 

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -436,6 +436,66 @@ Gender moves above date of birth, and Gesundheit moves above Notfallkontakt.
 like the other two, not a fallback: the report prints it, the filter offers it as a tag, and the
 figures table counts it in a column of its own beside `"Männlich"` and `"Weiblich"`.
 
+The three are always in that order — `male`, `female`, `diverse` — in the enum, in the labels, in
+the form's options, in the filter's tags and in the figures table, whose columns become
+`"Männlich" | "Weiblich" | "Divers" | "Gesamt" | "Teilnahme"`.
+
+## One order, everywhere
+
+Three orders change in this refactoring, and each of them is copied in several places that a test
+already pins. They are written out here in full so an implementation has one thing to compare
+against rather than several to reconcile.
+
+### The master data menu, which everything else follows
+
+```
+Klassen · Events · Programme · Leistungsstufen · Zugangskarten · Zustiegsstellen · Verpflegung
+```
+
+Klassen and Events swap; the rest is unchanged. This is the tag row's order on an event series
+record, and an event's row is the same list without Klassen and Events.
+
+### The report's field row
+
+Class moves ahead of event, following the menu. Everything else keeps its place:
+
+```
+attendance · class · event · gender · dateOfBirth · contact · program · rentedEquipment ·
+measurements · skillLevel · seasonPassOption · busPickupPoint · food · health · completeness
+```
+
+### The filter's category row
+
+Follows the field row, skipping what nothing filters on:
+
+```
+attendance · class · event · gender · program · equipmentRental · skillLevel ·
+seasonPassOption · busPickupPoint · foodOption · health · completeness
+```
+
+### The registration form and its schema
+
+The schema declares its fields in the form's order, so the stored record reads the way the
+student was asked. Cards, and the fields within them, exactly as the form section above states.
+
+### What is not settled: where "Gesundheit" sits in the report
+
+The field row above quietly assumes the report does **not** follow the form's card reshuffle, and
+that assumption should be made deliberately rather than inherited.
+
+Today the field row already mirrors the form's cards: `contact` sits where Notfallkontakt sat, and
+`health` after the Veranstaltung answers, where Gesundheit sat. Moving Gesundheit above
+Notfallkontakt in the form therefore argues for `health` moving above `contact` in the report —
+and, through the field row, up the filter row as well.
+
+What stops that being automatic is that **`contact` spans two cards**: it bundles the student's own
+`phoneNumber`, which the form asks in Persönliches, with the three emergency contact fields, which
+it asks in Notfallkontakt. A strict mirror is therefore not available without splitting that tag
+in two, which is a change to what a teacher can switch on and off in a report.
+
+So: leave the report row as written above, or move `health` ahead of `contact` — and if the
+latter, does `contact` split so the student's own number stays with Persönliches?
+
 ### Two steps, when the events differ
 
 The steering condition is per series and derived, never stored:

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -306,6 +306,30 @@ second sentence beneath it:
 Dieses Programm benötigt keine Ausrüstung.
 ```
 
+### An event may add, and never take away
+
+The two meanings of "empty" leave one thing unsayable: an event cannot refuse a question its
+series asks. An array carries two states, inheritance uses both of them, and there is no third
+for "asked nothing here".
+
+That is accepted rather than worked around. Expressing it would need absence and emptiness to say
+different things — the field missing meaning "inherit", `[]` meaning "asked nothing" — and with
+it a control to move between two states that look identical on screen. The cost lands on every
+category of every event to serve the one case that wanted it.
+
+**So the rule for a teacher is: put a list on the series only when every event asks it.** Where
+the events disagree, the series leaves that list empty and each event that wants the question
+names its own entries:
+
+| The school wants                         | Where the list goes                                |
+| ---------------------------------------- | -------------------------------------------------- |
+| Every event asks the same access cards   | On the series; no event names any                  |
+| Every event asks, but two of them differ | On the series, and those two name their own        |
+| Only some events ask at all              | Nowhere on the series; only on the events that ask |
+
+The price is that two events wanting the same list type it twice. The alternative price was a
+third state on all five lists of every event, and a switch whose two positions render the same.
+
 ## Registration
 
 ### The form, reordered
@@ -374,6 +398,8 @@ Nothing about Veranstaltung is stored during the first step.
 - A list left empty is inherited from the series and says so where its entries would be; a list
   with entries replaces the series' list outright. Adding the first entry is what overrides, and
   removing the last is what returns to inheriting — there is no separate control.
+- An event may add to what its series asks, never take away: a question the series asks is asked
+  of every event. A category only some events need is left off the series and named on those.
 - An event whose program is renamed or removed is refused while a student of that event has
   chosen it, on the same terms as the series-level rule.
 

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -54,7 +54,7 @@ no correct answer at the time it is put.
 | Seven sibling category pages                                         | A master list, a record page per series, a record page per event                 |
 | Nav: Eventreihen · Events · Klassen · …                              | Nav: five fixed entries; the categories move onto the record page as a tag row   |
 | Gender is male or female                                             | Gender is male, female or diverse                                                |
-| Form: Registrierung · Persönliches · Notfallkontakt · … · Gesundheit | Form: Registrierung · Persönliches · Gesundheit · Notfallkontakt · Veranstaltung |
+| Form: Registrierung · Persönliches · Notfallkontakt · … · Gesundheit | Form: Registrierung · Persönliches · Notfallkontakt · Gesundheit · Veranstaltung |
 | One registration step, complete only when everything is answered     | Two steps where any event carries lists of its own                               |
 
 ## The shape it moves to
@@ -424,14 +424,13 @@ reads the way the form asks:
 
 1. **Registrierung** — name, class, attendance
 2. **Persönliches** — gender, then date of birth, then phone number
-3. **Gesundheit**
-4. **Notfallkontakt**
+3. **Notfallkontakt**
+4. **Gesundheit**
 5. **Veranstaltung** — the answers drawn from the five overridable lists
 
-Gender moves above date of birth, and Gesundheit moves out from behind Veranstaltung to sit
-between the student's own details and the person to ring about them. Everything a student can
-answer about themselves is then asked before anything that depends on where they are going —
-which is also the seam the two-step registration cuts along.
+Gender moves above date of birth, and Gesundheit moves out from behind Veranstaltung. Everything a
+student can answer about themselves is then asked before anything that depends on where they are
+going — which is also the seam the two-step registration cuts along.
 
 ### Gender gains a third value
 
@@ -469,6 +468,18 @@ rentedEquipment · measurements · skillLevel · seasonPassOption · busPickupPo
 completeness
 ```
 
+The order runs inside a tag as well as between them, because a tag that gathers several fields is
+still read as one run of lines. Each is in the order the form asks for it:
+
+| Tag            | Its fields, in order                                                                   |
+| -------------- | -------------------------------------------------------------------------------------- |
+| `contact`      | the student's own number, then the emergency contact's name, relationship and number   |
+| `health`       | the illness note, then whether medication is carried                                   |
+| `measurements` | **shoe size, then height, then weight** — the form's order, and the reverse of today's |
+
+`measurements` is the one that actually moves: it currently reads weight, height, shoe size while
+the form asks the other way round.
+
 ### The filter's category row
 
 Follows the field row, skipping what nothing filters on:
@@ -483,22 +494,26 @@ seasonPassOption · busPickupPoint · foodOption · completeness
 The schema declares its fields in the form's order, so the stored record reads the way the
 student was asked. Cards, and the fields within them, exactly as the form section above states.
 
-### Why the report puts contact before Gesundheit and the form does not
+### The three rows say the same thing
 
-Both rows put everything about the student ahead of everything about the trip, and both are
-readable — but they disagree about one adjacency, deliberately.
+Put side by side, the form, the field row and the filter row now run in one order, and the tag
+that used to make that impossible no longer does.
 
-The form asks Gesundheit between Persönliches and Notfallkontakt. The report puts `contact`
-first, because its "Kontaktdaten" tag **is** part of Persönliches there: it opens with the
-student's own `phoneNumber` and only then lists who to ring. Grouped that way, contact before
-Gesundheit is the same grouping the form makes, read through a tag that happens to gather both
-numbers into one switch.
+| The form asks  | The report shows                       |
+| -------------- | -------------------------------------- |
+| Registrierung  | `attendance`, and class and event      |
+| Persönliches   | `gender`, `dateOfBirth` ┐              |
+| Notfallkontakt | ┘ `contact`                            |
+| Gesundheit     | `health`                               |
+| Veranstaltung  | the list-backed answers, in menu order |
 
-That tag is also why the two cannot simply be identical. `contact` spans two of the form's cards,
-so a strict mirror would need it split in two — which changes what a teacher can switch on and off
-in a report, to remove a difference nobody reading either one would trip over.
+`contact` is what forced the earlier compromise: it bundles the student's own `phoneNumber`,
+asked in Persönliches, with the three emergency contact fields asked in Notfallkontakt. With those
+two cards adjacent the bundle no longer straddles anything, so one tag can span them both and the
+row still reads in the form's order. Nothing has to be split, and neither row has to apologise for
+the other.
 
-What stays tied is the part that has one source: the six list-backed fields follow the master data
+What keeps them tied is the part with one source: the six list-backed fields follow the master data
 menu, and the filter row follows the field row. Those are the invariants tests pin.
 
 ### Two steps, when the events differ

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -506,8 +506,8 @@ event owns a list at all, so it never fires there.
 
 The refusals compose into a dead end, and it is the intended one. Removing an event is already
 refused while a registration names it, and un-assigning is now refused once the student has
-answered against it — so in a two-step series an event with answered students cannot be taken
-away at all.
+answered something that event owns — so an event whose students have answered against it cannot
+be taken away at all.
 
 That is the right answer rather than a gap to be patched. Removing an event mid-series is not a
 correction, it is a change of plan: the students assigned to it answered questions that only that

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -233,6 +233,12 @@ segment is normalised by proxies and frameworks at several points between the br
 page, and where it is decoded early the segment splits in two and the route stops matching. It
 works until the day somebody names an event "Woche 1/2".
 
+The existing segment is no precedent for it, which is easy to assume and wrong. The event series
+id in `/app/event-series/{series}` is a Firestore auto-id, and `documentIdSchema` refuses a `/`
+outright — so that segment has never carried an encoded slash and never can. Nothing in this
+application has yet put teacher-typed text in a path segment, and where a name genuinely could
+hold anything, the existing answer was a search parameter.
+
 |       | What names the event                     | What it costs                                                                                                                                                                                     |
 | ----- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **a** | The percent-encoded name, in the segment | Reads well and needs no stored change. Fails on the characters a path cannot carry, and fails in a way that looks like a routing bug rather than a bad name.                                      |

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -54,7 +54,7 @@ no correct answer at the time it is put.
 | Seven sibling category pages                                         | A master list, a record page per series, a record page per event                 |
 | Nav: Eventreihen · Events · Klassen · …                              | Nav: five fixed entries; the categories move onto the record page as a tag row   |
 | Gender is male or female                                             | Gender is male, female or diverse                                                |
-| Form: Registrierung · Persönliches · Notfallkontakt · … · Gesundheit | Form: Registrierung · Persönliches · Notfallkontakt · Gesundheit · Veranstaltung |
+| Form: Registrierung · Persönliches · Notfallkontakt · … · Gesundheit | Form: Registrierung · Persönliches · Gesundheit · Notfallkontakt · Veranstaltung |
 | One registration step, complete only when everything is answered     | Two steps where any event carries lists of its own                               |
 
 ## The shape it moves to
@@ -424,13 +424,14 @@ reads the way the form asks:
 
 1. **Registrierung** — name, class, attendance
 2. **Persönliches** — gender, then date of birth, then phone number
-3. **Notfallkontakt**
-4. **Gesundheit**
+3. **Gesundheit**
+4. **Notfallkontakt**
 5. **Veranstaltung** — the answers drawn from the five overridable lists
 
-Gender moves above date of birth, and Gesundheit moves ahead of Veranstaltung rather than
-trailing it. Everything a student can answer about themselves is then asked before anything that
-depends on where they are going — which is also the seam the two-step registration cuts along.
+Gender moves above date of birth, and Gesundheit moves out from behind Veranstaltung to sit
+between the student's own details and the person to ring about them. Everything a student can
+answer about themselves is then asked before anything that depends on where they are going —
+which is also the seam the two-step registration cuts along.
 
 ### Gender gains a third value
 
@@ -459,11 +460,13 @@ record, and an event's row is the same list without Klassen and Events.
 
 ### The report's field row
 
-Class moves ahead of event, following the menu. Everything else keeps its place:
+Class moves ahead of event, following the menu, and `health` comes up from the end to sit behind
+`contact`:
 
 ```
-attendance · class · event · gender · dateOfBirth · contact · program · rentedEquipment ·
-measurements · skillLevel · seasonPassOption · busPickupPoint · food · health · completeness
+attendance · class · event · gender · dateOfBirth · contact · health · program ·
+rentedEquipment · measurements · skillLevel · seasonPassOption · busPickupPoint · food ·
+completeness
 ```
 
 ### The filter's category row
@@ -471,8 +474,8 @@ measurements · skillLevel · seasonPassOption · busPickupPoint · food · heal
 Follows the field row, skipping what nothing filters on:
 
 ```
-attendance · class · event · gender · program · equipmentRental · skillLevel ·
-seasonPassOption · busPickupPoint · foodOption · health · completeness
+attendance · class · event · gender · health · program · equipmentRental · skillLevel ·
+seasonPassOption · busPickupPoint · foodOption · completeness
 ```
 
 ### The registration form and its schema
@@ -480,19 +483,20 @@ seasonPassOption · busPickupPoint · foodOption · health · completeness
 The schema declares its fields in the form's order, so the stored record reads the way the
 student was asked. Cards, and the fields within them, exactly as the form section above states.
 
-### The report's field row does not follow the form
+### Why the report puts contact before Gesundheit and the form does not
 
-Only one thing moves in the field row: class ahead of event, following the menu. The form's card
-reshuffle deliberately does **not** propagate, so `health` stays where it is, after the
-Veranstaltung answers, even though Gesundheit now precedes them in the form.
+Both rows put everything about the student ahead of everything about the trip, and both are
+readable — but they disagree about one adjacency, deliberately.
 
-The two orders answer different questions. A form is asked in the order that suits a student
-filling it in; a report is read in the order that suits a teacher scanning a class, and the
-registration's own facts sit better at its end. Tying them together would also force a decision
-nobody wants: `contact` bundles the student's own `phoneNumber`, which the form asks in
-Persönliches, with the three emergency contact fields it asks in Notfallkontakt — so a strict
-mirror is unavailable without splitting that tag, which changes what a teacher can switch on and
-off in a report.
+The form asks Gesundheit between Persönliches and Notfallkontakt. The report puts `contact`
+first, because its "Kontaktdaten" tag **is** part of Persönliches there: it opens with the
+student's own `phoneNumber` and only then lists who to ring. Grouped that way, contact before
+Gesundheit is the same grouping the form makes, read through a tag that happens to gather both
+numbers into one switch.
+
+That tag is also why the two cannot simply be identical. `contact` spans two of the form's cards,
+so a strict mirror would need it split in two — which changes what a teacher can switch on and off
+in a report, to remove a difference nobody reading either one would trip over.
 
 What stays tied is the part that has one source: the six list-backed fields follow the master data
 menu, and the filter row follows the field row. Those are the invariants tests pin.

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -73,8 +73,16 @@ series.
   "classOptions": ["2aWI", "2bWI"],
 
   // The five overridable categories, at series level. These apply to any event that names none
-  // of its own.
-  "programs": [{ "name": "Ski", "requiredEquipment": ["Helm", "Stöcke"] }],
+  // of its own. Each equipment entry says whether the school lends it — see "Required equipment".
+  "programs": [
+    {
+      "name": "Ski",
+      "requiredEquipment": [
+        { "name": "Helm", "isRentable": true },
+        { "name": "Lange, wasserdichte Hose", "isRentable": false },
+      ],
+    },
+  ],
   "skillLevels": ["Keine Vorkenntnisse", "Fortgeschritten"],
   "seasonPassOptions": ["Montafon"],
   "busPickupPoints": ["Dornbirn"],
@@ -97,7 +105,15 @@ series.
       "name": "Woche 2",
       // This event runs elsewhere, so it names its own programs — and with them their equipment,
       // because equipment belongs to the program that requires it and travels with it.
-      "programs": [{ "name": "Ski", "requiredEquipment": ["Helm", "Stöcke", "Lawinenpiepser"] }],
+      "programs": [
+        {
+          "name": "Ski",
+          "requiredEquipment": [
+            { "name": "Helm", "isRentable": true },
+            { "name": "Lawinenpiepser", "isRentable": true },
+          ],
+        },
+      ],
       "skillLevels": [],
       "seasonPassOptions": ["Arlberg"],
       "busPickupPoints": [],
@@ -504,6 +520,11 @@ qualifier, and a teacher switches on whichever they need — or both:
 "Ausrüstung" comes first in the field selector and in the printed lines, because a student packs
 their own things before collecting anything from the school.
 
+**The form does not split the same way.** It keeps one block, headed "Benötigte Ausrüstung", with
+every required item in it and only the borrowable ones tickable. A student is answering one
+question — what do I need, and what can I borrow — while a teacher is reading two, so the split
+earns its place in the report and not in the form.
+
 The two are different in kind, and the difference is deliberate rather than an oversight to be
 tidied away later. "Leihausrüstung" is the student's own answer and differs from student to
 student. "Ausrüstung" is their **program's** data, read through their choice of program — so every
@@ -757,6 +778,18 @@ way out, and it says what it is doing.
 - A student who has answered anything drawn from their event's own list may not be reassigned or
   un-assigned; the attempt is refused, and nothing is cleared on their behalf.
 - A student may amend either step at any time while the series is open to them.
+
+### US-37: Teacher says which required equipment the school lends
+
+- Every entry of a program's required equipment is either borrowable or the student's own to
+  bring, chosen in the dialog that names it as one of two tags.
+- A student is shown everything their program requires, and may tick only what is borrowable.
+- The rental question, and the measurements behind it, are asked only where the chosen program
+  has something borrowable; a program that lends nothing shows a packing list and asks nothing.
+- Making an entry non-borrowable is refused while a student of this series has borrowed it, on
+  the same terms as renaming or removing it.
+- The report offers the two halves as separate fields, "Ausrüstung" for what the student brings
+  and "Leihausrüstung" for what they borrow, either or both.
 
 ## Sequencing
 

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -415,6 +415,59 @@ names its own entries:
 The price is that two events wanting the same list type it twice. The alternative price was a
 third state on all five lists of every event, and a switch whose two positions render the same.
 
+## Required equipment says whether it can be borrowed
+
+A program's required equipment is the list of what a student needs in order to take part. Today
+that list means two things at once, because everything on it is also something the school lends —
+so a teacher who wants to tell students to bring long waterproof trousers has no way to say it
+without offering to supply them.
+
+Each entry therefore carries a flag of its own:
+
+```jsonc
+"requiredEquipment": [
+  { "name": "Helm", "isRentable": true },
+  { "name": "Lange, wasserdichte Hose", "isRentable": false },
+]
+```
+
+This is what an alternative program most needs. Its requirements are usually things a household
+already has, and listing them is the point — a student has to know to pack them — while lending
+them is not something the school does.
+
+### Where it shows up
+
+| Where                      | What changes                                                                                                                                                 |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| The equipment leaf         | Each row gains the flag beside its name; the list still holds at most `MAX_EQUIPMENT_ITEMS` entries with unique names                                        |
+| `rentsEquipment`           | Narrows from "some program requires anything" to "some program requires something **borrowable**" — it is what decides whether renting is asked about at all |
+| The form's equipment block | Lists **every** required item, so the student sees the whole of what they need; only the borrowable ones can be ticked, and the rest read as theirs to bring |
+| The form's rental question | "Musst du etwas ausleihen?" appears only when the chosen program has at least one borrowable item. A program with none shows a packing list and asks nothing |
+| The measurements           | Unchanged, and still behind the rental answer — which now cannot be reached by a program that lends nothing                                                  |
+| `scopeRentalToProgram`     | Scopes a student's rentals to the chosen program's **borrowable** names, and clears the rental answer when the program has none                              |
+| The completeness check     | Unchanged in shape; the rental branch is simply unreachable where nothing is borrowable                                                                      |
+| The report's rental field  | Offered by `rentsEquipment`, so it disappears for a series that lends nothing                                                                                |
+| The in-use guard           | Unchanged: it matches a student's stored rental by name, and a name nobody could rent is a name nobody holds                                                 |
+
+A student's `rentedEquipment` stays an array of names, so nothing about a stored registration
+changes shape.
+
+### Three things to settle
+
+**The wording.** The flag needs a label on the equipment row, and a non-borrowable item needs to
+read as the student's own responsibility on the form. Neither word is chosen here, because the
+right one is the school's.
+
+**Whether the flag may be withdrawn while somebody holds the item.** A student who has already
+ticked "Helm" has an answer that only made sense while it was borrowable. Turning the flag off is
+the same kind of act as renaming an entry a student has chosen, which is already refused — so it
+could be refused on the same terms, or allowed on the grounds that the stored answer remains true
+of the day it was given.
+
+**Whether the report shows the non-borrowable items.** They are the program's data rather than
+the student's answer, so they do not obviously belong in a report about students — but a teacher
+packing a coach may want exactly that list.
+
 ## Registration
 
 ### The form, reordered
@@ -665,7 +718,7 @@ emulator. Test-driven throughout: the failing test that states the new behaviour
 | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **1** | The editor concept: the route tree moves under `/app/event-series/{id}`, the navigation shrinks to its five fixed entries, the category tag row and the breadcrumb arrive, the header rows are hidden in Stammdaten. No stored shape changes. |
 | **2** | An event becomes a record — `events` goes from `string[]` to objects with a name. Registrations still store the event's name.                                                                                                                 |
-| **3** | The five per-event lists, the resolution rule, and the per-event editor pages.                                                                                                                                                                |
+| **3** | The five per-event lists, the resolution rule, the per-event editor pages, and the borrowable flag on required equipment.                                                                                                                     |
 | **4** | The registration form order, the schema field order, and `"diverse"`.                                                                                                                                                                         |
 | **5** | The two-step registration and its steering condition.                                                                                                                                                                                         |
 | **6** | Merge this document and `spec/refactoring-event-series.md` into `spec/requirements.md`, and delete both.                                                                                                                                      |

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -446,27 +446,73 @@ them is not something the school does.
 | The measurements           | Unchanged, and still behind the rental answer — which now cannot be reached by a program that lends nothing                                                  |
 | `scopeRentalToProgram`     | Scopes a student's rentals to the chosen program's **borrowable** names, and clears the rental answer when the program has none                              |
 | The completeness check     | Unchanged in shape; the rental branch is simply unreachable where nothing is borrowable                                                                      |
-| The report's rental field  | Offered by `rentsEquipment`, so it disappears for a series that lends nothing                                                                                |
-| The in-use guard           | Unchanged: it matches a student's stored rental by name, and a name nobody could rent is a name nobody holds                                                 |
+| The report                 | Gains a second field, "Ausrüstung", beside the existing "Leihausrüstung" — see below                                                                         |
+| The in-use guard           | Gains the flag: withdrawing it is refused while a student holds that item                                                                                    |
 
 A student's `rentedEquipment` stays an array of names, so nothing about a stored registration
 changes shape.
 
-### Three things to settle
+### The flag is set as a pair of tags, not a switch
 
-**The wording.** The flag needs a label on the equipment row, and a non-borrowable item needs to
-read as the student's own responsibility on the form. Neither word is chosen here, because the
-right one is the school's.
+The dialog that names an equipment item gains one more control: two tags, exactly one of which is
+chosen.
 
-**Whether the flag may be withdrawn while somebody holds the item.** A student who has already
-ticked "Helm" has an answer that only made sense while it was borrowable. Turning the flag off is
-the same kind of act as renaming an entry a student has chosen, which is already refused — so it
-could be refused on the same terms, or allowed on the grounds that the stored answer remains true
-of the day it was given.
+```
+Name  [ Lange, wasserdichte Hose        ]
 
-**Whether the report shows the non-borrowable items.** They are the program's data rather than
-the student's answer, so they do not obviously belong in a report about students — but a teacher
-packing a coach may want exactly that list.
+      [Keine Leihausrüstung]  Leihausrüstung
+```
+
+Both words are already constants — the filter offers the same pair for whether a student needs to
+borrow anything. The noun carries over cleanly: there, a student does or does not need rental
+equipment; here, an item either is rental equipment or is not. One vocabulary, used of the two
+things it can sensibly be used of.
+
+Three things follow from it being one choice rather than two switches:
+
+- **It is a radio group, not two pressed buttons.** Two independent `aria-pressed` tags would be
+  heard as two unrelated toggles, either or neither of which might be on. A single choice reads as
+  one, so the pair carries radio semantics and the tags are its options.
+- **The shared list does not learn about it.** `CrudList` serves all seven categories and only
+  equipment has a second field; teaching it a rental flag would be one module changing for one
+  caller's reason. The equipment leaf supplies the extra control to the dialog instead.
+- **A new item needs a side to start on.** Whichever it is, it is stated once and the seeded
+  defaults follow it, rather than each caller assuming.
+
+### Withdrawing the flag is refused while somebody holds the item
+
+A student who has ticked "Helm" gave an answer that only meant anything while "Helm" was
+borrowable. Taking the flag away is therefore the same act as renaming or removing an entry a
+student has chosen, which the in-use guard already refuses, and it is refused on the same terms:
+not while a registration of this series names it.
+
+The consistency is the point. Three different ways of invalidating the same answer — renaming the
+entry, deleting it, and withdrawing its flag — should not have three different outcomes, and a
+teacher should not have to learn which of them is the one that quietly changes what a student
+said.
+
+### The report names both halves of the list
+
+The two halves answer different questions, so they are two fields rather than one with a
+qualifier, and a teacher switches on whichever they need — or both:
+
+| Field            | Shows                                                     |
+| ---------------- | --------------------------------------------------------- |
+| "Ausrüstung"     | The student's program's **non-borrowable** required items |
+| "Leihausrüstung" | What the student actually asked to **borrow**             |
+
+"Ausrüstung" comes first in the field selector and in the printed lines, because a student packs
+their own things before collecting anything from the school.
+
+The two are different in kind, and the difference is deliberate rather than an oversight to be
+tidied away later. "Leihausrüstung" is the student's own answer and differs from student to
+student. "Ausrüstung" is their **program's** data, read through their choice of program — so every
+student on the same program shows the same list. That is what makes it useful for packing a coach,
+and it is why it is offered whenever any program requires something non-borrowable, mirroring the
+way `rentsEquipment` offers the rental field.
+
+With per-event programs, both resolve the program list from the student's event and fall back to
+the series, exactly as every other program-dependent answer does.
 
 ## Registration
 
@@ -520,9 +566,13 @@ Class moves ahead of event, following the menu, and `health` comes up from the e
 
 ```
 attendance · class · event · gender · dateOfBirth · contact · health · program ·
-rentedEquipment · measurements · skillLevel · seasonPassOption · busPickupPoint · food ·
-completeness
+ownEquipment · rentedEquipment · measurements · skillLevel · seasonPassOption ·
+busPickupPoint · food · completeness
 ```
+
+`ownEquipment` is the new one, labelled "Ausrüstung", and it sits ahead of `rentedEquipment`
+("Leihausrüstung"). Both stay beside the program they are drawn from, and the measurements stay
+behind them, because a shoe size is asked for in order to borrow.
 
 The order runs inside a tag as well as between them, because a tag that gathers several fields is
 still read as one run of lines:

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -200,13 +200,13 @@ L2  /app/event-series/{series}/{category}
     Zustiegsstellen  Verpflegung
     ⠿ Woche 1                      Öffnen ›        ✎  Ὕ1
 
-L3  /app/event-series/{series}/events/{event}/{category}
+L3  /app/event-series/{series}/events/{category}?event={event}
     Stammdaten › Eventreihen › Wintersportwoche 2026/27 › Events
     Woche 2
     [Programme ＋]  Leistungsstufen  Zugangskarten  Zustiegsstellen  Verpflegung
     ⠿ Ski                          Ausrüstung ›    ✎  Ὕ1
 
-L4  /app/event-series/{series}/events/{event}/programs?equipment={program}
+L4  /app/event-series/{series}/events/programs?event={event}&equipment={program}
     Stammdaten › … › Woche 2 › Programme
     Ski
     [Benötigte Ausrüstung ＋]
@@ -217,21 +217,21 @@ A series-level program's equipment is the same leaf one level up, at
 `/app/event-series/{series}/programs?equipment={program}`.
 
 `{category}` is a dynamic segment and `events` is a static one, because it is the only category
-whose entries have children of their own and a static segment wins over a dynamic one. Equipment
-keeps the `?equipment=` search parameter rather than a segment, because a program name is its
-identity and may hold characters a segment cannot carry.
+whose entries have children of their own and a static segment wins over a dynamic one. So the
+category is a segment at both levels, and what moves into a search parameter is only the record's
+identity — the event, alongside the program that equipment already names that way.
 
-### An event needs something a URL can carry — open, see Q5
+### An event is named by a search parameter, not by a segment
 
-`{event}` is the one segment naming a record a teacher typed. That is a problem the rest of the
-tree does not have: a program name was deliberately kept out of a segment for exactly this reason,
-and an event name is no different — it is editable, it is the identity (US-21), and nothing stops
-it holding a `/`, a `%` or a `#`.
+An event is the one record in the tree whose identity a teacher typed. That is a problem the rest
+of the tree does not have: a program name was deliberately kept out of a segment for exactly this
+reason, and an event name is no different — it is editable, it is the identity (US-21), and
+nothing stops it holding a `/`, a `%` or a `#`.
 
-Percent-encoding it is the obvious answer and it is not a reliable one. `%2F` inside a path
-segment is normalised by proxies and frameworks at several points between the browser and the
-page, and where it is decoded early the segment splits in two and the route stops matching. It
-works until the day somebody names an event "Woche 1/2".
+Percent-encoding it into a segment is the obvious answer and it is not a reliable one. `%2F`
+inside a path segment is normalised by proxies and frameworks at several points between the
+browser and the page, and where it is decoded early the segment splits in two and the route stops
+matching. It works until the day somebody names an event "Woche 1/2".
 
 The existing segment is no precedent for it, which is easy to assume and wrong. The event series
 id in `/app/event-series/{series}` is a Firestore auto-id, and `documentIdSchema` refuses a `/`
@@ -239,23 +239,26 @@ outright — so that segment has never carried an encoded slash and never can. N
 application has yet put teacher-typed text in a path segment, and where a name genuinely could
 hold anything, the existing answer was a search parameter.
 
-|       | What names the event                     | What it costs                                                                                                                                                                                     |
-| ----- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **a** | The percent-encoded name, in the segment | Reads well and needs no stored change. Fails on the characters a path cannot carry, and fails in a way that looks like a routing bug rather than a bad name.                                      |
-| **b** | The name, in a search parameter          | Cannot fail, and it is the precedent equipment already sets. The address stops reading as a hierarchy at the level where the hierarchy is the point.                                              |
-| **c** | A stored id on the event                 | Safe, opaque, survives a rename — and a rename becomes free, because nothing points at the name any more. Costs a generated id per event, and forces a decision about what a registration stores. |
-| **d** | The event's array index                  | **A trap.** An index is a position, not an identity: reordering or deleting silently re-points every link, bookmark and open tab at a different event. Do not use it.                             |
-|       |                                          |                                                                                                                                                                                                   |
+So the event joins it: `?event=`, beside the `?equipment=` that is already there. The address
+stops reading as a hierarchy at that level, which is a real loss on the pages where the hierarchy
+is the point — and the breadcrumb, not the address bar, is what the concept relies on to show it.
 
-Option **c** carries a second decision with it, which is why it is not simply the best answer. A
-registration stores `event` as a name today, so an id would mean either registrations start
-storing the id — after which renaming an event no longer has to be refused while students are
-assigned to it, because nothing needs rewriting — or they keep the name, and the event then has
-two identities, which is the thing this codebase most consistently refuses.
+The alternatives were weighed and set aside:
 
-Slugging the name is a fifth option and a worse version of **c**: a slug is safe in a path but two
-names can produce one slug, so it needs a uniqueness rule of its own, and it has to be stored to
-survive a rename — at which point it is an id that merely looks readable.
+|       | What names the event                     | Why not                                                                                                                                                                                      |
+| ----- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **a** | The percent-encoded name, in the segment | Fails on the characters a path cannot carry, and fails in a way that looks like a routing bug rather than a bad name.                                                                        |
+| **c** | A stored id on the event                 | The clean answer, and the expensive one: an id that is worth having is a document id, which means collections and references — the model deliberately dropped in favour of the one document. |
+| **d** | The event's array index                  | A position, not an identity: reordering or deleting silently re-points every link, bookmark and open tab at a different event.                                                               |
+
+Option **c** is the one to come back to, and it is not a URL decision on its own. Giving events
+real ids means giving them documents, and that is the same refactoring the document size limit
+would eventually force. Until something forces it, paying for it to get a tidier address is a
+poor trade — so readable paths wait for the day the storage changes for a reason of its own.
+
+Slugging the name would be a worse version of **c**: a slug is safe in a path but two names can
+produce one slug, so it needs a uniqueness rule of its own, and it has to be stored to survive a
+rename — at which point it is an id that merely looks readable.
 
 ### What the four screens share
 
@@ -419,7 +422,17 @@ Nothing about Veranstaltung is stored during the first step.
 
 ### Assignment is a step forward, and it does not go back
 
-Assigning is what begins step two, so it needs its own preconditions and one refusal.
+Assigning is what begins step two, so it carries three rules of its own — all of them enforced
+where the write happens, none of them a wizard or a prompt.
+
+**A series open to students cannot be assigned in.** Assigning, reassigning and un-assigning all
+require the series to be closed first. While it is open a student may be answering Veranstaltung
+at the moment a teacher moves them, and neither of them would ever know.
+
+Closing is the teacher's own act, and the application never does it on their behalf. An
+assignment that closed the series as a side effect would shut students out of a registration they
+were in the middle of, decided by somebody who was doing something else entirely — so the write
+is refused, and the teacher closes the series and tries again.
 
 **A student may only be assigned once their registration is complete** — in whichever sense
 applies: everything answered in a one-step series, everything outside Veranstaltung in a two-step
@@ -427,19 +440,15 @@ one. Assigning somebody who has not finished answering produces a registration t
 for two unrelated reasons at once, and a teacher cannot tell from the board which one they are
 looking at. Today the board's rule is only that the student is attending; this narrows it.
 
-**A student whose Veranstaltung answers are complete may not be un-assigned, and may not be moved
-to another event.** Their answers were drawn from that event's lists, and taking the event away
-would leave answers that came from nowhere, while moving them to another event would leave
-answers that came from the wrong place. Both are refused rather than silently cleared — clearing
-is a decision about somebody else's data, made by the person least likely to notice it happened.
-Un-assigning a student who has not yet answered Veranstaltung is free, because there is nothing
-to lose.
+**In a two-step series, a student who has chosen a program cannot be reassigned.** The program
+came from that event's own list — that is what made the series two-step in the first place — so
+moving the student elsewhere, or taking their event away, would leave an answer sourced from an
+event they are no longer in. The write is refused rather than the answer quietly cleared, which
+is the same shape as the rule that already refuses to rename a list entry a student has chosen.
 
-What that means for the teacher is a running order rather than a rule to remember: close the
-series to students, then assign. A series still open is one where a student can be answering
-Veranstaltung at the moment the teacher moves them. The teachers who do this are the skilled
-users of the application and the order is theirs to keep — whether the application should enforce
-it rather than rely on it is Q6.
+The last rule is narrow on purpose. It does not apply in a one-step series, where the program came
+from the series and survives any move; and it does not fire before a program is chosen, when there
+is nothing yet to invalidate.
 
 ## User stories
 
@@ -486,10 +495,11 @@ it rather than rely on it is Q6.
 - Step one is everything but Veranstaltung, and a registration that has it all reads complete.
 - Assignment to an event begins step two: Veranstaltung appears and the registration reads
   incomplete until it is answered.
+- Assigning, reassigning and un-assigning are refused while the series is open to students.
 - A student may only be assigned once their registration is complete in the sense that applies to
   their series.
-- A student whose Veranstaltung answers are complete may be neither un-assigned nor moved to
-  another event; the attempt is refused, and nothing is cleared on their behalf.
+- In a two-step series, a student who has chosen a program may not be reassigned or un-assigned;
+  the attempt is refused, and nothing is cleared on their behalf.
 - A student may amend either step at any time while the series is open to them.
 
 ## Sequencing
@@ -508,23 +518,3 @@ emulator. Test-driven throughout: the failing test that states the new behaviour
 | **6** | Merge this document and `spec/refactoring-event-series.md` into `spec/requirements.md`, and delete both.                                                                                                                                      |
 
 Environments are purged and reseeded after slices 2, 3 and 4.
-
-## Open questions
-
-### Q5 — What names an event in a URL?
-
-See "An event needs something a URL can carry" above. The four candidates and what each costs are
-stated there; what is open is which of them the events get.
-
-### Q6 — Should assignment be refused while the series is open to students?
-
-The order that keeps a teacher out of trouble is: close the series, then assign. The question is
-whether the application enforces it or merely relies on it.
-
-Enforcing it makes a race impossible — a student cannot be answering Veranstaltung at the moment
-their event changes underneath them. It also makes assignment unavailable during the window a
-teacher may reasonably want it, since a series is opened by generating its invitation link and
-is not closed again as a matter of course.
-
-Relying on it keeps the workflow open and leaves the two refusals above as the only guard, which
-is what the skilled users this page is built for would expect.

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -52,7 +52,7 @@ no correct answer at the time it is put.
 | `/app/{seriesId}/master-data/{category}`                             | `/app/event-series/{seriesId}/{category}` — no `master-data` segment left        |
 | The header selection scopes Stammdaten too                           | The header rows are hidden in Stammdaten; the record being edited is the URL     |
 | Seven sibling category pages                                         | A master list, a record page per series, a record page per event                 |
-| Nav: Eventreihen · Events · Klassen · …                              | Nav: Eventreihen · Klassen · Events · … , the categories indented under it       |
+| Nav: Eventreihen · Events · Klassen · …                              | Nav: five fixed entries; the categories move onto the record page as a tag row   |
 | Gender is male or female                                             | Gender is male, female or diverse                                                |
 | Form: Registrierung · Persönliches · Notfallkontakt · … · Gesundheit | Form: Registrierung · Persönliches · Gesundheit · Notfallkontakt · Veranstaltung |
 | One registration step, complete only when everything is answered     | Two steps where any event carries its own programs                               |
@@ -159,61 +159,95 @@ from there; a breadcrumb names the trail back.
 
 The event series id leaves the global scope segment, which is what takes Stammdaten out of the
 header selection. `/app/event-series` is already a segment the selection ignores, so the whole
-tree moves beneath it and the `master-data` segment disappears:
+tree moves beneath it and the `master-data` segment disappears.
+
+### Every level is a record with child collections
+
+The hierarchy has one shape, repeated. A screen shows **one record**; its **child collections** are
+offered as a row of tags, and the marked tag's entries are the list beneath.
+
+| The record              | Its child collections                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| "Stammdaten" — the root | "Eventreihen"                                                                                          |
+| One event series        | "Klassen", "Events", "Programme", "Leistungsstufen", "Zugangskarten", "Zustiegsstellen", "Verpflegung" |
+| One event               | "Programme", "Leistungsstufen", "Zugangskarten", "Zustiegsstellen", "Verpflegung"                      |
+| One program             | "Benötigte Ausrüstung"                                                                                 |
+
+Reading the root as a record is what makes the rule hold everywhere. A tag row with one tag — at
+the root, and at the equipment leaf — is the same screen as one with seven, with fewer tags.
+
+### The four screens
 
 ```
-/app/event-series                                   Eventreihen — the master list
-/app/event-series/{series}                          → redirects to classes
-/app/event-series/{series}/classes                  ┐
-/app/event-series/{series}/events                   │ the Eventreihe's own lists
-/app/event-series/{series}/programs      ?equipment=│
-/app/event-series/{series}/skill-levels             │
-/app/event-series/{series}/season-pass-options      │
-/app/event-series/{series}/bus-pickup-points        │
-/app/event-series/{series}/food-options             ┘
-/app/event-series/{series}/events/{event}           → redirects to programs
-/app/event-series/{series}/events/{event}/programs  ?equipment=   ┐ the five overridable
-/app/event-series/{series}/events/{event}/skill-levels            │ lists, at event level
-/app/event-series/{series}/events/{event}/season-pass-options     │
-/app/event-series/{series}/events/{event}/bus-pickup-points       │
-/app/event-series/{series}/events/{event}/food-options            ┘
-/app/users                                          Benutzerrechte
+L1  /app/event-series
+    ┈ breadcrumb row, empty ┈
+    Stammdaten
+    [Eventreihen ＋]
+    ⠿ Wintersportwoche 2026/27     Öffnen ›        ✎  Ὕ1
+
+L2  /app/event-series/{series}/{category}
+    Stammdaten › Eventreihen
+    Wintersportwoche 2026/27
+    Klassen  [Events ＋]  Programme  Leistungsstufen  Zugangskarten
+    Zustiegsstellen  Verpflegung
+    ⠿ Woche 1                      Öffnen ›        ✎  Ὕ1
+
+L3  /app/event-series/{series}/events/{event}/{category}
+    Stammdaten › Eventreihen › Wintersportwoche 2026/27 › Events
+    Woche 2
+    [Programme ＋]  Leistungsstufen  Zugangskarten  Zustiegsstellen  Verpflegung
+    ⠿ Ski                          Ausrüstung ›    ✎  Ὕ1
+
+L4  /app/event-series/{series}/events/{event}/programs?equipment={program}
+    Stammdaten › … › Woche 2 › Programme
+    Ski
+    [Benötigte Ausrüstung ＋]
+    ⠿ Helm                                         ✎  Ὕ1
 ```
 
-The header's event series rows are **not rendered** anywhere under `/app/event-series`. What is
-being edited is named by the page and by the breadcrumb, which is a place the reader is already
-looking, and which can name an archived series the header would not offer.
+A series-level program's equipment is the same leaf one level up, at
+`/app/event-series/{series}/programs?equipment={program}`.
 
-Equipment keeps the `?equipment=` search parameter rather than a path segment, because a program
-name is its identity and may hold characters a segment cannot carry.
+`{category}` is a dynamic segment and `events` is a static one, because it is the only category
+whose entries have children of their own and a static segment wins over a dynamic one. Equipment
+keeps the `?equipment=` search parameter rather than a segment, because a program name is its
+identity and may hold characters a segment cannot carry.
 
-### Navigation — open, see Q1
+### What the four screens share
 
-The requested order and indentation is settled at the series level:
+- **The side navigation never changes.** Five entries: "Registrierungen", "Zuteilungen" and
+  "Berichte", which the header scopes; then "Stammdaten" and "Benutzerrechte", which nothing
+  scopes. "Stammdaten" is the marked entry at every depth beneath it, and the rights page is
+  reached and rendered exactly as it is today.
+- **The header's event series rows are not rendered under `/app/event-series`.** What is being
+  edited is named by the title and the breadcrumb — which can also name an archived series, where
+  the header would offer none.
+- **One tag row per screen, and only the marked tag carries its add control.** The control's
+  accessible name is that category's own wording, so it reads "Neues Event" on one tag and "Neue
+  Klasse" on the next; pressing it opens a name form below the row. This is the tag row that
+  already carries per-tag controls on the marked tag, applied to a second row.
+- **The breadcrumb names the ancestors only**, stopping at the collection the record was reached
+  through — never at the record itself, which the title beneath already names.
+- **The title is the record.**
 
-```
-Registrierungen                 ┐
-Zuteilungen                     │ scoped by the header selection
-Berichte                        ┘
-Stammdaten
-  Eventreihen                   ← the master list
-    Klassen
-    Events
-    Programme
-    Leistungsstufen
-    Zugangskarten
-    Zustiegsstellen
-    Verpflegung
-  Benutzerrechte
-```
+### The breadcrumb's row is reserved even when it is empty
 
-Where the **per-event** lists belong is the open question. The nav cannot list them per event —
-there are as many sets as there are events, and data does not go in a navigation. Q1 states the
-candidates.
+The root has no ancestors and so draws no breadcrumb. Left at that, its title would sit a row
+higher than every other title and jump as a teacher moved down the hierarchy. So the breadcrumb
+occupies a row with a floor under its height, and at the root that row is simply empty — the same
+trick that already keeps a page with buttons and a page without them at one height.
 
-**Reordering the menu is not local.** The master data menu is the single source of answer order:
-the report fields, the filter categories and the registration form's card all follow it, each
-pinned by a test. Putting Klassen before Events moves class ahead of event in all four.
+It has to be reserved height rather than a hidden element: a screen-reader-only class is
+absolutely positioned and contributes none.
+
+One consequence is worth having deliberately. Whether the trail also names the record it ends at
+becomes a single decision in a single component — so if the empty root row proves worse than
+saying the record's name twice, that is a one-place change.
+
+**The tag order is the master data menu order, and reordering it is not local.** That order is the
+single source of answer order: the report fields, the filter categories and the registration form's
+card all follow it, each pinned by a test. Putting Klassen before Events moves class ahead of event
+in all four.
 
 ### Inherited state — open, see Q2
 
@@ -270,10 +304,13 @@ Nothing about Veranstaltung is stored during the first step.
 - Stammdaten opens on the list of Eventreihen. Opening one shows what that series is made of.
 - The lists of one series are reached from that series' record, never from a header selection;
   the header's series rows are not shown anywhere in Stammdaten.
-- A breadcrumb names the trail and every step of it is a link.
-- Menu order is Eventreihen, then Klassen, Events, Programme, Leistungsstufen, Zugangskarten,
-  Zustiegsstellen, Verpflegung; the categories are indented under Eventreihen, and Benutzerrechte
-  sits beside Eventreihen rather than under it.
+- A breadcrumb names the ancestors of what is open and every step of it is a link; the title names
+  the record itself.
+- A record's categories are offered as one row of tags, in the master data menu order — Klassen,
+  Events, Programme, Leistungsstufen, Zugangskarten, Zustiegsstellen, Verpflegung. Only the marked
+  tag offers to add an entry.
+- The side navigation holds five fixed entries and names no category, so it can never claim a
+  scope the page is not in. "Benutzerrechte" sits beside "Stammdaten" rather than under it.
 
 ### US-34: An event carries master data of its own
 
@@ -310,31 +347,18 @@ Each slice is a pull request of its own, and each is green on the whole gate bef
 starts — tests, lint, types, formatting, licence headers, and the rules tests against the
 emulator. Test-driven throughout: the failing test that states the new behaviour comes first.
 
-| Slice | What lands                                                                                                                                                                                             |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **1** | The editor concept: the route tree moves under `/app/event-series/{id}`, the nav is reordered and indented, the breadcrumb arrives, the header rows are hidden in Stammdaten. No stored shape changes. |
-| **2** | An event becomes a record — `events` goes from `string[]` to objects with a name. Registrations still store the event's name.                                                                          |
-| **3** | The five per-event lists, the resolution rule, and the per-event editor pages.                                                                                                                         |
-| **4** | The registration form order, the schema field order, and `"diverse"`.                                                                                                                                  |
-| **5** | The two-step registration and its steering condition.                                                                                                                                                  |
-| **6** | Merge this document and `spec/refactoring-event-series.md` into `spec/requirements.md`, and delete both.                                                                                               |
+| Slice | What lands                                                                                                                                                                                                                                    |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1** | The editor concept: the route tree moves under `/app/event-series/{id}`, the navigation shrinks to its five fixed entries, the category tag row and the breadcrumb arrive, the header rows are hidden in Stammdaten. No stored shape changes. |
+| **2** | An event becomes a record — `events` goes from `string[]` to objects with a name. Registrations still store the event's name.                                                                                                                 |
+| **3** | The five per-event lists, the resolution rule, and the per-event editor pages.                                                                                                                                                                |
+| **4** | The registration form order, the schema field order, and `"diverse"`.                                                                                                                                                                         |
+| **5** | The two-step registration and its steering condition.                                                                                                                                                                                         |
+| **6** | Merge this document and `spec/refactoring-event-series.md` into `spec/requirements.md`, and delete both.                                                                                                                                      |
 
 Environments are purged and reseeded after slices 2, 3 and 4.
 
 ## Open questions
-
-### Q1 — Where do the per-event lists live in the navigation?
-
-The nav is three levels deep already (Stammdaten › Eventreihen › Klassen), it collapses to an
-icon rail on a wide screen and to a strip across the top on a narrow one, and it may not contain
-data rows.
-
-|       | Option                                                                                                                                                   | Consequence                                                                                                                      |
-| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| **a** | Nav stops at the Eventreihe. Per-event lists are reached by opening an event; the breadcrumb carries the trail.                                          | Three levels, unchanged shape. While editing an event's programs the nav marks only "Events".                                    |
-| **b** | Nav grows a fourth, contextual level under Events while an event is open, headed by the event name.                                                      | The whole trail is visible, but the nav's contents change as you navigate, and a fourth level cannot survive the collapsed rail. |
-| **c** | Drop "Stammdaten" as a level: Eventreihen and Benutzerrechte become top-level items with icons of their own. Option b then costs three levels, not four. | Buys back the level option b needs; costs the grouping that tells the two apart from the header-scoped pages.                    |
-| **d** | Nav lists only Eventreihen and Benutzerrechte; every category becomes a tab on its record page.                                                          | Purest Concept A and it scales to any depth, but it drops the indented category list that was asked for.                         |
 
 ### Q2 — How is an inherited list shown on a per-event page?
 

--- a/spec/refactoring-per-event-categories.md
+++ b/spec/refactoring-per-event-categories.md
@@ -485,15 +485,22 @@ one. Assigning somebody who has not finished answering produces a registration t
 for two unrelated reasons at once, and a teacher cannot tell from the board which one they are
 looking at. Today the board's rule is only that the student is attending; this narrows it.
 
-**In a two-step series, a student who has chosen a program cannot be reassigned.** The program
-came from that event's own list — that is what made the series two-step in the first place — so
-moving the student elsewhere, or taking their event away, would leave an answer sourced from an
-event they are no longer in. The write is refused rather than the answer quietly cleared, which
-is the same shape as the rule that already refuses to rename a list entry a student has chosen.
+**A student who has answered anything drawn from their event's own list cannot be reassigned.**
+That answer came from the event rather than from the series, so moving the student elsewhere, or
+taking their event away, would leave an answer sourced from an event they are no longer in. The
+write is refused rather than the answer quietly cleared, which is the same shape as the rule that
+already refuses to rename a list entry a student has chosen.
 
-The last rule is narrow on purpose. It does not apply in a one-step series, where the program came
-from the series and survives any move; and it does not fire before a program is chosen, when there
-is nothing yet to invalidate.
+It follows the steering condition rather than naming one category, for the reason an event is a
+place: a lift pass bought for one resort is worthless at the other, and a pickup point on the way
+to Montafon is not on the way to Lech. Naming only the program would let through exactly the
+moves the change of place makes wrong — and would need a reason why a program invalidates a move
+while an access card does not, which there is not one of.
+
+The rule is still bounded by where the answer came from, not by what it is. It does not fire on an
+answer the series supplied, which survives any move; and it does not fire before the student has
+answered anything the event owns, when there is nothing yet to invalidate. In a one-step series no
+event owns a list at all, so it never fires there.
 
 ### An event that students have answered against cannot be removed
 
@@ -560,8 +567,8 @@ way out, and it says what it is doing.
 - Assigning, reassigning and un-assigning are refused while the series is open to students.
 - A student may only be assigned once their registration is complete in the sense that applies to
   their series.
-- In a two-step series, a student who has chosen a program may not be reassigned or un-assigned;
-  the attempt is refused, and nothing is cleared on their behalf.
+- A student who has answered anything drawn from their event's own list may not be reassigned or
+  un-assigned; the attempt is refused, and nothing is cleared on their behalf.
 - A student may amend either step at any time while the series is open to them.
 
 ## Sequencing
@@ -580,26 +587,3 @@ emulator. Test-driven throughout: the failing test that states the new behaviour
 | **6** | Merge this document and `spec/refactoring-event-series.md` into `spec/requirements.md`, and delete both.                                                                                                                                      |
 
 Environments are purged and reseeded after slices 2, 3 and 4.
-
-## Open questions
-
-### Q7 — Does the reassignment refusal follow the steering condition?
-
-The trigger for two steps is now any per-event list, not programs alone. The refusal that protects
-an answer did not move with it: it still names the program.
-
-The reason given for it generalises word for word. A student's access card, drawn from their
-event's own list, is invalidated by a move exactly as their program is — so on the same argument
-the rule reads "a student who has answered anything drawn from their event's own list cannot be
-reassigned", and the program is one case of it.
-
-Reading an event as a place rather than a week makes that stronger rather than weaker. Moving a
-student from Montafon to Lech invalidates their lift pass and their pickup point as surely as
-their program — arguably more plainly, since a pass bought for one resort is worthless at the
-other, while a program named "Ski" may well exist at both. A refusal that names only the program
-would let exactly the moves through that the place makes wrong.
-
-Against that: the narrower rule is easier to explain to a teacher, and the program is the answer
-most likely to exist. It would leave a student whose only per-event answer was a pickup point
-movable, and their pickup point silently unoffered afterwards — which the completeness check would
-report, though only after the fact.

--- a/src/app/app/(teacher)/[eventSeriesId]/master-data/programs/page.test.tsx
+++ b/src/app/app/(teacher)/[eventSeriesId]/master-data/programs/page.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Hannes Stauss <scalarion@nimblescape.com>
+ * Licensed under the MIT License. See LICENSE in the repository root for details.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+// Stubbed for their props alone: what this page decides is which view is opened and what it is
+// told, and the real ones reach for the Firebase client on import.
+const ProgramsView = () => null;
+const ProgramEquipmentView = () => null;
+
+vi.mock("@/components/master-data/programs-view", () => ({ ProgramsView }));
+vi.mock("@/components/master-data/program-equipment-view", () => ({ ProgramEquipmentView }));
+
+const { default: ProgramsPage } =
+  await import("@/app/app/(teacher)/[eventSeriesId]/master-data/programs/page");
+
+type Opened = { type: unknown; props: Record<string, unknown> };
+
+function open(eventSeriesId: string, searchParams: { equipment?: string }) {
+  return ProgramsPage({
+    params: Promise.resolve({ eventSeriesId }),
+    searchParams: Promise.resolve(searchParams),
+  }) as unknown as Promise<Opened>;
+}
+
+/**
+ * One page serves both lists, told apart by the equipment parameter. It is also the only place
+ * the series id is in reach, so a view it forgets to hand the id to cannot build a link back to
+ * this address — which is how the way out of the equipment list came to answer 404.
+ */
+describe("ProgramsPage", () => {
+  it("opens the programs list when no program is named", async () => {
+    const page = await open("s1", {});
+
+    expect(page.type).toBe(ProgramsView);
+    expect(page.props).toEqual({ eventSeriesId: "s1" });
+  });
+
+  it("opens the equipment list of the program the parameter names", async () => {
+    const page = await open("s1", { equipment: "Tennis" });
+
+    expect(page.type).toBe(ProgramEquipmentView);
+    expect(page.props).toEqual({ program: "Tennis", eventSeriesId: "s1" });
+  });
+
+  /** A name is the identity (US-21), so it may hold a character a path segment cannot carry. */
+  it("passes a program name a URL cannot spell in a segment through untouched", async () => {
+    const page = await open("s1", { equipment: "Ski & Board" });
+
+    expect(page.props.program).toBe("Ski & Board");
+  });
+});

--- a/src/components/master-data/program-equipment-view.tsx
+++ b/src/components/master-data/program-equipment-view.tsx
@@ -72,7 +72,7 @@ export function ProgramEquipmentView({
       )}
     >
       <Link
-        href="/app/master-data/programs"
+        href={`/app/${encodeURIComponent(eventSeriesId)}/master-data/programs`}
         className="text-muted-foreground hover:text-foreground flex w-fit items-center gap-1 text-sm transition-colors"
       >
         <ArrowLeft aria-hidden className="size-4" />

--- a/src/components/master-data/programs-view.test.tsx
+++ b/src/components/master-data/programs-view.test.tsx
@@ -24,12 +24,18 @@ const { ProgramEquipmentView: ScopedProgramEquipmentView } =
   await import("./program-equipment-view");
 
 // Which series the lists belong to comes from the page (Q8); the data hooks are mocked here.
-function ProgramsView() {
-  return <ScopedProgramsView eventSeriesId="s1" />;
+function ProgramsView({ eventSeriesId = "s1" }: { eventSeriesId?: string }) {
+  return <ScopedProgramsView eventSeriesId={eventSeriesId} />;
 }
 
-function ProgramEquipmentView({ program }: { program: string }) {
-  return <ScopedProgramEquipmentView program={program} eventSeriesId="s1" />;
+function ProgramEquipmentView({
+  program,
+  eventSeriesId = "s1",
+}: {
+  program: string;
+  eventSeriesId?: string;
+}) {
+  return <ScopedProgramEquipmentView program={program} eventSeriesId={eventSeriesId} />;
 }
 
 const ski = { name: "Ski", requiredEquipment: ["Helm", "Stöcke"] };
@@ -144,12 +150,41 @@ describe("ProgramEquipmentView", () => {
     expect(screen.getByText("Stöcke")).toBeInTheDocument();
   });
 
-  it("offers a way back to the programs list", () => {
+  it("offers a way back to the programs list of the same series", () => {
     render(<ProgramEquipmentView program="Ski" />);
 
     expect(screen.getByRole("link", { name: /alle programme/i })).toHaveAttribute(
       "href",
-      "/app/master-data/programs",
+      "/app/s1/master-data/programs",
+    );
+  });
+
+  /**
+   * Both views are the same page, told apart by the equipment parameter — so the way in and the
+   * way back are one address. Checking each against its own literal is what let the way back keep
+   * a path from before the series was a segment, which answers 404.
+   */
+  it("goes back to the address the equipment link came from", () => {
+    const { unmount } = render(<ProgramsView />);
+    const wayIn = screen
+      .getByRole("link", { name: "Benötigte Ausrüstung für Ski" })
+      .getAttribute("href");
+    unmount();
+
+    render(<ProgramEquipmentView program="Ski" />);
+
+    expect(screen.getByRole("link", { name: /alle programme/i })).toHaveAttribute(
+      "href",
+      wayIn?.split("?")[0],
+    );
+  });
+
+  it("percent-encodes a series id a URL would otherwise read as structure", () => {
+    render(<ProgramEquipmentView program="Ski" eventSeriesId="winter 2026/27" />);
+
+    expect(screen.getByRole("link", { name: /alle programme/i })).toHaveAttribute(
+      "href",
+      "/app/winter%202026%2F27/master-data/programs",
     );
   });
 


### PR DESCRIPTION
## Why

Master data describes an event series, but the editor shows seven sibling lists scoped by the same header control that filters registrations, assignments and reports. Nothing on the screen says the lists belong to the series — they read as seven global lists that happen to change when a header tag is pressed.

And a series that runs one week in Montafon and one in Lech cannot say so. Both weeks are made to offer one set of pickup points and access cards, so the only way to express a difference is to put the union in one list and hope the students pick correctly. Which in turn means a student is asked which program they want before anyone knows which event they are in.

## What is in this PR

The plan and the rules it will be held to. The only source changes are the three files carried from #139.

- **`spec/refactoring-per-event-categories.md`** — the plan, in six slices, with every design question settled and five user stories (US-33 to US-37).
- **`.github/instructions/clean-code.instructions.md`** — the Clean Code rules the refactoring is held to.
- **`.github/workflows/ci.yml`** — a pull request touching only `spec/` no longer runs the unit tests, the rules suite, the production build or Playwright.
- The commit from #139 (the 404 leaving a program's equipment list), which was never merged to `main` and would have conflicted with the route move in slice 1. **#139 is superseded by this branch** and its branch has been dropped.

## The plan, in short

| Slice | What lands |
| ----- | ---------- |
| 1 | The editor concept: routes move under `/app/event-series/{id}`, the nav shrinks to five fixed entries, the category tag row and breadcrumb arrive, header rows hidden in Stammdaten |
| 2 | An event becomes a record — `events` goes from `string[]` to objects |
| 3 | The five per-event lists, the resolution rule, the per-event editor pages, and the borrowable flag on required equipment |
| 4 | Registration form order, schema field order, and `"diverse"` |
| 5 | The two-step registration and its steering condition |
| 6 | Merge both refactoring documents into `spec/requirements.md` and delete them |

## The decisions

**Storage.** Everything stays on the one event series document; a per-event list is an array property of the event object, exactly as a per-series list is an array property of the series.

**Inheritance.** An empty per-event list means the series' list applies, and the page says so where its entries would be — no link, no override control. Adding the first entry is what overrides; removing the last is what returns to inheriting. Empty means inherit in *exactly one place*: at the root it means the school has no series, on a series' list it means that question is never asked, and on a program's equipment it means that program requires nothing. An event may add to what its series asks and never take away.

**The editor.** Drill-down record pages, and one shape repeated at every level: a screen shows one record, its child collections are a row of tags, the marked tag carries the add control, and its entries are the list beneath. Reading the root as a record makes that hold from the Eventreihen list down to the equipment of a per-event program. The categories leave the navigation entirely — indenting them under Eventreihen while scoping them to an event would have had the breadcrumb say "Woche 2 › Programme" while the nav marked the *series'* "Programme".

**The document limit.** No artificial cap. A number chosen to make the arithmetic safe would be invented against a case nobody has met. Instead the 1 MiB refusal Firestore already gives is recognised and answered with a sentence saying what happened, and concurrent edits are last-write-wins — a trade against a bounded audience of one or two coordinated maintainers, with the loss it can cause written down rather than implied.

**URLs.** An event is named by a search parameter, not a path segment. `%2F` is normalised at several points between browser and page, so a segment works until somebody names an event "Woche 1/2" — and the existing segment is no precedent, since a series id is a Firestore auto-id and `documentIdSchema` refuses a slash. Real ids would fix it and would mean collections and references, the model deliberately dropped in favour of the one document.

**Equipment says whether it can be borrowed.** A required item becomes `{ name, isRentable }`, because "Helm" and "Lange, wasserdichte Hose" are both required and only one of them is the school's to lend. Today a program that requires anything at all offers the rental question, so a student is asked to tick a rental for trousers they were told to bring. The flag makes `rentsEquipment` mean *requires something borrowable*, and the rental question — with the measurements behind it — is asked only where that holds. The report splits into "Ausrüstung" for what the student brings and "Leihausrüstung" for what they borrow; the form does not split, because a student is answering one question where a teacher is reading two.

**Two steps.** A series registers in two steps as soon as *any* event names *any* list of its own — not programs alone, since an event with its own access cards has exactly the same problem.

**Assignment.** A series open to students cannot be assigned in, and the application never closes one on the teacher's behalf. A student may only be assigned once their registration is complete in the sense their series uses. A student who has answered anything drawn from their event's own list cannot be reassigned — that answer came from the event, and an event names *where* the school goes as much as *when*, so a move invalidates a lift pass and a pickup point as surely as a program.

**One order, written once.** The menu, the tag rows, the form cards, the report fields and the filter row are each fixed and each stated once, so a later slice cannot quietly disagree with an earlier one — including the measurements, which the form and the report currently ask in opposite orders.

## Verification

`vitest` (2065 tests), `eslint`, `tsc --noEmit`, `prettier --check`, `license:check` — all green.
